### PR TITLE
fix: upgrade Back to Harvous toolbar CTA styling

### DIFF
--- a/Changelog/2.3.1.md
+++ b/Changelog/2.3.1.md
@@ -1,0 +1,14 @@
+# Version 2.3.1
+
+**Release Date**: July 25, 2026
+
+## Features
+
+- Polar billing + My Church hub (#17)
+
+## Fixes
+
+- Keep upgrade Back to Harvous CTA blue and unclipped
+- Remove duplicate Sharing page exports that broke SPA build (#16)
+- Drop stale marketing hint and migration banner imports (#15)
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.3.0
+**Version:** 2.3.1
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/scripts/public-route-boot.js
+++ b/public/scripts/public-route-boot.js
@@ -35,9 +35,9 @@
       PUBLIC_ROUTE_CLASS +
       ' #root{min-height:100%;display:flex;flex-direction:column}' +
       '.public-page{font-family:inherit;background:var(--site-paper);min-height:100svh;color:var(--site-ink);display:flex;flex-direction:column;overflow:hidden}' +
-      '.public-toolbar{position:sticky;top:0;display:flex;justify-content:center;padding:14px 16px;z-index:100}' +
-      '.public-toolbar__pill{display:inline-flex;align-items:center;gap:8px;padding:6px 6px 6px 10px;background:rgba(255,255,255,.85);border:.5px solid var(--site-rule);border-radius:999px;box-shadow:0 1px 3px rgba(26,25,22,.06)}' +
-      '.public-toolbar__cta{display:inline-flex;align-items:center;padding:8px 14px;border-radius:999px;background:var(--site-accent);color:#fff;font-size:14px;font-weight:600;text-decoration:none}' +
+      '.public-toolbar{position:sticky;top:0;display:flex;justify-content:center;padding:14px 16px;z-index:100;box-sizing:border-box}' +
+      '.public-toolbar__pill{display:inline-flex;align-items:center;gap:8px;padding:5px 5px 5px 10px;max-width:min(100%,calc(100vw - 32px));box-sizing:border-box;background:rgba(255,255,255,.85);border:.5px solid var(--site-rule);border-radius:999px;box-shadow:0 1px 3px rgba(26,25,22,.06)}' +
+      '.public-toolbar__cta{display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box;height:36px;padding:0 14px;border:0;border-radius:999px;background:var(--site-accent);color:#fff;-webkit-text-fill-color:#fff;font-size:13px;font-weight:600;line-height:1;text-decoration:none;white-space:nowrap}' +
       '.public-body{flex:1;overflow:auto}' +
       '.page-loading{display:flex;align-items:center;justify-content:center;min-height:40vh}' +
       '.page-loading::after{content:"";width:6px;height:6px;border-radius:50%;background:var(--site-ink-soft);box-shadow:12px 0 0 var(--site-ink-soft),-12px 0 0 var(--site-ink-soft);animation:harvous-public-loading-pulse 1.2s ease-in-out infinite}' +

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-3-0';
+const CACHE_NAME = 'harvous-cache-v2-3-1';
 const NAV_API_CACHE = 'harvous-nav-api-v10';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 

--- a/release-notes/v2.3-july-2026.md
+++ b/release-notes/v2.3-july-2026.md
@@ -1,7 +1,7 @@
-# What's New in Harvous v2.3.0
+# What's New in Harvous v2.3.1
 
 **Release Date:** July 25, 2026
-**Version:** 2.3.0
+**Version:** 2.3.1
 
 This release includes improvements to navigation, organization, and overall user experience.
 
@@ -12,11 +12,21 @@ This release includes improvements to navigation, organization, and overall user
 ### General improvements
 
 **What changed:**
-- My Church hub connection and staff create gates
-- Complete Harvous Plus billing on Polar
+- Polar billing + My Church hub (#17)
+- Keep upgrade Back to Harvous CTA blue and unclipped
+- Drop stale marketing hint and migration banner imports (#15)
 
 **How it helps you:**
 - Makes your Bible study workflow smoother
+- Smoother, more reliable experience
+
+### Visual polish
+
+**What changed:**
+- Remove duplicate Sharing page exports that broke SPA build (#16)
+
+**How it helps you:**
+- Smoother, more reliable experience
 
 ---
 

--- a/spa/src/styles/public-pages.css
+++ b/spa/src/styles/public-pages.css
@@ -138,7 +138,11 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 6px 6px 10px;
+  /* Symmetric inset so the CTA pill sits fully inside the glass capsule
+     (longer labels like “Back to my Harvous” looked clipped at 6px). */
+  padding: 5px 5px 5px 10px;
+  max-width: min(100%, calc(100vw - 32px));
+  box-sizing: border-box;
   background: rgba(255, 255, 255, 0.85);
   border: 0.5px solid var(--site-rule);
   border-radius: 999px;
@@ -186,27 +190,40 @@
   color: var(--site-ink);
 }
 
-/* CTA pill ("Open app" / "Sign in") — matches prototype "Not now" dismiss
-   styling; keeps the public nav pill radius (999px). */
+/* CTA pill ("Open app" / "Sign in" / "Back to my Harvous") — site accent,
+   matching public-route-boot critical CSS and the marketing header. Keep
+   boot + bundle in sync so we never get white text on a light hover fill. */
 .public-toolbar__cta {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex: 0 1 auto;
+  min-width: 0;
+  box-sizing: border-box;
   height: 36px;
   padding: 0 14px;
+  border: 0;
   border-radius: 999px;
-  border: 1px solid var(--pds-border-control);
-  background: var(--pds-bg-sidebar-input);
-  box-shadow: var(--pds-glass-rim);
-  font-family: var(--pds-font-body);
+  background: var(--site-accent);
+  box-shadow: none;
+  font-family:
+    "Google Sans", "Reddit Sans", ui-sans-serif, system-ui, sans-serif;
   font-size: 13px;
-  font-weight: 500;
-  color: var(--pds-text-primary);
+  font-weight: 600;
+  line-height: 1;
+  color: #fff;
+  -webkit-text-fill-color: #fff;
   text-decoration: none;
-  transition: background 0.1s;
+  white-space: nowrap;
+  transition: filter 120ms ease;
 }
 .public-toolbar__cta:hover {
-  background: var(--pds-bg-sidebar-input-hover);
+  background: var(--site-accent);
+  filter: brightness(1.06);
+}
+.public-toolbar__cta:focus-visible {
+  outline: 2px solid var(--site-accent);
+  outline-offset: 2px;
 }
 
 /* ─── Body ──────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
- Post-checkout `/upgrade` toolbar CTA (“Back to my Harvous”) was clipping and could show white text on a light fill (boot critical CSS vs bundle hover styles disagreed).
- Aligns boot + bundle to the site accent blue CTA and gives the glass pill enough inset for the longer label.

## Test plan
- [ ] Open `/upgrade` signed in — toolbar CTA is blue, white text, fully inside the white pill
- [ ] Hover — stays blue (slightly brighter), still readable
- [ ] After Polar checkout return — same


Made with [Cursor](https://cursor.com)