### PR TITLE
fix: allow same-origin requests in CSRF middleware

### DIFF
--- a/server/middleware/csrf.ts
+++ b/server/middleware/csrf.ts
@@ -81,7 +81,14 @@ export async function csrfProtection(c: Context, next: Next) {
   // If Origin header is present, validate it
   if (origin) {
     const allowed = getAllowedOrigins();
-    if (!allowed.has(origin)) {
+
+    // Also accept same-origin requests: compare Origin against the request's own host.
+    // This handles Netlify deploy previews and any domain not in the static list.
+    const host = c.req.header('Host') || c.req.header('X-Forwarded-Host');
+    const proto = c.req.header('X-Forwarded-Proto') || 'https';
+    const selfOrigin = host ? `${proto}://${host}` : null;
+
+    if (!allowed.has(origin) && origin !== selfOrigin) {
       return c.json(
         { error: 'Forbidden: invalid origin', code: 'CSRF_REJECTED' },
         403
@@ -95,7 +102,11 @@ export async function csrfProtection(c: Context, next: Next) {
     try {
       const refererOrigin = new URL(referer).origin;
       const allowed = getAllowedOrigins();
-      if (!allowed.has(refererOrigin)) {
+      const host = c.req.header('Host') || c.req.header('X-Forwarded-Host');
+      const proto = c.req.header('X-Forwarded-Proto') || 'https';
+      const selfOrigin = host ? `${proto}://${host}` : null;
+
+      if (!allowed.has(refererOrigin) && refererOrigin !== selfOrigin) {
         return c.json(
           { error: 'Forbidden: invalid referer', code: 'CSRF_REJECTED' },
           403


### PR DESCRIPTION
The CSRF middleware only checked a static allowlist of origins, rejecting requests from Netlify deploy previews or any domain not explicitly listed. Now also compares the Origin/Referer against the request's own Host header, so same-origin requests always pass regardless of deploy URL.

https://claude.ai/code/session_01X9wsPNLeEL47LRoe9pYuwP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CSRF enforcement logic; while the change is small, miscomputing `selfOrigin` (e.g., via proxy headers) could unintentionally relax origin checks in some deployments.
> 
> **Overview**
> Updates the CSRF middleware to accept same-origin state-changing requests even when the origin is not in the static allowlist.
> 
> When `Origin` or `Referer` is present, it now derives a `selfOrigin` from `Host`/`X-Forwarded-Host` and `X-Forwarded-Proto` and allows the request if it matches, reducing false rejections for deploy-preview or dynamic hostnames.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e3bee2cb953febd8ab845d1ea71849130f15f2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->