### PR TITLE
fix(profile): a partial cached profile stops passing for a complete one

### DIFF
--- a/spa/src/hooks/queries/__tests__/profile-snapshot-placeholder.test.tsx
+++ b/spa/src/hooks/queries/__tests__/profile-snapshot-placeholder.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * The sessionStorage profile snapshot is not a whole profile, and useProfile must not
+ * serve it as if it were.
+ *
+ * `seedProfileNamesAfterSignUp` writes only the identity fields it can know before the
+ * first fetch, and a snapshot left by an older build carries only the fields that build
+ * knew about. Seeded as `initialData` with `initialDataUpdatedAt` 30s in the past, React
+ * Query treated that partial object as fresh for the rest of the 5-minute staleTime and
+ * skipped the fetch — so every field the snapshot lacked read `undefined` for ~4.5 minutes
+ * after a load, with no error and no loading state to distinguish "not known yet" from
+ * "has no value". It cost an afternoon on the Home continue-reading card, which read a
+ * profile field that get-profile does return and silently never rendered.
+ *
+ * As `placeholderData` the snapshot still paints on the first render (no avatar/name
+ * flash) but the mount fetch runs and fills in the rest.
+ */
+const USER_ID = 'user_derek';
+
+vi.mock('@clerk/clerk-react', () => ({
+  useAuth: () => ({
+    userId: USER_ID,
+    isLoaded: true,
+    isSignedIn: true,
+    getToken: async () => 'jwt',
+  }),
+}));
+vi.mock('../../useAuthReady', () => ({ useAuthReady: () => true }));
+vi.mock('../../../lib/api', () => ({ api: { get: vi.fn() } }));
+
+import { api } from '../../../lib/api';
+import { useProfile, type UserProfile } from '../useProfile';
+
+/**
+ * A snapshot in the shape seedProfileNamesAfterSignUp leaves behind: the long-stable core
+ * and nothing else. Every field asserted on below is deliberately absent.
+ */
+const PARTIAL_SNAPSHOT = {
+  id: USER_ID,
+  firstName: 'Derek',
+  lastName: 'Johnson',
+  email: 'derek@example.com',
+  profileImageUrl: null,
+  displayName: 'Derek J',
+  userColor: 'purple',
+  church: null,
+  defaultTranslation: 'NET',
+};
+
+/** What get-profile actually returns — the snapshot's core plus everything it never carried. */
+const SERVER_PROFILE = {
+  ...PARTIAL_SNAPSHOT,
+  hasLockPinSet: true,
+  sharedSpaceSwitcherOrder: ['space_romans', 'space_psalms'],
+  connectedOrgId: 'org_grace',
+  connectedChurchId: 'church_grace',
+  isHomeChurchStaff: true,
+  churchName: 'Grace Chapel',
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function wrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function newClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+describe('useProfile with a partial sessionStorage snapshot', () => {
+  beforeEach(() => {
+    // hasClerkSessionCookieHint() gates the snapshot read.
+    document.cookie = '__client_uat=1';
+    sessionStorage.setItem('harvous-profile-cache', JSON.stringify(PARTIAL_SNAPSHOT));
+  });
+
+  it('does not report a field the snapshot lacks as undefined — it fetches and fills it in', async () => {
+    vi.mocked(api.get).mockResolvedValue(SERVER_PROFILE);
+    const queryClient = newClient();
+
+    const { result } = renderHook(() => useProfile(), { wrapper: wrapper(queryClient) });
+
+    await waitFor(() => expect(result.current.isPlaceholderData).toBe(false));
+
+    // The regression: each of these read `undefined` for the whole staleTime, because the
+    // snapshot was seeded as fresh initialData and no fetch ever ran to correct it.
+    expect(result.current.data?.hasLockPinSet).toBe(true);
+    expect(result.current.data?.sharedSpaceSwitcherOrder).toEqual([
+      'space_romans',
+      'space_psalms',
+    ]);
+    expect(result.current.data?.connectedOrgId).toBe('org_grace');
+    expect(result.current.data?.isHomeChurchStaff).toBe(true);
+    expect(result.current.data?.churchName).toBe('Grace Chapel');
+  });
+
+  it('fetches on mount instead of trusting the snapshot for the whole staleTime', async () => {
+    vi.mocked(api.get).mockResolvedValue(SERVER_PROFILE);
+    const queryClient = newClient();
+
+    renderHook(() => useProfile(), { wrapper: wrapper(queryClient) });
+
+    await waitFor(() => expect(api.get).toHaveBeenCalledWith('/api/user/get-profile'));
+  });
+
+  it('still paints the snapshot on the first render, so there is no avatar/name flash', () => {
+    vi.mocked(api.get).mockReturnValue(deferred<UserProfile>().promise);
+    const queryClient = newClient();
+
+    const { result } = renderHook(() => useProfile(), { wrapper: wrapper(queryClient) });
+
+    // Synchronously available on the very first render — the reason initialData was
+    // reached for in the first place, and the thing a placeholder must not give up.
+    expect(result.current.data?.firstName).toBe('Derek');
+    expect(result.current.data?.displayName).toBe('Derek J');
+    expect(result.current.data?.userColor).toBe('purple');
+    expect(result.current.isLoading).toBe(false);
+    // ...and it is labelled, so a consumer can tell "not known yet" from "has no value".
+    expect(result.current.isPlaceholderData).toBe(true);
+  });
+
+  it('keeps the partial snapshot out of the query cache', () => {
+    vi.mocked(api.get).mockReturnValue(deferred<UserProfile>().promise);
+    const queryClient = newClient();
+
+    renderHook(() => useProfile(), { wrapper: wrapper(queryClient) });
+
+    // Optimistic mutations patch ['profile', userId] by reading it back. Committing a
+    // partial snapshot there would let them write a half-profile to the server's shape.
+    expect(queryClient.getQueryData(['profile', USER_ID])).toBeUndefined();
+  });
+
+  it('holds the placeholder reference steady across renders', () => {
+    vi.mocked(api.get).mockReturnValue(deferred<UserProfile>().promise);
+    const queryClient = newClient();
+
+    const { result, rerender } = renderHook(() => useProfile(), {
+      wrapper: wrapper(queryClient),
+    });
+    const first = result.current.data;
+    rerender();
+
+    // The snapshot is re-parsed from JSON on every read. Without memoization each render
+    // produces a new object, and consumers keyed on `profile` re-run every effect and
+    // recompute every memo for as long as the fetch is in flight.
+    expect(result.current.data).toBe(first);
+  });
+});

--- a/spa/src/hooks/queries/useProfile.ts
+++ b/spa/src/hooks/queries/useProfile.ts
@@ -1,5 +1,6 @@
 import { useAuth } from '@clerk/clerk-react';
 import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { useAuthReady } from '../useAuthReady';
 import { api } from '../../lib/api';
 import { updateCachedProfileData } from '@/utils/profile-cache';
@@ -63,7 +64,27 @@ function setCachedUserNames(firstName: string | null, lastName: string | null) {
   }
 }
 
