### PR TITLE
Extract canonicalBookOrderMap to shared utility

### DIFF
--- a/server/utils/build-space-scripture-index.ts
+++ b/server/utils/build-space-scripture-index.ts
@@ -9,6 +9,8 @@ import {
   normalizeScriptureReference,
   parseScriptureReference,
 } from '@/utils/scripture-detector';
+// Single source of truth for the 0-based canonical order; the client keys drill targets by the same map.
+import { canonicalBookOrderMap } from '@/utils/scripture-passage-drill';
 
 type BibleChapterRow = { book: string };
 
@@ -65,23 +67,6 @@ function extractDataScriptureReferences(html: string): string[] {
     if (v) out.push(v);
   }
   return out;
-}
-
-/** Canonical book order: first-seen index in bible-chapters.json (matches native ordering intent). */
-export function canonicalBookOrderMap(): Map<string, number> {
-  const data = bibleChaptersData as BibleChapterRow[];
-  const m = new Map<string, number>();
-  let i = 0;
-  for (const row of data) {
-    if (!m.has(row.book)) {
-      m.set(row.book, i++);
-    }
-  }
-  const song = m.get('Song of Solomon');
-  if (song !== undefined && !m.has('Song of Songs')) {
-    m.set('Song of Songs', song);
-  }
-  return m;
 }
 
 /** First canonical book label per book order (walks bible-chapters in canonical sequence). */

--- a/src/utils/__tests__/scripture-passage-drill.test.ts
+++ b/src/utils/__tests__/scripture-passage-drill.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  canonicalBookOrderMap,
   findMostRecentNoteForScriptureReference,
   findScripturePassageDrill,
   findScripturePassageWithNotes,
@@ -20,6 +21,24 @@ function book(
     })),
   };
 }
+
+describe('canonicalBookOrderMap', () => {
+  // Passage keys stored by the server index and computed by the client both start with this number.
+  // If a refactor swaps this for bible-chapters.json's own 1-based `bookOrder` field, every book
+  // shifts by one and previously stored keys stop matching — these assertions catch that.
+  it('is 0-based, not the 1-based bookOrder field in bible-chapters.json', () => {
+    const map = canonicalBookOrderMap();
+    expect(map.get('Genesis')).toBe(0);
+    expect(map.get('John')).toBe(42);
+    expect(map.size).toBeGreaterThanOrEqual(66);
+  });
+
+  it('aliases "Song of Songs" to the "Song of Solomon" order', () => {
+    const map = canonicalBookOrderMap();
+    expect(map.get('Song of Songs')).toBe(map.get('Song of Solomon'));
+    expect(map.get('Song of Solomon')).toBe(21);
+  });
+});
 
 describe('findScripturePassageDrill', () => {
   it('returns null for empty reference', () => {

--- a/src/utils/scripture-passage-drill.ts
+++ b/src/utils/scripture-passage-drill.ts
@@ -21,7 +21,15 @@ export type ScriptureIndexBookLike = {
   passages: ScriptureIndexPassageLike[];
 };
 
-function canonicalBookOrderMap(): Map<string, number> {
+/**
+ * Canonical book order: 0-based first-seen index in bible-chapters.json (matches native ordering intent).
+ *
+ * Deliberately NOT the 1-based `bookOrder` field inside bible-chapters.json — passage keys
+ * (`bookOrder:chapter:verseStart:verseEnd`) are built from this map on both the client and the server,
+ * so switching to the JSON field would shift every stored key by one. Server code imports this same
+ * implementation (via the esbuild `--alias:@=src` flag) so the two sides cannot drift apart.
+ */
+export function canonicalBookOrderMap(): Map<string, number> {
   const data = bibleChaptersData as BibleChapterRow[];
   const m = new Map<string, number>();
   let i = 0;


### PR DESCRIPTION
## Summary
Moves `canonicalBookOrderMap()` from the server-side build utility to a shared client utility module, making it the single source of truth for canonical book ordering across both client and server. This ensures passage keys (formatted as `bookOrder:chapter:verseStart:verseEnd`) are computed identically on both sides.

## Key Changes
- **Moved function:** `canonicalBookOrderMap()` from `server/utils/build-space-scripture-index.ts` to `src/utils/scripture-passage-drill.ts` and exported it
- **Updated imports:** Server build utility now imports the function from the shared location via the esbuild `@` alias
- **Added tests:** New test suite in `scripture-passage-drill.test.ts` validates:
  - 0-based indexing (Genesis = 0, John = 42) to catch accidental shifts to the 1-based `bookOrder` field in bible-chapters.json
  - "Song of Songs" alias correctly maps to "Song of Solomon" order (index 21)
- **Enhanced documentation:** Added detailed JSDoc explaining why this must remain 0-based and why both sides import the same implementation

## Implementation Details
The function builds a canonical book order map from bible-chapters.json by tracking first-seen book names in sequence. It also aliases "Song of Songs" to match "Song of Solomon" ordering. The tests are defensive — they catch if a future refactor accidentally switches to the 1-based `bookOrder` field, which would shift every stored passage key by one and break client-server key matching.

https://claude.ai/code/session_01YQEfHpe7sCmR8eiQwgeX1B