### PR TITLE
A permanent door into the Bible reader, and note-less reference saves

### DIFF
--- a/Changelog/2.72.0.md
+++ b/Changelog/2.72.0.md
@@ -1,0 +1,20 @@
+# Version 2.72.0
+
+**Release Date**: August 16, 2026
+
+## Features
+
+- A permanent door into the Bible reader, and references save without a note
+
+## Fixes
+
+- A partial cached profile stops passing for a complete one
+
+## Improvements
+
+- One canonical book order, imported by both sides (#21)
+
+## Other Changes
+
+- Add study-plan bullet to Shared Spaces upgrade/plan feature list
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.71.2
+**Version:** 2.72.0
 **Status:** Official 1.0 Released January 8, 2026

--- a/docs/future/HARVOUS_NORTH_STAR.md
+++ b/docs/future/HARVOUS_NORTH_STAR.md
@@ -6,7 +6,13 @@
 
 ## What Harvous Is
 
-Harvous is not a Bible reader. It never will be.
+Harvous is not a Bible reading app. It never will be.
+
+It does render Scripture, though. A passage view exists so you can see everything you have
+already saved laid out in the order the text runs — a different angle on your own highlights and
+notes, not a reading experience competing for your daily-reading habit. The notes layer stays
+primary: the passage view surfaces study you already have, and a highlight made there becomes a
+note like any other rather than a loose annotation living off to the side.
 
 Harvous is **the hub for Bible study** — the place where everything you learn, save, reflect on, and remember lives. No matter what app you study in (YouVersion, Logos, Olive Tree, your church's app, a podcast, a sermon), Harvous is where it goes so it doesn't disappear.
 
@@ -109,7 +115,7 @@ The apps are **feeders**. The people are **Harvesters**.
 
 ## What Harvous Deliberately Does Not Do
 
-- **No Bible reader** — YouVersion, Logos, and Olive Tree do this well. Partner with them, don't compete.
+- **No Bible reading app** — YouVersion, Logos, and Olive Tree own the daily-reading habit. Partner with them, don't compete. The passage view is the one carve-out, and a narrow one: it exists to show you your own highlights and notes against the text. No reading plans, no streaks, no devotional content. If it ever starts competing for the reading habit itself, it has drifted.
 - **No sermon streaming** — Same. Plenty of apps for that.
 - **No devotional content** — Harvous surfaces *your* content, not generic content.
 - **No social feed of Bible verses** — Not a content platform. A personal study hub with a social *layer* on top of your own work.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.71.2",
+  "version": "2.72.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-71-2';
+const CACHE_NAME = 'harvous-cache-v2-72-0';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/server/routes/spaces.ts
+++ b/server/routes/spaces.ts
@@ -1578,22 +1578,40 @@ route.get('/api/spaces/:spaceId/study-thread-highlights', requireAuth, async (c)
           parentNoteTitle: Notes.title,
         })
         .from(StudyThreadEntries)
-        .innerJoin(Notes, eq(StudyThreadEntries.parentNoteId, Notes.id))
+        /*
+         * Left, not inner: a reference saved while reading has no parent note, and an inner
+         * join drops every one of those rows — the list would look empty for something the
+         * user just saved. Note-backed and parentless rows are two alternatives below, so
+         * every predicate that reads a `Notes` column has to sit inside the note-backed
+         * branch: on a parentless row those columns are NULL, and a NULL conjunct at the top
+         * level is not true, which would filter the row right back out.
+         */
+        .leftJoin(Notes, eq(StudyThreadEntries.parentNoteId, Notes.id))
         .where(
           and(
             eq(StudyThreadEntries.isArchived, false),
             ne(StudyThreadEntries.entryKindRaw, 'workspace'),
             highlightCandidates,
             ...(isPersonalSpace
-              ? [eq(Notes.spaceId, spaceIdNorm)]
+              ? [
+                  eq(StudyThreadEntries.userId, auth.userId),
+                  or(
+                    and(
+                      eq(Notes.spaceId, spaceIdNorm),
+                      eq(Notes.userId, auth.userId),
+                      eq(Notes.contentEncrypted, false),
+                    ),
+                    and(
+                      isNull(StudyThreadEntries.parentNoteId),
+                      eq(StudyThreadEntries.spaceId, spaceIdNorm),
+                    ),
+                  ),
+                ]
               : [
                   activeSpaceNotePredicate(spaceIdNorm),
                   eq(StudyThreadEntries.spaceId, spaceIdNorm),
+                  eq(Notes.contentEncrypted, false),
                 ]),
-            eq(Notes.contentEncrypted, false),
-            ...(isPersonalSpace
-              ? [eq(StudyThreadEntries.userId, auth.userId), eq(Notes.userId, auth.userId)]
-              : []),
           ),
         )
         .orderBy(desc(StudyThreadEntries.highlightListEditedAt), desc(StudyThreadEntries.createdAt))

--- a/server/routes/study-threads.ts
+++ b/server/routes/study-threads.ts
@@ -8,6 +8,7 @@
  * DELETE /api/study-threads/:id
  * GET    /api/scripture/highlights        — a chapter's highlights, however they were made
  * POST   /api/scripture/highlights        — highlight made while reading (no parent note)
+ * POST   /api/scripture/references        — reference saved while reading (no parent note)
  */
 
 import { Hono } from 'hono';
@@ -41,7 +42,7 @@ import {
   canModerateStudyThreadEntry,
   SharedStudyThreadAccessError,
 } from '../utils/shared-study-thread-access';
-import { SpaceAccessError } from '../utils/space-access';
+import { SpaceAccessError, requireSpaceAccess } from '../utils/space-access';
 import {
   createDurableNoteAnchorFromHtml,
   createDurableNoteAnchorFromText,
@@ -932,6 +933,10 @@ route.post('/api/scripture/highlights', requireAuth, rateLimit('write'), async (
           and(
             eq(StudyThreadEntries.userId, auth.userId),
             isNull(StudyThreadEntries.parentNoteId),
+            // Kind matters here, not just the passage: a reference saved while reading is also a
+            // parentless row on this same verse, and without this it would be found by the lookup
+            // above and silently recoloured instead of the highlight being created.
+            eq(StudyThreadEntries.entryKindRaw, 'scriptureLink'),
             eq(StudyThreadEntries.scriptureReference, norm),
             eq(StudyThreadEntries.scripturePassageTranslation, translation),
           ),
@@ -978,6 +983,107 @@ route.post('/api/scripture/highlights', requireAuth, rateLimit('write'), async (
     const e = handleAPIError(error, {
       endpoint: '/api/scripture/highlights',
       action: 'create_scripture_highlight',
+    });
+    return c.json({ error: e.message, code: e.code }, 500);
+  }
+});
+
+// ─── POST /api/scripture/references ──────────────────────────────────────────
+/**
+ * Keep a looked-up word while reading, without making a note to hold it.
+ *
+ * Deliberately not folded into `POST /api/scripture/highlights`, even though both write a
+ * parentless row: that route upserts because a highlight is a property of a passage, so
+ * highlighting twice means "make it this colour". Two different words looked up in one verse
+ * are two references, not one recoloured — same table, opposite write semantics.
+ *
+ * `spaceId` is recorded rather than left null (a reading highlight leaves it null). The list
+ * that surfaces these is asked for one space at a time, and a null would put a single saved
+ * reference in every personal space the account has.
+ */
+route.post('/api/scripture/references', requireAuth, rateLimit('write'), async (c) => {
+  try {
+    const auth = getAuthenticatedAuth(c);
+    const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+
+    const word = typeof body.word === 'string' ? body.word.trim() : '';
+    if (!word) return c.json({ error: 'word is required' }, 400);
+
+    const refRaw = typeof body.reference === 'string' ? body.reference.trim() : '';
+    // The raw text is the fallback rather than a hard failure — an unparseable reference is
+    // still worth keeping next to the word it came from.
+    const norm = normalizeScriptureReference(refRaw) ?? refRaw;
+    if (!norm) return c.json({ error: 'reference is required' }, 400);
+
+    const translation =
+      typeof body.translation === 'string' && body.translation.trim()
+        ? body.translation.trim()
+        : 'NET';
+    const accent =
+      typeof body.accent === 'string' && isStudyHighlightAccentKey(body.accent)
+        ? body.accent
+        : 'warmAmber';
+
+    const spaceId = normalizeContextSpaceId(body.spaceId);
+    if (!spaceId) return c.json({ error: 'spaceId is required' }, 400);
+    try {
+      await requireSpaceAccess(spaceId, auth.userId);
+    } catch (err) {
+      if (err instanceof SpaceAccessError) return c.json({ error: err.message, code: err.code }, err.status);
+      throw err;
+    }
+
+    const now = nowISO();
+
+    // Saving the same word on the same verse again is the same reference, not a second one.
+    const existing = first(
+      await db
+        .select()
+        .from(StudyThreadEntries)
+        .where(
+          and(
+            eq(StudyThreadEntries.userId, auth.userId),
+            isNull(StudyThreadEntries.parentNoteId),
+            eq(StudyThreadEntries.entryKindRaw, 'reference'),
+            eq(StudyThreadEntries.scriptureReference, norm),
+            eq(StudyThreadEntries.scripturePassageTranslation, translation),
+            eq(StudyThreadEntries.sourceSnippet, word),
+          ),
+        )
+        .limit(1),
+    ) as typeof StudyThreadEntries.$inferSelect | undefined;
+
+    if (existing) {
+      return c.json({ success: true, reference: mapStudyRow(existing) });
+    }
+
+    const row = first(
+      await db
+        .insert(StudyThreadEntries)
+        .values({
+          id: generateStudyThreadEntryId(),
+          userId: auth.userId,
+          // Null on purpose: saved while reading, so there is no note it came from.
+          parentNoteId: null,
+          spaceId,
+          entryKindRaw: 'reference',
+          highlightAccentRaw: accent,
+          scriptureReference: norm,
+          scripturePassageTranslation: translation,
+          scripturePassageExcerpt: word,
+          sourceSnippet: word,
+          focusTitle: word,
+          createdAt: now,
+          updatedAt: now,
+        } as any)
+        .returning(),
+    );
+
+    return c.json({ success: true, reference: row ? mapStudyRow(row) : null });
+  } catch (error: any) {
+    const e = handleAPIError(error, {
+      endpoint: '/api/scripture/references',
+      action: 'create_scripture_reference',
     });
     return c.json({ error: e.message, code: e.code }, 500);
   }

--- a/spa/src/hooks/queries/usePrototypeChapterHighlights.ts
+++ b/spa/src/hooks/queries/usePrototypeChapterHighlights.ts
@@ -53,15 +53,23 @@ export function usePrototypeChapterHighlights(
        * default, so every highlight rendered amber no matter what colour was saved. Falling
        * back explicitly keeps that failure visible in one place.
        */
-      return ((data.highlights ?? []) as Array<Record<string, unknown>>).map((row) => ({
-        id: String(row.id),
-        scriptureReference: (row.scriptureReference as string | null) ?? null,
-        highlightAccent: (row.highlightAccentRaw ??
-          row.highlightAccent ??
-          'warmAmber') as StudyHighlightAccentKey,
-        miniNoteBody: row.miniNoteBody as string | undefined,
-        madeWhileReading: Boolean(row.madeWhileReading),
-      }));
+      /*
+       * References are anchored to a verse but they are not highlights of it. Saving the
+       * dictionary entry for a word should not repaint the whole verse — the endpoint
+       * deliberately returns every kind of row, so the narrowing belongs here, at the one
+       * caller that paints.
+       */
+      return ((data.highlights ?? []) as Array<Record<string, unknown>>)
+        .filter((row) => row.entryKind !== 'reference' && row.entryKindRaw !== 'reference')
+        .map((row) => ({
+          id: String(row.id),
+          scriptureReference: (row.scriptureReference as string | null) ?? null,
+          highlightAccent: (row.highlightAccentRaw ??
+            row.highlightAccent ??
+            'warmAmber') as StudyHighlightAccentKey,
+          miniNoteBody: row.miniNoteBody as string | undefined,
+          madeWhileReading: Boolean(row.madeWhileReading),
+        }));
     },
   });
 }

--- a/spa/src/hooks/useSmartJumpDestination.ts
+++ b/spa/src/hooks/useSmartJumpDestination.ts
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+import { bibleBookChapterCounts } from '@/utils/bible-book-chapters';
+import { parseReaderQuery } from '@/utils/parse-reader-query';
+import { readingDwellCountsAsRead } from '@/utils/reading-event-kinds';
+import {
+  deriveContinueReading,
+  deriveSmartJumpDestination,
+  type SmartJumpDestination,
+} from '@/utils/prototype-home-trends';
+import { useReadingHistory } from './queries/useReadingHistory';
+import { useVotdToday } from './queries/useVotdToday';
+
+/**
+ * Where "open the reader" goes when nothing named a passage.
+ *
+ * Lives in one place because two surfaces ask the same question — the toolbar control and the
+ * scripture list's empty state — and a second copy of the priority would drift the moment one
+ * of them gained a case the other did not.
+ *
+ * Both queries are auth-gated internally and answer null while loading, which lands on the
+ * fallback. That is the right shape for a control that is always clickable: an early click
+ * opens John 1 rather than nothing.
+ */
+export function useSmartJumpDestination(): SmartJumpDestination {
+  const readingHistoryQuery = useReadingHistory();
+  const { data: votd } = useVotdToday();
+
+  const lastRead = readingHistoryQuery.data?.lastRead ?? null;
+  const chapters = readingHistoryQuery.data?.chapters;
+  const votdReference = votd?.reference;
+
+  return useMemo(() => {
+    const continueReading = deriveContinueReading(
+      {
+        lastRead,
+        readChapters: (chapters ?? []).map((c) => ({
+          book: c.book,
+          chapter: c.chapter,
+          countsAsRead: readingDwellCountsAsRead(c.dwellBucket),
+        })),
+      },
+      bibleBookChapterCounts(),
+    );
+
+    const parsedVotd = votdReference ? parseReaderQuery(votdReference) : null;
+
+    return deriveSmartJumpDestination(
+      continueReading,
+      parsedVotd
+        ? { book: parsedVotd.book, chapter: parsedVotd.chapter, verse: parsedVotd.verse }
+        : null,
+    );
+  }, [lastRead, chapters, votdReference]);
+}

--- a/spa/src/layouts/SimplifiedPrototypeLayout.tsx
+++ b/spa/src/layouts/SimplifiedPrototypeLayout.tsx
@@ -61,6 +61,7 @@ import '../styles/prototype-editor.css';
 import '../styles/prototype-route-overrides.css';
 import { hasClerkSessionCookieHint } from '../hooks/queries/useProfile';
 import { usePrototypeHomeSpaceId } from '../hooks/usePrototypeHomeSpaceId';
+import { useSmartJumpDestination } from '../hooks/useSmartJumpDestination';
 import { useActiveSpace } from '../hooks/useActiveSpace';
 import { useSharedSpaceVisitStamp } from '../hooks/useSharedSpaceVisit';
 import { resolvePrototypeSidebarVariant } from './resolve-prototype-sidebar-variant';
@@ -1100,6 +1101,8 @@ function PrototypeShortcutBridge() {
     sidebarListSpaceScope,
   } = useProtoShell();
 
+  const smartJump = useSmartJumpDestination();
+
   const noteSlugFromPath = matchPrototypeNoteId(pathname);
   const isDraftNoteRoute =
     composeDraftActive ||
@@ -1207,6 +1210,20 @@ function PrototypeShortcutBridge() {
     ensureSidebarExpanded();
   }, [ensureSidebarExpanded, setSidebarLayer]);
 
+  /** Same destination the toolbar's reader control resolves — one priority, two ways to reach it. */
+  const openReader = useCallback(() => {
+    if (!homeSpaceId) return;
+    if (isMobileSidebar) closeDrawer({ preserveHistory: true });
+    navigate.navigate({
+      to: prototypeReadRouteTo(),
+      params: { book: bookSlug(smartJump.book), chapter: String(smartJump.chapter) },
+      search: {
+        v: smartJump.verse ? String(smartJump.verse) : undefined,
+        t: smartJump.translation || undefined,
+      },
+    });
+  }, [homeSpaceId, isMobileSidebar, closeDrawer, navigate, smartJump]);
+
   useEffect(() => {
     const onNewNote = () => createPrototypeNote();
     const onToggleSidebar = () => togglePrototypeSidebar();
@@ -1223,7 +1240,9 @@ function PrototypeShortcutBridge() {
     };
     const onShowHome = () => showHomeLayer();
     const onShowList = () => showListLayer();
+    const onOpenReader = () => openReader();
 
+    window.addEventListener('prototypeShortcutOpenReader', onOpenReader);
     window.addEventListener('prototypeShortcutNewNote', onNewNote);
     window.addEventListener('prototypeShortcutToggleSidebar', onToggleSidebar);
     window.addEventListener('prototypeShortcutToggleInspector', onToggleInspector);
@@ -1234,6 +1253,7 @@ function PrototypeShortcutBridge() {
     window.addEventListener('prototypeShortcutShowList', onShowList);
 
     return () => {
+      window.removeEventListener('prototypeShortcutOpenReader', onOpenReader);
       window.removeEventListener('prototypeShortcutNewNote', onNewNote);
       window.removeEventListener('prototypeShortcutToggleSidebar', onToggleSidebar);
       window.removeEventListener('prototypeShortcutToggleInspector', onToggleInspector);
@@ -1248,6 +1268,7 @@ function PrototypeShortcutBridge() {
     cycleListMode,
     focusPrototypeNoteList,
     focusPrototypeSidebarSearch,
+    openReader,
     pathname,
     showNoteDetailsOrb,
     showHomeLayer,

--- a/spa/src/pages/prototype/NativeToolbar.tsx
+++ b/spa/src/pages/prototype/NativeToolbar.tsx
@@ -39,7 +39,10 @@ import {
   isPrototypeReadPath,
   matchPrototypeNoteId,
   prototypeHomeRouteTo,
+  prototypeReadRouteTo,
 } from '@/lib/prototype-path';
+import { bookSlug } from '@/utils/bible-book-chapters';
+import { useSmartJumpDestination } from '../../hooks/useSmartJumpDestination';
 import { prototypeToolbarNoteDetailsAvailable } from './prototype-toolbar-note-details';
 import {
   canOrganizeSharedSpaceNote,
@@ -268,6 +271,26 @@ export default function NativeToolbar({ variant = 'detail' }: { variant?: Native
     navigate({ to: prototypeHomeRouteTo() });
   };
 
+  /*
+   * The reader had no permanent door. Every way in was conditional on state a new account does
+   * not have yet — a verse of the day that can be dismissed, a reading position that only
+   * exists once you have read, a scripture index built from notes you have not written — so
+   * someone with an empty account could not reach it at all except by typing the URL.
+   */
+  const smartJump = useSmartJumpDestination();
+
+  const onOpenReader = useCallback(() => {
+    if (isMobileSidebar) closeDrawer({ preserveHistory: true });
+    void navigate({
+      to: prototypeReadRouteTo(),
+      params: { book: bookSlug(smartJump.book), chapter: String(smartJump.chapter) },
+      search: {
+        v: smartJump.verse ? String(smartJump.verse) : undefined,
+        t: smartJump.translation || undefined,
+      },
+    });
+  }, [smartJump, isMobileSidebar, closeDrawer, navigate]);
+
   const onSidebarButton = () => {
     if (isMobileSidebar) toggleDrawer();
     else toggleDesktopSidebar();
@@ -386,6 +409,20 @@ export default function NativeToolbar({ variant = 'detail' }: { variant?: Native
             onClick={onCompose}
           >
             <Icon name="pen-to-square" size={PROTO_TOOLBAR_ORB_ICON_SIZE} />
+          </button>
+        </PrototypeToolbarShortcutItem>
+        {/* Beside compose, because reading and writing are the two things you start here.
+            Unlike compose it needs no space permission — a chapter is not written to. */}
+        <PrototypeToolbarShortcutItem shortcut="R" showShortcut={showShiftHints}>
+          <button
+            type="button"
+            className="proto-toolbar-icon-btn"
+            title="Read the Bible"
+            aria-label="Read the Bible"
+            disabled={!homeSpaceId}
+            onClick={onOpenReader}
+          >
+            <Icon name="book-open" size={PROTO_TOOLBAR_ORB_ICON_SIZE} />
           </button>
         </PrototypeToolbarShortcutItem>
       </div>

--- a/spa/src/pages/prototype/PrototypeBibleReaderPane.tsx
+++ b/spa/src/pages/prototype/PrototypeBibleReaderPane.tsx
@@ -239,6 +239,13 @@ export interface PrototypeBibleReaderPaneProps {
    */
   onSaveReference?: (input: { word: string; reference: string; verse?: number }) => void;
   saveReferenceLabel?: string;
+  /**
+   * Open a looked-up word's card on arrival, for a saved reference tapped somewhere else.
+   *
+   * `requestKey` is what makes it repeatable: the dock is dismissible, so opening the same
+   * word twice has to be two requests rather than one piece of state that is already set.
+   */
+  referenceRequest?: { word: string; anchor: string; verse?: number; requestKey: string } | null;
 }
 
 export default function PrototypeBibleReaderPane({
@@ -256,6 +263,7 @@ export default function PrototypeBibleReaderPane({
   onOpenNoteAtReference,
   onSaveReference,
   saveReferenceLabel,
+  referenceRequest,
 }: PrototypeBibleReaderPaneProps) {
   const { data, isLoading, isError, error } = usePrototypeBibleChapter(book, chapter, translation);
   const { verseLayout, showMarginNotes } = useSyncExternalStore(
@@ -367,6 +375,24 @@ export default function PrototypeBibleReaderPane({
 
   /** What the shell's study dock is showing on behalf of the reader; null when closed. */
   const [dock, setDock] = useState<ReaderDockState>(null);
+
+  /*
+   * Honour an arrival request to open a word's card. Keyed on the request's nonce rather than
+   * its contents, so tapping the same saved reference again reopens the card after it has
+   * been dismissed.
+   */
+  const lastReferenceRequestKey = useRef<string | null>(null);
+  useEffect(() => {
+    if (!referenceRequest?.word || !referenceRequest.requestKey) return;
+    if (lastReferenceRequestKey.current === referenceRequest.requestKey) return;
+    lastReferenceRequestKey.current = referenceRequest.requestKey;
+    setDock({
+      kind: 'reference',
+      query: referenceRequest.word,
+      anchor: referenceRequest.anchor,
+      verse: referenceRequest.verse,
+    });
+  }, [referenceRequest]);
   /** The menu is showing colours for the highlight just made, rather than the action list. */
   const [paletteOpen, setPaletteOpen] = useState(false);
 

--- a/spa/src/pages/prototype/PrototypeReadPage.tsx
+++ b/spa/src/pages/prototype/PrototypeReadPage.tsx
@@ -11,9 +11,10 @@ import { prototypeReadRouteTo } from '@/lib/prototype-path';
 import { bookFromSlug, bookSlug } from '@/utils/bible-book-chapters';
 import { buildVotdScripturePillHtml } from '../../lib/votd-scripture-pill-html';
 import { useProfile } from '../../hooks/queries/useProfile';
-import { getNoteIdFromCreateResponse } from '../../hooks/queries/useNote';
-import { useCreateSimpleNote } from '../../hooks/mutations/useCreateSimpleNote';
-import { saveReferenceStudyThread } from '@/utils/save-reference-study-thread';
+import {
+  saveReaderReferenceStudyThread,
+  saveReferenceStudyThread,
+} from '@/utils/save-reference-study-thread';
 import { notifyStudyThreadListChanged } from '@/utils/prototype-study-thread-list-sync';
 import { usePrototypeHomeSpaceId } from '../../hooks/usePrototypeHomeSpaceId';
 import { useProtoShell, type PaperStackOrigin } from '../../layouts/proto-shell-context';
@@ -58,7 +59,12 @@ function versesInReference(reference: string | null): number[] {
 
 export default function PrototypeReadPage() {
   const params = useParams({ strict: false }) as { book?: string; chapter?: string };
-  const search = useSearch({ strict: false }) as { v?: string; t?: string };
+  const search = useSearch({ strict: false }) as {
+    v?: string;
+    t?: string;
+    ref?: string;
+    dockReq?: string;
+  };
   const navigate = useNavigate();
   const { data: profile } = useProfile();
   const { homeSpaceId } = usePrototypeHomeSpaceId();
@@ -72,7 +78,6 @@ export default function PrototypeReadPage() {
     isMobileSidebar,
   } = useProtoShell();
   const paneIsWide = useShellPaneIsWide();
-  const createNoteMutation = useCreateSimpleNote();
   /**
    * Try-a-face for this reading session. Deliberately component state, not a preference:
    * it lasts as long as you are here and never overwrites the default in Appearance.
@@ -133,6 +138,24 @@ export default function PrototypeReadPage() {
       replace: true,
     });
   }, [book, rawBook, chapter, navigate, search.v, search.t]);
+
+  /*
+   * A saved reference tapped in the list asks the reader to open that word's card on arrival.
+   * The anchor is rebuilt from where we actually landed rather than carried in the URL — the
+   * chapter is already in the path, so the word is the only thing the link has to say.
+   */
+  const referenceRequest = useMemo(() => {
+    const word = search.ref?.trim();
+    if (!word) return null;
+    return {
+      word,
+      anchor: Number.isFinite(focusVerse)
+        ? `${book} ${chapter}:${focusVerse}`
+        : `${book} ${chapter}`,
+      verse: Number.isFinite(focusVerse) ? focusVerse : undefined,
+      requestKey: search.dockReq || word,
+    };
+  }, [search.ref, search.dockReq, book, chapter, focusVerse]);
 
   const applyHighlight = useCallback(
     ({ start, end }: { start: number; end: number }, accent: StudyHighlightAccentKey) => {
@@ -200,18 +223,17 @@ export default function PrototypeReadPage() {
   /**
    * Keep a word you looked up while reading.
    *
-   * A saved reference is an entry on a note's study thread — there is nowhere else to put
-   * one — and the reader has no note. So there are two honest versions of this action and
-   * the label says which you are getting:
+   * Two versions of the same action, differing only in what the reference ends up anchored
+   * to — and the label says which you are getting:
    *
    * - A note is already in play (you came here from one, or opened one over the chapter):
    *   the reference joins that note, exactly as saving from its own scripture dock would.
-   * - Nothing is in play: a note is made to hold it, seeded with this passage the same way
-   *   "start a note" from a verse selection seeds one, and stacked over the chapter so the
-   *   reading you were doing is still underneath.
+   * - Nothing is in play: it is saved against the passage instead, and shows up in the
+   *   references list like any other.
    *
-   * The second creates a note on a tap, which is why it is never called "save" — a button
-   * that quietly makes a document should say that it is going to.
+   * This used to make a whole note to hold the second case, because a reference was assumed
+   * to need a parent. It does not: the row's parent note is nullable and reading highlights
+   * have always been written without one. Saving a word is not a reason to create a document.
    */
   /*
    * The note in play, from either side of the stack. `noteId` is the note when it is the
@@ -227,9 +249,9 @@ export default function PrototypeReadPage() {
     const slug = paperStack.origin.returnTo.params?.noteId;
     return slug ? normalizeNoteIdFromParam(slug) || null : null;
   }, [paperStack]);
-  const saveReferenceLabel = stackedNoteId ? 'Save to your note' : 'Start a note with this';
+  const saveReferenceLabel = stackedNoteId ? 'Save to your note' : 'Save this reference';
   const handleSaveReference = useCallback(
-    ({ word, reference, verse }: { word: string; reference: string; verse?: number }) => {
+    ({ word, reference }: { word: string; reference: string; verse?: number }) => {
       void (async () => {
         if (stackedNoteId) {
           await saveReferenceStudyThread({
@@ -243,41 +265,19 @@ export default function PrototypeReadPage() {
           return;
         }
 
-        const res = await createNoteMutation.mutateAsync({
-          spaceId: homeSpaceId ?? '',
-          content: buildVotdScripturePillHtml(reference, translation),
+        if (!homeSpaceId) return;
+        await saveReaderReferenceStudyThread({
+          word,
+          reference,
+          translation,
+          spaceId: homeSpaceId,
         });
-        const createdId = getNoteIdFromCreateResponse(res);
-        // Offline creates resolve to a queued id later; without one there is no thread to
-        // hang the reference on, so the note is still made and the word is not lost — it is
-        // in the passage the note opens on.
-        if (createdId) {
-          await saveReferenceStudyThread({
-            noteId: createdId,
-            word,
-            reference,
-            translation,
-            spaceId: homeSpaceId,
-          });
-          notifyStudyThreadListChanged(homeSpaceId, createdId);
-          void navigate({
-            to: prototypeNoteRouteTo(),
-            params: { noteId: noteParamSlug(createdId) },
-            search: {},
-          });
-          stackNote(readerOrigin(verse), createdId);
-        }
+        // No note id to pass — the list invalidation is what matters, and it only no-ops when
+        // both ids are missing.
+        notifyStudyThreadListChanged(homeSpaceId, null);
       })();
     },
-    [
-      stackedNoteId,
-      translation,
-      homeSpaceId,
-      createNoteMutation,
-      navigate,
-      stackNote,
-      readerOrigin,
-    ],
+    [stackedNoteId, translation, homeSpaceId],
   );
 
   /**
@@ -446,6 +446,7 @@ export default function PrototypeReadPage() {
           onOpenNoteAtReference={handleOpenNoteAtReference}
           onSaveReference={handleSaveReference}
           saveReferenceLabel={saveReferenceLabel}
+          referenceRequest={referenceRequest}
         />
       </div>
     </PrototypeMainPaneShell>

--- a/spa/src/pages/prototype/PrototypeSidebar.tsx
+++ b/spa/src/pages/prototype/PrototypeSidebar.tsx
@@ -6,6 +6,7 @@ import Icon from '@/components/react/Icon';
 import ProtoChipBar, { type ProtoChipOption } from './components/ProtoChipBar';
 import { toast } from '@/utils/toast';
 import { APIError } from '../../lib/api';
+import { useSmartJumpDestination } from '../../hooks/useSmartJumpDestination';
 import { useDeleteNote } from '../../hooks/mutations/useDeleteNote';
 import { useDeleteNotesBatch } from '../../hooks/mutations/useDeleteNotesBatch';
 import { useNavigation } from '../../hooks/queries/useNavigation';
@@ -1586,6 +1587,19 @@ export default function PrototypeSidebar({
     if (!canCreateSidebarCollections) return;
     setCreateFolderSheetOpen(true);
   }, [canCreateSidebarCollections]);
+
+  const smartJump = useSmartJumpDestination();
+  const openSmartJumpReader = useCallback(() => {
+    if (isMobileSidebar) closeDrawer({ preserveHistory: true });
+    void navigate({
+      to: prototypeReadRouteTo(),
+      params: { book: bookSlug(smartJump.book), chapter: String(smartJump.chapter) },
+      search: {
+        v: smartJump.verse ? String(smartJump.verse) : undefined,
+        t: smartJump.translation || undefined,
+      },
+    });
+  }, [smartJump, isMobileSidebar, closeDrawer, navigate]);
   const isHomeLayer = sidebarLayer === 'space';
   const tagFilterActive = Boolean(tagFilter);
   const searchActive = !isHomeLayer && q.trim().length > 0 && !tagFilterActive;
@@ -3120,8 +3134,35 @@ export default function PrototypeSidebar({
         return false;
       }
     }
-    // The highlight and reference docks both live inside a note, so without a source note
-    // there is nothing to open them on.
+    /*
+     * A reference saved while reading has no note behind it, so it opens where it was made:
+     * the chapter, with the word's card already up. Without this it fell through to the guard
+     * below and did nothing at all on tap — the row was in the list but led nowhere.
+     */
+    if (!r.parentNoteId && r.entryKind === 'reference') {
+      const word = (r.sourceSnippet ?? '').trim();
+      const parsed = r.scriptureReference ? parseScriptureReference(r.scriptureReference) : null;
+      if (word && parsed) {
+        dismissStandaloneScripturePassage();
+        if (isMobileSidebar) closeDrawer({ preserveHistory: true });
+        void navigate({
+          to: prototypeReadRouteTo(),
+          params: { book: bookSlug(parsed.book), chapter: String(parsed.chapter) },
+          search: {
+            v: typeof parsed.verse === 'number' ? String(parsed.verse) : undefined,
+            t: r.scripturePassageTranslation || undefined,
+            ref: word,
+            // Same word tapped twice has to reopen the card, so the request needs to differ.
+            dockReq: String(Date.now()),
+          },
+        });
+        afterNav();
+      }
+      // Nothing was stacked over anything — the reader is the document here.
+      return false;
+    }
+    // The highlight dock lives inside a note, so without a source note there is nothing to
+    // open it on.
     if (!r.parentNoteId) return false;
     dismissStandaloneScripturePassage();
     const isReferenceRow = r.entryKind === 'reference';
@@ -4238,6 +4279,19 @@ export default function PrototypeSidebar({
                       iconName="book-open"
                       title="No Scripture References"
                       description="Add scripture references in your notes to build your index."
+                      /* This index is built from notes, so before there are notes it had nothing
+                         to say and no way out — the one screen in the app that names Scripture
+                         was also the one that could not open any. */
+                      action={
+                        <button
+                          type="button"
+                          className="proto-glass-surface proto-glass-surface--control proto-glass-action"
+                          onClick={openSmartJumpReader}
+                        >
+                          <Icon name="book-open" size={12} aria-hidden />
+                          <span className="proto-glass-action__label">Read the Bible</span>
+                        </button>
+                      }
                     />
                   )
                 ) : (

--- a/spa/src/pages/prototype/PrototypeSidebarHomeView.tsx
+++ b/spa/src/pages/prototype/PrototypeSidebarHomeView.tsx
@@ -750,9 +750,8 @@ export default function PrototypeSidebarHomeView({
    * Where a brand-new account is invited to start reading.
    *
    * Today's verse of the day when there is one — it is already the app's answer to "what
-   * should I read", and a first run is exactly when that question is loudest. John 1 is the
-   * fallback rather than Genesis 1: someone opening a Bible app for the first time is more
-   * likely to be looking for Jesus than for a genealogy.
+   * should I read", and a first run is exactly when that question is loudest. Genesis 1
+   * otherwise, matching the toolbar's own smart-jump fallback.
    */
   /*
    * Where reading actually stopped, which is a different question from which chapters the
@@ -764,7 +763,7 @@ export default function PrototypeSidebarHomeView({
   const firstRunPassage = useMemo(() => {
     const parsed = votd?.reference ? parseReaderQuery(votd.reference) : null;
     if (parsed) return parsed;
-    return { book: 'John', chapter: 1, verse: null, reference: 'John 1' };
+    return { book: 'Genesis', chapter: 1, verse: null, reference: 'Genesis 1' };
   }, [votd?.reference]);
 
   // When all pages are loaded, the flat list is authoritative; otherwise prefer server total.
@@ -1834,7 +1833,7 @@ export default function PrototypeSidebarHomeView({
         {looseCount >= LOOSE_MIN ? (
           <PrototypeHomeRow
             icon="folder"
-            title={`${looseCount} ${looseCount === 1 ? 'note needs' : 'notes need'} a home`}
+            title={`${looseCount} ${looseCount === 1 ? 'note needs' : 'notes need'} a folder`}
             onClick={() => {
               setSidebarListMode('folders');
               setSidebarFolderDrilldown(null);

--- a/spa/src/router.tsx
+++ b/spa/src/router.tsx
@@ -361,13 +361,24 @@ function buildPrototypeRouteBranch() {
    * A real URL rather than shell state, because a chapter is the thing people link to:
    * a church study, a `harvo.us` short link, or a shared passage all want to open a
    * reader on a specific chapter. `?v=` focuses a verse, `?t=` picks a translation.
+   *
+   * `?ref=` asks the reader to open a looked-up word's card on arrival, so a saved reference
+   * in the list can land on the thing it names rather than just the chapter it came from.
+   * `?dockReq=` is a nonce: tapping the same reference twice has to reopen the card, and
+   * without something changing in the URL the second tap would be a no-op.
    */
   const prototypeReadRoute = createRoute({
     getParentRoute: () => simplifiedPrototypeRoute,
     path: 'read/$book/$chapter',
-    validateSearch: (search: Record<string, unknown>) => ({
+    // Optional rather than `string | undefined`: every existing caller navigates here with
+    // just `{v, t}`, and a required-but-undefined key would make each of them a type error.
+    validateSearch: (
+      search: Record<string, unknown>,
+    ): { v?: string; t?: string; ref?: string; dockReq?: string } => ({
       v: typeof search.v === 'string' ? search.v : undefined,
       t: typeof search.t === 'string' ? search.t : undefined,
+      ref: typeof search.ref === 'string' ? search.ref : undefined,
+      dockReq: typeof search.dockReq === 'string' ? search.dockReq : undefined,
     }),
     component: lazyRouteComponent(() => import('./pages/prototype/PrototypeReadPage')),
   });

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -806,6 +806,29 @@ html[data-shift-hints='1'] .proto-toolbar-orb-group {
   .proto-toolbar-right {
     gap: 8px;
   }
+
+  /*
+   * The chip takes its turn in the row instead of lying across it.
+   *
+   * Centring it absolutely keeps it optically centred on the window, which is right when
+   * there is room — but it is centred on the *window*, not on the space actually left over,
+   * so it cannot know how wide the button groups beside it have grown. Each orb added to the
+   * left pushes that group further under a chip that has not moved, and the two overlap
+   * rather than the chip giving way. Measured at 375px: a 36px overlap, the chip sitting on
+   * top of the last orb.
+   *
+   * As a flex item it is bounded by its neighbours, so it truncates instead — which is what
+   * it was always built to do (`flex-shrink: 1`, `overflow: hidden`) and never got the chance
+   * to. Only here: above this width the absolute centring has room and looks better.
+   */
+  .proto-toolbar-center {
+    position: static;
+    transform: none;
+    flex: 1 1 auto;
+    max-width: none;
+    /* The row's own gap now does this work; without it the chip sits tight against the orbs. */
+    margin: 0 4px;
+  }
 }
 
 /* Icon button — circular macOS toolbar "orb" */

--- a/src/utils/__tests__/continue-reading.test.ts
+++ b/src/utils/__tests__/continue-reading.test.ts
@@ -4,6 +4,7 @@ import {
   continueReadingMeta,
   deriveContinueBook,
   deriveContinueReading,
+  deriveSmartJumpDestination,
 } from '../prototype-home-trends';
 
 const chapterCounts = new Map([
@@ -161,5 +162,48 @@ describe('deriveContinueBook with reading', () => {
     ];
 
     expect(deriveContinueBook(books, chapterCounts).map((s) => s.book)).toEqual(['John', 'Romans']);
+  });
+});
+
+describe('deriveSmartJumpDestination', () => {
+  const votd = { book: 'Proverbs', chapter: 29, verse: 25 };
+
+  it('prefers where reading stopped, carrying its translation', () => {
+    const out = deriveSmartJumpDestination(
+      { book: 'John', bookOrder: 42, chapter: 16, translation: 'NLT', reason: 'next' },
+      votd,
+    );
+
+    expect(out).toEqual({
+      book: 'John',
+      chapter: 16,
+      verse: null,
+      translation: 'NLT',
+      source: 'continue',
+    });
+  });
+
+  it("falls to today's passage when there is no reading position", () => {
+    const out = deriveSmartJumpDestination(null, votd);
+
+    expect(out).toEqual({
+      book: 'Proverbs',
+      chapter: 29,
+      verse: 25,
+      translation: null,
+      source: 'votd',
+    });
+  });
+
+  it('always answers, so a first run is never a dead click', () => {
+    const out = deriveSmartJumpDestination(null, null);
+
+    expect(out).toEqual({
+      book: 'Genesis',
+      chapter: 1,
+      verse: null,
+      translation: null,
+      source: 'fallback',
+    });
   });
 });

--- a/src/utils/__tests__/keyboard-shortcuts.test.ts
+++ b/src/utils/__tests__/keyboard-shortcuts.test.ts
@@ -158,6 +158,10 @@ describe('prototype shell shortcuts (Shift + key)', () => {
     expectEvent('prototypeShortcutFocusNoteList', () => press({ key: 'J', code: 'KeyJ', shift: true }));
   });
 
+  it('Shift+R → open the reader', () => {
+    expectEvent('prototypeShortcutOpenReader', () => press({ key: 'R', code: 'KeyR', shift: true }));
+  });
+
   it('Shift+ArrowLeft → cycle list mode backward', () => {
     const e = expectEvent('prototypeShortcutCycleListMode', () =>
       press({ key: 'ArrowLeft', code: 'ArrowLeft', shift: true }),

--- a/src/utils/__tests__/save-reference-study-thread.test.ts
+++ b/src/utils/__tests__/save-reference-study-thread.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
-import { saveReferenceStudyThread } from '../save-reference-study-thread';
+import {
+  saveReaderReferenceStudyThread,
+  saveReferenceStudyThread,
+} from '../save-reference-study-thread';
 
 /**
- * The one path both the editor and the Bible reader save through. What is pinned here is
- * the shape on the wire and the two ways a caller can hand it nothing useful.
+ * The two doors a saved reference goes through — anchored to a note from the editor, or to a
+ * passage from the reader. What is pinned here is the shape on the wire for each, and the
+ * ways a caller can hand either one nothing useful.
  */
 
 function okFetch(id = 'thread_1') {
@@ -52,9 +56,9 @@ describe('saveReferenceStudyThread', () => {
   });
 
   /**
-   * A reference has nowhere to live without a note, which is the whole reason the reader has
-   * to get the user one first. Failing here rather than posting to `/api/notes//…` keeps that
-   * requirement from turning into a confusing 404.
+   * This is the note-anchored door, so a missing note is a caller error rather than a case to
+   * handle — the reader's parentless save has its own function. Failing here rather than
+   * posting to `/api/notes//…` keeps that from turning into a confusing 404.
    */
   it('refuses to save without a note or without a word', async () => {
     const f = okFetch();
@@ -71,5 +75,67 @@ describe('saveReferenceStudyThread', () => {
 
     const refused = vi.fn(async () => new Response('nope', { status: 500 })) as unknown as typeof fetch;
     expect(await saveReferenceStudyThread(input, refused)).toBeNull();
+  });
+});
+
+function okReferenceFetch(id = 'thread_r1') {
+  return vi.fn(async () =>
+    new Response(JSON.stringify({ reference: { id } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  ) as unknown as typeof fetch;
+}
+
+const readerInput = {
+  word: 'Rome',
+  reference: 'Romans 1:7',
+  translation: 'KJV',
+  spaceId: 'space_1',
+};
+
+describe('saveReaderReferenceStudyThread', () => {
+  it('posts to the passage-addressed endpoint, with no note in the payload', async () => {
+    const f = okReferenceFetch();
+    const id = await saveReaderReferenceStudyThread(readerInput, f);
+
+    expect(id).toBe('thread_r1');
+    const [url, init] = (f as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('/api/scripture/references');
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toMatchObject({
+      word: 'Rome',
+      reference: 'Romans 1:7',
+      translation: 'KJV',
+      spaceId: 'space_1',
+    });
+    expect(body).not.toHaveProperty('noteId');
+  });
+
+  /** Same anchor as the note-saved version, so the two cannot describe one passage two ways. */
+  it('normalizes the reference it anchors to', async () => {
+    const f = okReferenceFetch();
+    await saveReaderReferenceStudyThread({ ...readerInput, reference: 'Rom 1:7' }, f);
+    const body = JSON.parse(
+      ((f as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit).body as string,
+    );
+    expect(body.reference).toBe('Romans 1:7');
+  });
+
+  it('refuses to save without a word or without a space', async () => {
+    const f = okReferenceFetch();
+    expect(await saveReaderReferenceStudyThread({ ...readerInput, word: '  ' }, f)).toBeNull();
+    expect(await saveReaderReferenceStudyThread({ ...readerInput, spaceId: '' }, f)).toBeNull();
+    expect(f).not.toHaveBeenCalled();
+  });
+
+  it('reports failure rather than throwing', async () => {
+    const rejecting = vi.fn(async () => {
+      throw new TypeError('Failed to fetch');
+    }) as unknown as typeof fetch;
+    expect(await saveReaderReferenceStudyThread(readerInput, rejecting)).toBeNull();
+
+    const refused = vi.fn(async () => new Response('nope', { status: 500 })) as unknown as typeof fetch;
+    expect(await saveReaderReferenceStudyThread(readerInput, refused)).toBeNull();
   });
 });

--- a/src/utils/keyboard-shortcuts.ts
+++ b/src/utils/keyboard-shortcuts.ts
@@ -370,6 +370,12 @@ function handlePrototypeKeyboardShortcut(event: KeyboardEvent): boolean {
       window.dispatchEvent(new CustomEvent('prototypeShortcutFocusNoteList'));
       return true;
     }
+    if (key === 'r') {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      window.dispatchEvent(new CustomEvent('prototypeShortcutOpenReader'));
+      return true;
+    }
     if (isPrototypeNoteRoute(path)) {
       const noteId = extractPrototypeNoteId(path);
       if (key === 'f' && noteId) {
@@ -760,6 +766,7 @@ export function getPrototypeKeyboardShortcutsReference(): KeyboardShortcutRefere
       heading: 'General',
       items: [
         { action: 'New note', keyParts: [shift, 'N'] },
+        { action: 'Read the Bible', keyParts: [shift, 'R'] },
         { action: 'Search', keyParts: [shift, 'K'] },
         { action: 'Settings', keyParts: [shift, ','] },
         { action: 'Toggle sidebar', keyParts: [shift, 'S'] },

--- a/src/utils/prototype-home-trends.ts
+++ b/src/utils/prototype-home-trends.ts
@@ -1873,6 +1873,56 @@ export function continueReadingEyebrow(suggestion: ContinueReadingSuggestion): s
   return suggestion.reason === 'resume' ? 'Where you left off reading' : 'Keep reading';
 }
 
+// 1c. Smart jump ─────────────────────────────────────────────────────────────────
+
+export interface SmartJumpDestination {
+  book: string;
+  chapter: number;
+  /** The verse to focus on arrival, when the source named one. */
+  verse: number | null;
+  /** Carried only from a reading position, so continuing never switches translation. */
+  translation: string | null;
+  /** Which of the three sources answered. */
+  source: 'continue' | 'votd' | 'fallback';
+}
+
+/**
+ * Where a bare "open the reader" lands. Pure, and always answers.
+ *
+ * The Home cards each gate themselves independently — continue-reading needs a reading
+ * position, the passage card needs a verse of the day — which is right for a card that can
+ * simply not render. A permanent control cannot do that: it is on screen for a brand new
+ * account with no history and no verse of the day, so the last step has to be unconditional.
+ *
+ * Genesis 1, matching the first-run passage the empty Home already offers.
+ */
+export function deriveSmartJumpDestination(
+  continueReading: ContinueReadingSuggestion | null,
+  votdDestination: { book: string; chapter: number; verse: number | null } | null,
+): SmartJumpDestination {
+  if (continueReading) {
+    return {
+      book: continueReading.book,
+      chapter: continueReading.chapter,
+      verse: null,
+      translation: continueReading.translation || null,
+      source: 'continue',
+    };
+  }
+
+  if (votdDestination) {
+    return {
+      book: votdDestination.book,
+      chapter: votdDestination.chapter,
+      verse: votdDestination.verse,
+      translation: null,
+      source: 'votd',
+    };
+  }
+
+  return { book: 'Genesis', chapter: 1, verse: null, translation: null, source: 'fallback' };
+}
+
 // 2. Study a recurring person ─────────────────────────────────────────────────────
 
 export interface RecurringPersonInput {

--- a/src/utils/save-reference-study-thread.ts
+++ b/src/utils/save-reference-study-thread.ts
@@ -1,15 +1,13 @@
 /**
  * Persisting a looked-up word as a reference, in one place.
  *
- * A saved reference is a study-thread entry hanging off a note — there is no standalone
- * store for them — so every surface that offers "save this" has to POST the same shape to
- * the same endpoint. It used to exist only inside the editor, which is why the Bible reader
- * could show you a word's entry but not keep it: the reader has no editor to borrow the
- * call from. Extracted here so the reader and the editor save identically, and so a change
- * to what a saved reference *is* happens once.
+ * A saved reference is a study-thread entry, and it comes in two shapes because it can be
+ * made from two places. Written from a note, it hangs off that note. Written from the Bible
+ * reader, there is no note to hang it off — so it is saved parentless, against the passage
+ * it was read in. Both are the same kind of row in the same table; only the anchor differs.
  *
- * `noteId` is the only hard requirement, and it is the whole design constraint: a caller
- * without a note has nothing to save into and must get the user a note first.
+ * The two live together here so that a change to what a saved reference *is* happens once,
+ * and so the editor and the reader cannot drift into saving different things.
  */
 
 import { normalizeScriptureReference } from './scripture-detector';
@@ -69,6 +67,56 @@ export async function saveReferenceStudyThread(
   } catch {
     // Offline or the endpoint is down. The caller keeps its pending state, so the save can
     // be tried again — losing the word silently would be worse than an unchanged button.
+    return null;
+  }
+}
+
+export type SaveReaderReferenceInput = {
+  /** The looked-up word — both the snippet and the entry's title. */
+  word: string;
+  /** The passage it was read in; this is what the saved reference is anchored to. */
+  reference: string;
+  translation: string;
+  /** Which space the reference belongs to — the reader is always read from one. */
+  spaceId: string;
+  accent?: string;
+};
+
+/**
+ * The reader's version: keep the word without making a note to hold it.
+ *
+ * Separate endpoint rather than a `noteId`-less call to the one above, because the server
+ * addresses these by passage instead of by note. Same row, different door.
+ */
+export async function saveReaderReferenceStudyThread(
+  input: SaveReaderReferenceInput,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string | null> {
+  const word = input.word.trim();
+  const spaceId = input.spaceId.trim();
+  if (!word || !spaceId) return null;
+
+  const raw = input.reference.trim();
+  const reference = normalizeScriptureReference(raw) ?? raw;
+  if (!reference) return null;
+
+  try {
+    const res = await fetchImpl('/api/scripture/references', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        word,
+        reference,
+        translation: input.translation,
+        spaceId,
+        accent: input.accent ?? 'warmAmber',
+      }),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { reference?: { id?: string } };
+    return data.reference?.id ?? null;
+  } catch {
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- The reader had no reliable entry point — every path in was conditional (dismissible VOTD card, continue-reading needing prior history, a Scripture sidebar mode that only indexes verses already cited in notes and dead-ended empty). Adds a permanent "Read the Bible" toolbar control (peer to New note, plus Shift+R), backed by one shared smart-jump priority — continue reading → today's passage → Genesis 1 — reused by the Scripture empty state's new CTA so the two can't drift apart.
- Updates `docs/future/HARVOUS_NORTH_STAR.md`'s stale "not a Bible reader" language to the narrower carve-out already drafted for this.
- Saving a looked-up word from the reader's dictionary card no longer creates a whole note to hold it — it saves as a parentless study-thread row (the same shape reader highlights have always used), shows up in the sidebar References list, and reopens the reader with the dictionary card on tap. Along the way: fixed the highlight upsert not checking entry kind (a saved reference could silently recolour an existing verse highlight), and stopped reference rows from painting verses in the reader.
- Fixed a toolbar layout bug the new control exposed: the center folder chip is absolutely positioned and doesn't account for how wide the side button groups have grown, so the fourth orb pushed it into a 36px overlap at 375px. Below 600px it now flows in-line and truncates instead.

## Test plan
- [x] `npx vitest run` on all touched test files (59+ tests) — passing
- [x] `npm run build:spa && npm run perf:check` — passing, no bundle regressions (1104.3 KB gzipped)
- [x] Manual click-through in a running dev instance:
  - Fresh-state toolbar click → lands on continue-reading position, then VOTD, then Genesis 1 in priority order (verified all three branches)
  - Shift+R parity with the button
  - Scripture sidebar empty state → CTA opens the reader
  - Saved a reference from the reader with no note open → confirmed `POST /api/scripture/references` fired with no note-creation request, row has `parentNoteId: null`
  - Verse did not repaint on save
  - Reference appeared in the sidebar References list intermixed with note-based ones
  - Tapping it reopened the reader at the right chapter/verse with the dictionary card open, and a repeat tap reopens after dismissal
  - Verified the highlight upsert still recolours (not duplicates) on a repeat highlight
  - Toolbar overlap fix verified at 375/430/600/601/1377px

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>