-function getCachedProfile(): UserProfile | undefined {
+/**
+ * What the sessionStorage profile snapshot actually guarantees — which is much less than
+ * a `UserProfile`.
+ *
+ * Three writers fill this key and they disagree about how much they carry: the queryFn
+ * stores the whole get-profile payload, `seedProfileNamesAfterSignUp` stores only the
+ * identity fields it can know before the first fetch ever runs, and a snapshot left by an
+ * older build carries whatever `UserProfile` happened to hold on the day it was written.
+ * So the only fields that are always present are the core below; everything else is
+ * `Partial`.
+ *
+ * Typing this as a full `UserProfile` is what let a half-filled snapshot pass for a
+ * complete profile — see the `placeholderData` note in `useProfile`.
+ */
+export type CachedSessionProfile = Pick<
+  UserProfile,
+  'id' | 'firstName' | 'lastName' | 'email' | 'profileImageUrl' | 'displayName' | 'userColor' | 'church'
+> &
+  Partial<UserProfile>;
+
+function getCachedProfile(): CachedSessionProfile | undefined {
   try {
     const raw = sessionStorage.getItem(HARVOUS_PROFILE_CACHE_KEY);
     return raw ? JSON.parse(raw) : undefined;
@@ -99,20 +120,26 @@ export function readClerkUserIdForProfileCache(): string | undefined {
   return undefined;
 }
 
-/** Synchronous cached profile for the active session user (sessionStorage), for instant nav before RQ fetch. */
-export function getCachedProfileForSessionUser(clerkUserId?: string | null): UserProfile | undefined {
+/**
+ * Synchronous cached profile for the active session user (sessionStorage), for instant nav
+ * before the RQ fetch lands. Returns a `CachedSessionProfile`, not a `UserProfile`: treat
+ * every field outside the core as "not known yet", never as "has no value".
+ */
+export function getCachedProfileForSessionUser(
+  clerkUserId?: string | null,
+): CachedSessionProfile | undefined {
   if (!clerkUserId || typeof window === 'undefined') return undefined;
   try {
     const raw = sessionStorage.getItem(HARVOUS_PROFILE_CACHE_KEY);
     if (!raw) return undefined;
-    const p = JSON.parse(raw) as UserProfile;
+    const p = JSON.parse(raw) as CachedSessionProfile;
     return p.id === clerkUserId ? p : undefined;
   } catch {
     return undefined;
   }
 }
 
-function setCachedProfile(profile: UserProfile) {
+function setCachedProfile(profile: CachedSessionProfile) {
   try {
     sessionStorage.setItem(HARVOUS_PROFILE_CACHE_KEY, JSON.stringify(profile));
   } catch {
@@ -126,7 +153,14 @@ export function updateCachedProfile(updates: Partial<UserProfile>) {
   if (updates.userColor) setCachedUserColor(updates.userColor);
 }
 
-/** Optimistic profile names after sign-up — before get-profile backfills UserMetadata. */
+/**
+ * Optimistic profile names after sign-up — before get-profile backfills UserMetadata.
+ *
+ * Writes a deliberately partial snapshot: none of the church, lock-PIN, or switcher-order
+ * fields are knowable yet. It is the main reason the snapshot is only a
+ * `CachedSessionProfile`, and the reason `useProfile` seeds it as a placeholder that a
+ * fetch replaces rather than as `initialData` that suppresses one.
+ */
 export function seedProfileNamesAfterSignUp(
   userId: string,
   names: { firstName: string; lastName: string; email?: string },
@@ -201,14 +235,35 @@ export interface XPData {
   backfilled?: boolean;
 }
 
+/**
+ * Widen the snapshot for React Query's placeholder slot.
+ *
+ * Sound only because it is a *placeholder*: React Query keeps it out of the query cache and
+ * still fetches on mount, so whatever the snapshot is missing arrives with the response
+ * instead of reading `undefined` for the length of `staleTime`. Consumers that care about a
+ * field the snapshot may not carry should check `isPlaceholderData` before concluding it
+ * has no value. Do not reuse this to pass a snapshot off as a profile anywhere else.
+ */
+function asPlaceholderProfile(snapshot: CachedSessionProfile | undefined): UserProfile | undefined {
+  return snapshot as UserProfile | undefined;
+}
+
 export function useProfile() {
   const { userId } = useAuth();
   const authReady = useAuthReady();
   const sessionHint = hasClerkSessionCookieHint();
   const effectiveUserId =
     userId ?? (sessionHint ? readClerkUserIdForProfileCache() : undefined);
-  const cachedForSessionUser =
-    effectiveUserId && sessionHint ? getCachedProfileForSessionUser(effectiveUserId) : undefined;
+  // Memoized for reference stability, which the placeholder slot needs:
+  // getCachedProfileForSessionUser re-parses the snapshot on every call, and React Query
+  // only reuses a placeholder it can compare by reference. A fresh object each render
+  // would hand every consumer a new `profile` on every render until the fetch lands,
+  // re-firing their effects and blowing their memos.
+  const cachedForSessionUser = useMemo(
+    () =>
+      effectiveUserId && sessionHint ? getCachedProfileForSessionUser(effectiveUserId) : undefined,
+    [effectiveUserId, sessionHint],
+  );
 
   return useQuery({
     queryKey: ['profile', userId ?? effectiveUserId ?? 'none'],
@@ -269,9 +324,21 @@ export function useProfile() {
           return profile;
         }),
     staleTime: 5 * 60_000,
-    placeholderData: cachedForSessionUser,
-    initialData: cachedForSessionUser,
-    initialDataUpdatedAt: cachedForSessionUser ? Date.now() - 30_000 : undefined,
+    // Placeholder, deliberately — not `initialData`.
+    //
+    // The snapshot can be missing anything (see CachedSessionProfile). As `initialData` it
+    // was parked in the query cache as a complete and — with `initialDataUpdatedAt` set 30s
+    // in the past — *fresh* profile, so React Query skipped the fetch for the rest of the
+    // 5-minute staleTime. Any field the snapshot didn't carry then read `undefined` for up
+    // to ~4.5 minutes after a load, with no error and no loading state: `hasLockPinSet`
+    // showing neither Set nor Not set, `sharedSpaceSwitcherOrder` losing the user's order,
+    // `connectedOrgId` making a connected church look disconnected. It reads exactly like
+    // the feature being broken.
+    //
+    // A placeholder paints just as fast — synchronously on first render, so no avatar/name
+    // flash — but stays out of the cache and lets the mount fetch run, so the response
+    // fills in the rest. `isPlaceholderData` marks the window where a field may be missing.
+    placeholderData: asPlaceholderProfile(cachedForSessionUser),
   });
 }
 


### PR DESCRIPTION
`useProfile` could serve a profile object missing fields — with no error and no loading state — for up to ~4.5 minutes after a page load.

## The mechanism

The hook seeded the query from the sessionStorage profile snapshot with `initialData` plus `initialDataUpdatedAt: Date.now() - 30_000`. Against a `staleTime` of 5 minutes, that told React Query the snapshot was a complete, *fresh* profile, so no fetch ran for the rest of the window.

The snapshot is not complete. Three writers fill `harvous-profile-cache` and they carry different amounts:

| Writer | Carries |
|---|---|
| `useProfile` queryFn | the whole get-profile payload |
| `seedProfileNamesAfterSignUp` | 9 identity fields knowable before the first fetch |
| an older build | whatever `UserProfile` held on the day it was written |

Every field outside that common core read `undefined` after a reload. Not as an error, not as a loading state — just absent, which is indistinguishable from "has no value".

## Blast radius

This is already live, not merely a latent trap. Fields absent from the sign-up snapshot but read by shipping consumers:

- `hasLockPinSet` — `PrototypeSettingsIndex` shows neither Set nor Not set
- `sharedSpaceSwitcherOrder` — `SpaceSwitcherMenu` and `PrototypeNoteMoreMenu` lose the user's order
- `connectedOrgId` — `useChurchPlannerAccess` and `useChurchSermons` make a connected church look disconnected
- `isHomeChurchStaff` — staff affordances vanish in `SpaceSwitcherMenu` / `PrototypeSidebarChurchHubView`

It was originally hit on the Home continue-reading card, which read a field get-profile does return and silently never rendered. That consumer was worked around by reading `/api/reading/recent` instead, so nothing regressed — but the next field anyone added would have hit the same wall.

## The fix

Seed the snapshot as `placeholderData` rather than `initialData`.

It paints just as fast — synchronously on the first render, so no avatar/name flash, which is the reason `initialData` was reached for — but stays out of the query cache and lets the mount fetch run, so the response fills in whatever the snapshot lacked. React Query reports `status: 'success'` with `isPlaceholderData: true`, so no consumer that branches on `isLoading` changes behaviour, and consumers can now distinguish "not known yet" from "has no value".

Two supporting changes:

- **`CachedSessionProfile`** — the snapshot is typed as its stable core plus `Partial<UserProfile>`, so it can no longer masquerade as a full profile. The widening needed for React Query's placeholder slot is contained in one documented `asPlaceholderProfile` function instead of an inline cast. It bites where it matters: a newly-added *required* `UserProfile` field will not typecheck against the snapshot.
- **`useMemo` on the snapshot read** — `getCachedProfileForSessionUser` re-parses JSON on every call, and React Query only reuses a placeholder it can compare by reference. Unmemoized, every consumer would get a new `profile` object each render until the fetch landed, re-firing effects and blowing memos. This was dormant under `initialData` (the pre-existing `placeholderData` line never activated, since `initialData` wins when both are set).

## Note on the original diagnosis

The report that prompted this attributed the partial cache to `updateCachedProfileData`. That writes a different key (`profileData`), which `useProfile` never reads — the two caches are separate and the "denorm-only" comment at `useProfile.ts:253` is deliberate. Persisting the full profile there would have been a no-op for this bug.

## Behaviour change to be aware of

The optimistic profile mutations (`useUpdateTranslation`, `useUpdateChurch`, `useUpdateSharedSpaceSwitcherOrder`) already no-op when the query cache is empty — they all guard with `prev ? … : prev`, which is the cold-cache case today. This widens that window by the length of one fetch. Their behaviour is otherwise unchanged.

## Testing

5 new tests in `spa/src/hooks/queries/__tests__/profile-snapshot-placeholder.test.tsx`. I verified 4 of them fail when `initialData` is restored; the 5th (reference stability) passes under `initialData` by construction and guards the `useMemo`.

- Full suite: 3519 passed. Two pre-existing failures in `server/utils/__tests__/` (`support-inbox.integration`, `dismissed-auto-tags`) reproduce identically on `main` — they need a live DB and an LLM key, neither available in the container.
- `typecheck:ratchet` passes at 146 errors, no regressions.
- `check:auth-gated-queries`, `check:thread-terminology`, `design:check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W6N2uYo8CwBzjXrfmyZH14)_