### PR TITLE
fix: drop stale marketing imports that break Netlify build

### DIFF
--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -3,7 +3,6 @@ import { getBackTarget, popNavStack } from '@/utils/nav-stack';
 import { extractIdFromPath } from '@/utils/url-helpers';
 import { ClerkProvider, useAuth, useUser } from '@clerk/clerk-react';
 import { hasClerkSessionCookieHint } from './hooks/queries/useProfile';
-import { syncMarketingSessionHint } from './utils/marketing-session-hint';
 import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 import { clearUserClientCaches } from '@/utils/clear-user-client-caches';
 import { RouterProvider } from '@tanstack/react-router';
@@ -246,16 +245,6 @@ function AuthSignedOutCacheCleanup() {
     if (!isLoaded || isSignedIn) return;
     clearUserClientCaches(queryClient);
   }, [isLoaded, isSignedIn, queryClient]);
-  return null;
-}
-
-/** Parent-domain cookie so harvous.com can show Open app without a credentialed cross-origin fetch. */
-function MarketingSiteSessionHint() {
-  const { isLoaded, isSignedIn } = useAuth();
-  useEffect(() => {
-    if (!isLoaded) return;
-    syncMarketingSessionHint(Boolean(isSignedIn));
-  }, [isLoaded, isSignedIn]);
   return null;
 }
 
@@ -795,7 +784,6 @@ export default function App() {
     <HarvousClerkProvider>
       <QueryClientProvider client={queryClient}>
         <AuthSignedOutCacheCleanup />
-        <MarketingSiteSessionHint />
         <PublicRouteClassBridge />
         <PendingAuthRedirectBridge />
         <QueryClient401Redirect />

--- a/spa/src/pages/prototype/PrototypeSidebar.tsx
+++ b/spa/src/pages/prototype/PrototypeSidebar.tsx
@@ -79,7 +79,6 @@ import PrototypeSidebarHomeView from './PrototypeSidebarHomeView';
 import ProtoSpaceLoading from './ProtoSpaceLoading';
 import PrototypeListEmptyState, { PrototypeListNoMatchEmptyState } from './PrototypeListEmptyState';
 import { SIDEBAR_NO_MATCH_COPY } from './sidebar-no-match-copy';
-import PrototypeMigrationBanner from './PrototypeMigrationBanner';
 import PrototypeSidebarToolbar from './PrototypeSidebarToolbar';
 import {
   applyFolderPinOrdering,
@@ -3229,10 +3228,6 @@ export default function PrototypeSidebar({
 
           </>
         )}
-      </div>
-
-      <div className="proto-sidebar-floating-stack">
-        <PrototypeMigrationBanner />
       </div>
 
       {highlightDeleteTarget ? (


### PR DESCRIPTION
## Summary
- Removes `marketing-session-hint` / migration-banner call sites from `App.tsx` and `PrototypeSidebar.tsx`
- Unblocks Netlify production builds (`Could not resolve ./utils/marketing-session-hint`)

## Test plan
- [ ] Netlify build succeeds on this branch
- [ ] App loads signed-in and signed-out


Made with [Cursor](https://cursor.com)