### PR TITLE
Fix reader re-landing on repeat verse taps, and a recall shelf that could only shrink

### DIFF
--- a/Changelog/2.72.1.md
+++ b/Changelog/2.72.1.md
@@ -1,0 +1,8 @@
+# Version 2.72.1
+
+**Release Date**: August 16, 2026
+
+## Fixes
+
+- Re-landing on a repeated verse request, and a recall shelf that could only shrink
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.72.0
+**Version:** 2.72.1
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.72.0",
+  "version": "2.72.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-72-0';
+const CACHE_NAME = 'harvous-cache-v2-72-1';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/spa/src/pages/prototype/PrototypeBibleReaderPane.tsx
+++ b/spa/src/pages/prototype/PrototypeBibleReaderPane.tsx
@@ -246,6 +246,14 @@ export interface PrototypeBibleReaderPaneProps {
    * word twice has to be two requests rather than one piece of state that is already set.
    */
   referenceRequest?: { word: string; anchor: string; verse?: number; requestKey: string } | null;
+  /**
+   * Changes when the same verse is asked for again, so arriving twice lands twice.
+   *
+   * Landing keys off `focusVerse`, which does not change when you re-open the passage you are
+   * already on — and by then you may have cleared the landing with a stray tap, so the second
+   * ask did nothing at all.
+   */
+  landRequestKey?: string;
 }
 
 export default function PrototypeBibleReaderPane({
@@ -264,6 +272,7 @@ export default function PrototypeBibleReaderPane({
   onSaveReference,
   saveReferenceLabel,
   referenceRequest,
+  landRequestKey,
 }: PrototypeBibleReaderPaneProps) {
   const { data, isLoading, isError, error } = usePrototypeBibleChapter(book, chapter, translation);
   const { verseLayout, showMarginNotes } = useSyncExternalStore(
@@ -638,7 +647,9 @@ export default function PrototypeBibleReaderPane({
     scroller.scrollTop = Math.max(0, scroller.scrollTop + (elRect.top - scrollerRect.top) - centreOffset);
     setLanding([focusVerse, focusVerse]);
     setFocusedVerse(focusVerse);
-  }, [focusVerse, verses.length]);
+    // `landRequestKey` so asking for the verse you are already on lands on it again: the
+    // verse number has not changed, but the request is new.
+  }, [focusVerse, verses.length, landRequestKey]);
 
   const selectVerse = useCallback((num: number, extend: boolean) => {
     setSelection((current) => {

--- a/spa/src/pages/prototype/PrototypeDailyPassagePill.tsx
+++ b/spa/src/pages/prototype/PrototypeDailyPassagePill.tsx
@@ -148,7 +148,13 @@ export default function PrototypeDailyPassagePill({
     navigate({
       to: prototypeReadRouteTo(),
       params: { book: bookSlug(parsed.book), chapter: String(parsed.chapter) },
-      search: { v: verse ? String(verse) : undefined, t: votd.translation || undefined },
+      search: {
+        v: verse ? String(verse) : undefined,
+        t: votd.translation || undefined,
+        // Asking for today's passage again should land on the verse again, even when the
+        // reader is already open on it and the verse was clicked away.
+        req: String(Date.now()),
+      },
     });
   }, [afterNav, navigate, votd.reference, votd.translation]);
 

--- a/spa/src/pages/prototype/PrototypeReadPage.tsx
+++ b/spa/src/pages/prototype/PrototypeReadPage.tsx
@@ -63,7 +63,7 @@ export default function PrototypeReadPage() {
     v?: string;
     t?: string;
     ref?: string;
-    dockReq?: string;
+    req?: string;
   };
   const navigate = useNavigate();
   const { data: profile } = useProfile();
@@ -153,9 +153,9 @@ export default function PrototypeReadPage() {
         ? `${book} ${chapter}:${focusVerse}`
         : `${book} ${chapter}`,
       verse: Number.isFinite(focusVerse) ? focusVerse : undefined,
-      requestKey: search.dockReq || word,
+      requestKey: search.req || word,
     };
-  }, [search.ref, search.dockReq, book, chapter, focusVerse]);
+  }, [search.ref, search.req, book, chapter, focusVerse]);
 
   const applyHighlight = useCallback(
     ({ start, end }: { start: number; end: number }, accent: StudyHighlightAccentKey) => {
@@ -447,6 +447,7 @@ export default function PrototypeReadPage() {
           onSaveReference={handleSaveReference}
           saveReferenceLabel={saveReferenceLabel}
           referenceRequest={referenceRequest}
+          landRequestKey={search.req}
         />
       </div>
     </PrototypeMainPaneShell>

--- a/spa/src/pages/prototype/PrototypeSidebar.tsx
+++ b/spa/src/pages/prototype/PrototypeSidebar.tsx
@@ -1597,6 +1597,7 @@ export default function PrototypeSidebar({
       search: {
         v: smartJump.verse ? String(smartJump.verse) : undefined,
         t: smartJump.translation || undefined,
+        req: String(Date.now()),
       },
     });
   }, [smartJump, isMobileSidebar, closeDrawer, navigate]);
@@ -3152,8 +3153,9 @@ export default function PrototypeSidebar({
             v: typeof parsed.verse === 'number' ? String(parsed.verse) : undefined,
             t: r.scripturePassageTranslation || undefined,
             ref: word,
-            // Same word tapped twice has to reopen the card, so the request needs to differ.
-            dockReq: String(Date.now()),
+            // Same row tapped twice has to land and reopen the card again, so the request
+            // needs to differ — the router treats an identical URL as no navigation at all.
+            req: String(Date.now()),
           },
         });
         afterNav();
@@ -3296,6 +3298,7 @@ export default function PrototypeSidebar({
             search: {
               v: result.scriptureFocusVerse ? String(result.scriptureFocusVerse) : undefined,
               t: undefined,
+              req: String(Date.now()),
             },
           });
           return;
@@ -4375,7 +4378,7 @@ export default function PrototypeSidebar({
                             void navigate({
                               to: prototypeReadRouteTo(),
                               params: { book: bookSlug(bookTitle), chapter: String(p.chapter) },
-                              search: { v: String(p.verseStart), t: undefined },
+                              search: { v: String(p.verseStart), t: undefined, req: String(Date.now()) },
                             });
                           }}
                         >

--- a/spa/src/pages/prototype/PrototypeSidebarHomeView.tsx
+++ b/spa/src/pages/prototype/PrototypeSidebarHomeView.tsx
@@ -1620,21 +1620,22 @@ export default function PrototypeSidebarHomeView({
   );
 
   /*
-   * Once the shelf has been shown, it does not grow.
+   * Once a row has been shown, it keeps its place.
    *
    * The presentation gate waits on fifteen queries and presents Home once — but it has a
    * 2.5s deadline behind it, because a disabled query stays pending forever and a blank
    * Home is worse than a little jitter. On a cold load that deadline fires first, and
-   * whatever lands afterwards used to join the deck.
+   * whatever lands afterwards used to reorder the deck.
    *
    * That was tolerable while this was a card stack: one card showed and a late arrival
-   * changed something behind it. Flat, every arrival is a row appearing under the pointer
-   * in a list someone is already reading. So the first set to be presented is the set for
-   * this visit — newcomers wait for the next mount, which is the right cadence for a shelf
-   * that is a daily selection rather than a feed.
+   * changed something behind it. Flat, every arrival moves rows under the pointer in a list
+   * someone is already reading. So position is what is frozen: a row that has been shown
+   * stays where it is for the visit.
    *
-   * Removals still apply: snoozing is how the deck gets trained, and a row that has been
-   * put away has to leave. Only joining is frozen, and only after something has shown.
+   * What is *not* frozen is the count. Freezing the id list alone meant the shelf could only
+   * ever shrink — see the resolution below — so a slow load left it short and late data
+   * quietly took rows away. Removals still apply: snoozing is how the deck gets trained, and
+   * a row that has been put away has to leave.
    */
   const [shownRecallIds, setShownRecallIds] = useState<string[] | null>(null);
   useEffect(() => {
@@ -1644,11 +1645,49 @@ export default function PrototypeSidebarHomeView({
 
   const recallOpportunities = useMemo(() => {
     if (shownRecallIds === null) return selectedRecallOpportunities;
-    const byId = new Map(selectedRecallOpportunities.map((op) => [op.id, op]));
-    return shownRecallIds
-      .map((id) => byId.get(id))
+
+    /*
+     * Resolve against every live candidate, not the selected six.
+     *
+     * `selectRecallOpportunities` rotates by a modulus of the candidate count and *then*
+     * slices — so when a late page changes membership, everything in the tail moves and a row
+     * that is still perfectly valid can fall outside the top six. Looking it up in the sliced
+     * list found nothing and the row disappeared mid-read, which is the one thing freezing the
+     * shelf was supposed to prevent. Snoozed rows are still excluded, because putting one away
+     * has to remove it.
+     */
+    const snoozed = new Set(recallSnoozedIds);
+    const live = new Map(
+      recallCandidates.filter((op) => !snoozed.has(op.id)).map((op) => [op.id, op]),
+    );
+
+    const pinned = shownRecallIds
+      .map((id) => live.get(id))
       .filter((op): op is RecallOpportunity => Boolean(op));
-  }, [shownRecallIds, selectedRecallOpportunities]);
+
+    /*
+     * Then top back up to the limit. The presentation gate has a 2.5s deadline behind it, so a
+     * cold load can snapshot a half-assembled shelf and — with joining frozen — leave it short
+     * for the whole visit. Backfilling only ever appends, and only into space something else
+     * vacated or never filled, so the rows already being read stay put.
+     */
+    const shown = new Set(pinned.map((op) => op.id));
+    const backfill = selectedRecallOpportunities.filter((op) => !shown.has(op.id));
+    return [...pinned, ...backfill].slice(0, 6);
+  }, [shownRecallIds, selectedRecallOpportunities, recallCandidates, recallSnoozedIds]);
+
+  /*
+   * Anything that made it onto the shelf joins the frozen set, backfilled rows included.
+   * Without this they would be the only unpinned rows on screen and would keep the exact
+   * instability this is here to stop — just one row further down.
+   */
+  useEffect(() => {
+    if (shownRecallIds === null) return;
+    const known = new Set(shownRecallIds);
+    const added = recallOpportunities.map((op) => op.id).filter((id) => !known.has(id));
+    if (added.length === 0) return;
+    setShownRecallIds([...shownRecallIds, ...added]);
+  }, [recallOpportunities, shownRecallIds]);
 
   const topCanonSection = useMemo(
     () => deriveTopCanonSections([...fingerprintsById.values()], 1)[0],
@@ -1878,6 +1917,7 @@ export default function PrototypeSidebarHomeView({
                   search: {
                     v: firstRunPassage.verse ? String(firstRunPassage.verse) : undefined,
                     t: undefined,
+                    req: String(Date.now()),
                   },
                 });
               }}

--- a/spa/src/router.tsx
+++ b/spa/src/router.tsx
@@ -364,8 +364,12 @@ function buildPrototypeRouteBranch() {
    *
    * `?ref=` asks the reader to open a looked-up word's card on arrival, so a saved reference
    * in the list can land on the thing it names rather than just the chapter it came from.
-   * `?dockReq=` is a nonce: tapping the same reference twice has to reopen the card, and
-   * without something changing in the URL the second tap would be a no-op.
+   *
+   * `?req=` is a nonce meaning "this is a fresh request, apply the arrival behaviour again".
+   * The router dedupes a navigation to a URL you are already on — same history entry, same
+   * location key, no state change anywhere — so tapping Today's passage a second time after
+   * clicking the verse away is invisible to the reader without it. One nonce rather than one
+   * per behaviour: landing on the verse and opening the word's card are the same event.
    */
   const prototypeReadRoute = createRoute({
     getParentRoute: () => simplifiedPrototypeRoute,
@@ -374,11 +378,11 @@ function buildPrototypeRouteBranch() {
     // just `{v, t}`, and a required-but-undefined key would make each of them a type error.
     validateSearch: (
       search: Record<string, unknown>,
-    ): { v?: string; t?: string; ref?: string; dockReq?: string } => ({
+    ): { v?: string; t?: string; ref?: string; req?: string } => ({
       v: typeof search.v === 'string' ? search.v : undefined,
       t: typeof search.t === 'string' ? search.t : undefined,
       ref: typeof search.ref === 'string' ? search.ref : undefined,
-      dockReq: typeof search.dockReq === 'string' ? search.dockReq : undefined,
+      req: typeof search.req === 'string' ? search.req : undefined,
     }),
     component: lazyRouteComponent(() => import('./pages/prototype/PrototypeReadPage')),
   });


### PR DESCRIPTION
## Summary
- **Reader re-landing**: navigating to a verse you're already on is a no-op to the router (same URL, same history entry), so the landing effect never re-ran — clicking away from a highlighted verse and re-selecting the same passage (e.g. Today's passage) left nothing highlighted. Generalizes the dictionary-dock nonce already in place (`dockReq` -> `req`) into one "fresh arrival" signal covering both re-landing and reopening a reference card, stamped at the six sidebar/Home sites that navigate to a verse.
- **Recall shelf shrinking**: `selectRecallOpportunities` rotates by a modulus of the live candidate count and then slices to the limit. Home prefetches the rest of the notes list in the background, so an arriving page could shift the rotation and push an already-shown, unsnoozed row out of the slice — the frozen-shelf lookup found nothing for that id and dropped it, with no way to backfill. Now resolves shown rows against all live candidates instead of the sliced set, and backfills to the limit (newly-backfilled rows get pinned too, so they don't inherit the same instability one row later).

## Test plan
- [x] `npx vitest run` on all touched suites — 59 tests passing
- [x] `npm run build:spa && npm run perf:check` — passing, no bundle regressions (1104.5 KB gzipped)
- [x] Manual verification in a running dev instance:
  - Reader: arrive on `?v=25` -> verse 25 focused -> click away -> cleared -> reselect the same passage -> verse 25 focused again, and repeatable (confirmed twice with a fresh nonce each time)
  - Recall shelf on a cold load: 26 samples over 8s, row count constant at 11, nothing lost after appearing, no render loop from the new backfill effect
  - Warm-cache sampling (8 samples over 5s) also stable with 12 rows, no shrink

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>