### PR TITLE
Fix VOTD scheduling gap with yesterday backfill

### DIFF
--- a/server/routes/votd.ts
+++ b/server/routes/votd.ts
@@ -244,39 +244,30 @@ app.delete('/api/admin/votd/schedule/:id', async (c) => {
 });
 
 // ─── POST /api/admin/votd/publish-daily ──────────────────────────────────────
-app.post('/api/admin/votd/publish-daily', async (c) => {
-  const unauthorized = requireVotdAuth(c);
-  if (unauthorized) return unauthorized;
 
-  const target = c.req.query('target');
-  let todayStr: string;
-  if (target === 'next') {
-    if (!c.get('cronAuthed')) {
-      return c.json({ error: 'target=next requires VOTD cron bearer auth' }, 403);
-    }
-    const d = new Date();
-    d.setUTCDate(d.getUTCDate() + 1);
-    todayStr = utcDateStr(d);
-  } else {
-    todayStr = utcDateStr(new Date());
-  }
-
+/** Pick a verse and publish it for the given UTC date string. Idempotent. */
+async function publishForDate(dateStr: string): Promise<{
+  alreadyPublished: boolean;
+  featuredItemId: string;
+  reference?: string;
+  source?: string;
+}> {
   const published = first(
     await db
       .select({ featuredItemId: VotdPublishHistory.featuredItemId })
       .from(VotdPublishHistory)
-      .where(eq(VotdPublishHistory.publishedDate, todayStr))
+      .where(eq(VotdPublishHistory.publishedDate, dateStr))
       .limit(1),
   );
   if (published) {
-    return c.json({ success: true, alreadyPublished: true, featuredItemId: published.featuredItemId });
+    return { alreadyPublished: true, featuredItemId: published.featuredItemId };
   }
 
-  let manual = first(
+  const manual = first(
     await db
       .select()
       .from(VotdSchedule)
-      .where(and(eq(VotdSchedule.scheduledDate, todayStr), eq(VotdSchedule.isPublished, false)))
+      .where(and(eq(VotdSchedule.scheduledDate, dateStr), eq(VotdSchedule.isPublished, false)))
       .orderBy(desc(VotdSchedule.createdAt))
       .limit(1),
   );
@@ -292,11 +283,7 @@ app.post('/api/admin/votd/publish-daily', async (c) => {
 
   if (manual) {
     scheduleId = manual.id;
-    pick = {
-      reference: manual.reference,
-      source: 'override',
-      label: null,
-    };
+    pick = { reference: manual.reference, source: 'override', label: null };
     translation = manual.translation || 'NET';
     try {
       verseText = manual.verseText || (await fetchVerseText(manual.reference, translation));
@@ -308,20 +295,13 @@ app.post('/api/admin/votd/publish-daily', async (c) => {
     verse = manual.verse ?? null;
     verseEnd = manual.verseEnd ?? null;
   } else {
-    pick = await pickDailyVerseForPublish(todayStr);
+    pick = await pickDailyVerseForPublish(dateStr);
     const normalizedRef = normalizeScriptureReference(pick.reference);
     const parsed = parseScriptureReference(normalizedRef);
-    if (!parsed) {
-      return c.json({ error: `Could not parse reference: "${pick.reference}"` }, 500);
-    }
+    if (!parsed) throw new Error(`Could not parse reference: "${pick.reference}"`);
     const verseStart = Array.isArray(parsed.verse) ? parsed.verse[0] : parsed.verse;
     const vEnd = Array.isArray(parsed.verse) ? parsed.verse[1] : undefined;
-    try {
-      verseText = await fetchVerseText(normalizedRef, translation);
-    } catch (e) {
-      console.error('[votd/publish-daily] fetchVerseText', e);
-      return c.json({ error: `Could not load verse text for ${pick.reference}` }, 500);
-    }
+    verseText = await fetchVerseText(normalizedRef, translation);
     book = parsed.book;
     chapter = parsed.chapter;
     verse = verseStart;
@@ -330,7 +310,7 @@ app.post('/api/admin/votd/publish-daily', async (c) => {
   }
 
   const result = await publishVotdCore({
-    dateStr: todayStr,
+    dateStr,
     reference: pick.reference,
     translation,
     verseText,
@@ -343,12 +323,52 @@ app.post('/api/admin/votd/publish-daily', async (c) => {
     scheduleId,
   });
 
+  return { alreadyPublished: false, featuredItemId: result.featuredItemId, reference: pick.reference, source: pick.source };
+}
+
+app.post('/api/admin/votd/publish-daily', async (c) => {
+  const unauthorized = requireVotdAuth(c);
+  if (unauthorized) return unauthorized;
+
+  const target = c.req.query('target');
+  let todayStr: string;
+  if (target === 'next') {
+    if (!c.get('cronAuthed')) {
+      return c.json({ error: 'target=next requires VOTD cron bearer auth' }, 403);
+    }
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() + 1);
+    todayStr = utcDateStr(d);
+  } else {
+    todayStr = utcDateStr(new Date());
+    // Backfill yesterday if it was missed (cron catch-up runs only, not manual admin sessions).
+    // This recovers from scheduling gaps, e.g. when the cron schedule itself changes mid-day.
+    if (c.get('cronAuthed')) {
+      const yesterdayStr = utcPreviousCalendarDay(todayStr);
+      publishForDate(yesterdayStr).catch((e) => {
+        console.error('[votd/publish-daily] yesterday backfill failed:', yesterdayStr, e);
+      });
+    }
+  }
+
+  let result: Awaited<ReturnType<typeof publishForDate>>;
+  try {
+    result = await publishForDate(todayStr);
+  } catch (e) {
+    console.error('[votd/publish-daily] publishForDate', e);
+    return c.json({ error: e instanceof Error ? e.message : String(e) }, 500);
+  }
+
+  if (result.alreadyPublished) {
+    return c.json({ success: true, alreadyPublished: true, featuredItemId: result.featuredItemId });
+  }
+
   return c.json({
     success: true,
     featuredItemId: result.featuredItemId,
-    reference: pick.reference,
+    reference: result.reference,
     scheduledDate: todayStr,
-    source: pick.source,
+    source: result.source,
   });
 });
 


### PR DESCRIPTION
## Summary

- The dual-cron migration (`74bacb3`) created a gap where April 9's VOTD was never published — the old 11:00 UTC cron was removed and both new crons (23:55 and 00:05) had already passed when the commit landed
- Extracts a `publishForDate(dateStr)` helper to deduplicate the pick-and-publish logic
- The 00:05 UTC catch-up now fire-and-forgets a backfill for yesterday when called via cron bearer auth, so any single-day scheduling gap auto-recovers on the next run

## After merging

Trigger a manual `workflow_dispatch` on "Publish Verse of the Day" to publish today's (April 9) VOTD immediately.

https://claude.ai/code/session_015vsoTLqjiddGd1v63BgyZN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the VOTD publish path and adds an automatic backfill write, which could create unexpected publishes if date calculations or auth conditions are wrong, but the change is scoped to a single route and is idempotent via publish history checks.
> 
> **Overview**
> Fixes missed VOTD days by making the cron-triggered `POST /api/admin/votd/publish-daily` *also* fire-and-forget a publish attempt for yesterday (only when `cronAuthed` and not using `target=next`).
> 
> Refactors the pick-and-publish logic into an idempotent `publishForDate(dateStr)` helper (reused for today/yesterday) and centralizes error handling by throwing from parsing/fetching failures and catching once in the route before returning a 500.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4ca676ff5c929c68e682948829cb6f66e85d937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->