### PR TITLE
Fix Bible reader highlights not appearing in the Highlights list

### DIFF
--- a/Changelog/2.72.2.md
+++ b/Changelog/2.72.2.md
@@ -1,0 +1,10 @@
+# Version 2.72.2
+
+**Release Date**: August 16, 2026
+
+## Fixes
+
+- Highlighting a verse now actually reaches the Highlights list
+- Stop the browser's HTTP cache from serving stale mutated data
+- Mobile geometry, per-note margin refs, and the standalone passage pane
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.72.1
+**Version:** 2.72.2
 **Status:** Official 1.0 Released January 8, 2026

--- a/netlify/functions/api.cjs
+++ b/netlify/functions/api.cjs
@@ -249763,7 +249763,8 @@ route10.delete("/api/study-threads/:id", requireAuth, rateLimit("write"), async 
           contextSpaceId,
           lock: true
         });
-        if (locked.spaceId !== context2.spaceId) {
+        const effectiveSpaceId = locked.parentNoteId ? context2.spaceId : locked.spaceId;
+        if (locked.spaceId !== effectiveSpaceId) {
           throw new SharedStudyThreadAccessError(404, "Response not found");
         }
         const membershipRole = context2.isShared ? first(
@@ -249792,7 +249793,7 @@ route10.delete("/api/study-threads/:id", requireAuth, rateLimit("write"), async 
           and(
             eq(StudyThreadEntries.id, id),
             locked.parentNoteId ? eq(StudyThreadEntries.parentNoteId, locked.parentNoteId) : isNull(StudyThreadEntries.parentNoteId),
-            context2.spaceId ? eq(StudyThreadEntries.spaceId, context2.spaceId) : isNull(StudyThreadEntries.spaceId)
+            effectiveSpaceId ? eq(StudyThreadEntries.spaceId, effectiveSpaceId) : isNull(StudyThreadEntries.spaceId)
           )
         );
         if (locked.entryKindRaw === "linkedNote" && locked.linkedNoteId && locked.parentNoteId) {
@@ -249836,13 +249837,17 @@ route10.get("/api/scripture/highlights", requireAuth, async (c) => {
         like(StudyThreadEntries.scriptureReference, `${book} ${chapter}:%`)
       )
     ).orderBy(desc(StudyThreadEntries.createdAt));
-    return c.json({
-      success: true,
-      highlights: rows.map((row) => ({
-        ...mapStudyRow(row),
-        madeWhileReading: row.parentNoteId === null
-      }))
-    });
+    return c.json(
+      {
+        success: true,
+        highlights: rows.map((row) => ({
+          ...mapStudyRow(row),
+          madeWhileReading: row.parentNoteId === null
+        }))
+      },
+      200,
+      { "Cache-Control": "private, max-age=0, no-store" }
+    );
   } catch (error) {
     const e = handleAPIError(error, {
       endpoint: "/api/scripture/highlights",
@@ -249860,6 +249865,14 @@ route10.post("/api/scripture/highlights", requireAuth, rateLimit("write"), async
     if (!norm) return c.json({ error: "reference is required" }, 400);
     const accent = typeof body.accent === "string" && isStudyHighlightAccentKey(body.accent) ? body.accent : "warmAmber";
     const translation = typeof body.translation === "string" && body.translation.trim() ? body.translation.trim() : "NET";
+    const spaceId = normalizeContextSpaceId(body.spaceId);
+    if (!spaceId) return c.json({ error: "spaceId is required" }, 400);
+    try {
+      await requireSpaceAccess(spaceId, auth.userId);
+    } catch (err) {
+      if (err instanceof SpaceAccessError) return c.json({ error: err.message, code: err.code }, err.status);
+      throw err;
+    }
     const now2 = nowISO();
     const existing = first(
       await db.select().from(StudyThreadEntries).where(
@@ -249877,7 +249890,7 @@ route10.post("/api/scripture/highlights", requireAuth, rateLimit("write"), async
     );
     if (existing) {
       const updated = first(
-        await db.update(StudyThreadEntries).set({ highlightAccentRaw: accent, updatedAt: now2 }).where(eq(StudyThreadEntries.id, existing.id)).returning()
+        await db.update(StudyThreadEntries).set({ highlightAccentRaw: accent, spaceId, updatedAt: now2 }).where(eq(StudyThreadEntries.id, existing.id)).returning()
       );
       return c.json({ success: true, highlight: updated ? mapStudyRow(updated) : null });
     }
@@ -249888,7 +249901,7 @@ route10.post("/api/scripture/highlights", requireAuth, rateLimit("write"), async
         // Null on purpose: made while reading, so there is no note it came from. It is still
         // the same kind of row a scripture dock writes, and every surface reads it the same.
         parentNoteId: null,
-        spaceId: null,
+        spaceId,
         entryKindRaw: "scriptureLink",
         highlightAccentRaw: accent,
         scriptureReference: norm,
@@ -297520,22 +297533,26 @@ route12.get("/api/spaces/:spaceId/study-thread-highlights", requireAuth, async (
     }
     const eligibleRows = rows.filter((row) => studyThreadEligibleForHighlightList(row));
     const authorMap = isPersonalSpace ? {} : await batchAuthorAttribution(eligibleRows.map((row) => row.userId));
-    return c.json({
-      success: true,
-      studyThreads: eligibleRows.map((row) => {
-        const { parentNoteTitle, ...entry } = row;
-        const author = authorMap[row.userId];
-        return {
-          ...mapStudyRow(entry),
-          parentNoteTitle: parentNoteTitle ?? "",
-          ...isPersonalSpace ? {} : {
-            authorDisplayName: author?.displayName ?? "A Harvous User",
-            authorColor: author?.userColor ?? "blue",
-            isOwnHighlight: row.userId === auth.userId
-          }
-        };
-      })
-    });
+    return c.json(
+      {
+        success: true,
+        studyThreads: eligibleRows.map((row) => {
+          const { parentNoteTitle, ...entry } = row;
+          const author = authorMap[row.userId];
+          return {
+            ...mapStudyRow(entry),
+            parentNoteTitle: parentNoteTitle ?? "",
+            ...isPersonalSpace ? {} : {
+              authorDisplayName: author?.displayName ?? "A Harvous User",
+              authorColor: author?.userColor ?? "blue",
+              isOwnHighlight: row.userId === auth.userId
+            }
+          };
+        })
+      },
+      200,
+      { "Cache-Control": "private, max-age=0, no-store" }
+    );
   } catch (error) {
     const standardError = handleAPIError(error, {
       endpoint: "/api/spaces/[spaceId]/study-thread-highlights",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.72.1",
+  "version": "2.72.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-72-1';
+const CACHE_NAME = 'harvous-cache-v2-72-2';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/server/routes/spaces.ts
+++ b/server/routes/spaces.ts
@@ -1649,24 +1649,32 @@ route.get('/api/spaces/:spaceId/study-thread-highlights', requireAuth, async (c)
       ? {}
       : await batchAuthorAttribution(eligibleRows.map((row) => row.userId));
 
-    return c.json({
-      success: true,
-      studyThreads: eligibleRows.map((row) => {
-        const { parentNoteTitle, ...entry } = row;
-        const author = authorMap[row.userId];
-        return {
-          ...mapStudyRow(entry),
-          parentNoteTitle: parentNoteTitle ?? '',
-          ...(isPersonalSpace
-            ? {}
-            : {
-                authorDisplayName: author?.displayName ?? 'A Harvous User',
-                authorColor: author?.userColor ?? 'blue',
-                isOwnHighlight: row.userId === auth.userId,
-              }),
-        };
-      }),
-    });
+    // Overrides app.ts's blanket cache default (see GET /api/user/get-profile's comment) —
+    // this is the sidebar's "Highlights" list. Highlighting a verse in the reader or a note's
+    // scripture dock and expecting it to show up here is exactly the same-session mutation
+    // this override exists for.
+    return c.json(
+      {
+        success: true,
+        studyThreads: eligibleRows.map((row) => {
+          const { parentNoteTitle, ...entry } = row;
+          const author = authorMap[row.userId];
+          return {
+            ...mapStudyRow(entry),
+            parentNoteTitle: parentNoteTitle ?? '',
+            ...(isPersonalSpace
+              ? {}
+              : {
+                  authorDisplayName: author?.displayName ?? 'A Harvous User',
+                  authorColor: author?.userColor ?? 'blue',
+                  isOwnHighlight: row.userId === auth.userId,
+                }),
+          };
+        }),
+      },
+      200,
+      { 'Cache-Control': 'private, max-age=0, no-store' },
+    );
   } catch (error: any) {
     const standardError = handleAPIError(error, {
       endpoint: '/api/spaces/[spaceId]/study-thread-highlights',

--- a/server/routes/study-threads.ts
+++ b/server/routes/study-threads.ts
@@ -762,7 +762,18 @@ route.delete('/api/study-threads/:id', requireAuth, rateLimit('write'), async (c
           contextSpaceId,
           lock: true,
         });
-        if (locked.spaceId !== context.spaceId) {
+        /*
+         * `resolveStudyEntryParentContext` always answers `spaceId: null` for a parentless
+         * row (see its early return above) — it has no note to look a space up from, and
+         * never did. That was harmless while every parentless row's own `spaceId` was also
+         * null (made-while-reading highlights, before `POST /api/scripture/highlights`
+         * started stamping the real one), because null matched null. A saved reference
+         * (`POST /api/scripture/references`) has always stamped a real one, so this exact
+         * mismatch already made references undeletable — the row's own `spaceId` is what's
+         * authoritative for a parentless row, not what this note-shaped resolver can derive.
+         */
+        const effectiveSpaceId = locked.parentNoteId ? context.spaceId : locked.spaceId;
+        if (locked.spaceId !== effectiveSpaceId) {
           throw new SharedStudyThreadAccessError(404, 'Response not found');
         }
         const membershipRole = context.isShared
@@ -811,8 +822,8 @@ route.delete('/api/study-threads/:id', requireAuth, rateLimit('write'), async (c
               locked.parentNoteId
                 ? eq(StudyThreadEntries.parentNoteId, locked.parentNoteId)
                 : isNull(StudyThreadEntries.parentNoteId),
-              context.spaceId
-                ? eq(StudyThreadEntries.spaceId, context.spaceId)
+              effectiveSpaceId
+                ? eq(StudyThreadEntries.spaceId, effectiveSpaceId)
                 : isNull(StudyThreadEntries.spaceId),
             ),
           );
@@ -881,13 +892,20 @@ route.get('/api/scripture/highlights', requireAuth, async (c) => {
       )
       .orderBy(desc(StudyThreadEntries.createdAt));
 
-    return c.json({
-      success: true,
-      highlights: rows.map((row) => ({
-        ...mapStudyRow(row),
-        madeWhileReading: row.parentNoteId === null,
-      })),
-    });
+    // Overrides app.ts's blanket `private, max-age=30, stale-while-revalidate=60` default —
+    // same class of bug as GET /api/user/get-profile (see that route's comment). Highlighting
+    // a verse and leaving and returning to this same chapter hits this same URL.
+    return c.json(
+      {
+        success: true,
+        highlights: rows.map((row) => ({
+          ...mapStudyRow(row),
+          madeWhileReading: row.parentNoteId === null,
+        })),
+      },
+      200,
+      { 'Cache-Control': 'private, max-age=0, no-store' },
+    );
   } catch (error: any) {
     const e = handleAPIError(error, {
       endpoint: '/api/scripture/highlights',
@@ -914,6 +932,26 @@ route.post('/api/scripture/highlights', requireAuth, rateLimit('write'), async (
       typeof body.translation === 'string' && body.translation.trim()
         ? body.translation.trim()
         : 'NET';
+
+    /*
+     * Required, like the sibling `/api/scripture/references` below — a highlight made while
+     * reading used to leave this null on the theory that a nullable space would surface it in
+     * every personal space the account has. `/api/spaces/:spaceId/study-thread-highlights`
+     * (the sidebar's own Highlights list) never implemented that half: for a parentless row
+     * it requires an exact `spaceId` match, so a null one matched no space at all and the
+     * highlight was invisible everywhere except the reader that made it. Stamping the real
+     * space — the same fix `references` already had — is what makes it show up, and is also
+     * the correct behaviour once a highlight can be made inside a Shared Space: "every
+     * personal space" was never going to include someone else's room anyway.
+     */
+    const spaceId = normalizeContextSpaceId(body.spaceId);
+    if (!spaceId) return c.json({ error: 'spaceId is required' }, 400);
+    try {
+      await requireSpaceAccess(spaceId, auth.userId);
+    } catch (err) {
+      if (err instanceof SpaceAccessError) return c.json({ error: err.message, code: err.code }, err.status);
+      throw err;
+    }
 
     const now = nowISO();
 
@@ -948,7 +986,10 @@ route.post('/api/scripture/highlights', requireAuth, rateLimit('write'), async (
       const updated = first(
         await db
           .update(StudyThreadEntries)
-          .set({ highlightAccentRaw: accent, updatedAt: now } as any)
+          // `spaceId` too, not just the colour — heals a row created before this endpoint
+          // stamped one, so re-touching an old orphaned highlight is what recovers it rather
+          // than requiring every existing highlight to be deleted and remade.
+          .set({ highlightAccentRaw: accent, spaceId, updatedAt: now } as any)
           .where(eq(StudyThreadEntries.id, existing.id))
           .returning(),
       );
@@ -964,7 +1005,7 @@ route.post('/api/scripture/highlights', requireAuth, rateLimit('write'), async (
           // Null on purpose: made while reading, so there is no note it came from. It is still
           // the same kind of row a scripture dock writes, and every surface reads it the same.
           parentNoteId: null,
-          spaceId: null,
+          spaceId,
           entryKindRaw: 'scriptureLink',
           highlightAccentRaw: accent,
           scriptureReference: norm,

--- a/spa/src/hooks/queries/usePrototypeChapterHighlights.ts
+++ b/spa/src/hooks/queries/usePrototypeChapterHighlights.ts
@@ -9,6 +9,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuthReady } from '../useAuthReady';
 import type { StudyHighlightAccentKey } from '@/utils/study-highlight-accents';
+import { notifyStudyThreadListChanged } from '@/utils/prototype-study-thread-list-sync';
 
 export interface ChapterHighlight {
   id: string;
@@ -74,7 +75,22 @@ export function usePrototypeChapterHighlights(
   });
 }
 
-export function useCreateChapterHighlight(book: string, chapter: number, translation: string) {
+/**
+ * @param spaceId The reader's home space — required by the server (see `POST
+ *   /api/scripture/highlights`) so the row can be found again. A highlight is a
+ *   `StudyThreadEntries` row exactly like one made from a note's scripture dock, and the
+ *   sidebar's Highlights list (`usePrototypeSpaceStudyThreadHighlights`) reads the same table
+ *   scoped to one space — a row with no space matched none of them, so a highlight made here
+ *   was invisible everywhere but the chapter that made it. Also used to invalidate that list
+ *   below: without it, the query's global 60s `staleTime` (see `App.tsx`) meant a revisit
+ *   inside that window still served the stale list even once the row itself was fixed.
+ */
+export function useCreateChapterHighlight(
+  book: string,
+  chapter: number,
+  translation: string,
+  spaceId: string | null | undefined,
+) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (input: {
@@ -82,11 +98,12 @@ export function useCreateChapterHighlight(book: string, chapter: number, transla
       accent: StudyHighlightAccentKey;
       excerpt?: string;
     }) => {
+      if (!spaceId) throw new Error('No space to save this highlight to yet');
       const res = await fetch('/api/scripture/highlights', {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...input, translation }),
+        body: JSON.stringify({ ...input, translation, spaceId }),
       });
       if (!res.ok) throw new Error('Failed to save highlight');
       return res.json();
@@ -95,6 +112,7 @@ export function useCreateChapterHighlight(book: string, chapter: number, transla
       void queryClient.invalidateQueries({
         queryKey: chapterHighlightsKey(book, chapter, translation),
       });
+      notifyStudyThreadListChanged(spaceId, null);
     },
   });
 }

--- a/spa/src/pages/prototype/PrototypeBibleReaderPane.tsx
+++ b/spa/src/pages/prototype/PrototypeBibleReaderPane.tsx
@@ -217,10 +217,25 @@ export interface PrototypeBibleReaderPaneProps {
    * what it is given, which is what keeps the two surfaces one layer instead of two.
    */
   highlights?: ReadonlyMap<number, ReaderVerseHighlight>;
-  /** Paint the selected verses in this accent. */
-  onHighlight?: (range: { start: number; end: number }, accent: StudyHighlightAccentKey) => void;
+  /**
+   * Paint the selected verses in this accent.
+   *
+   * `excerpt` is the selected verses' own text — required server-side for a `scriptureLink`
+   * row to be eligible for the sidebar's Highlights list at all (see
+   * `studyThreadEligibleForHighlightList`), not just decoration. Built here rather than
+   * passed down, because this component already holds the verse text the selection covers.
+   */
+  onHighlight?: (
+    range: { start: number; end: number },
+    accent: StudyHighlightAccentKey,
+    excerpt: string,
+  ) => void;
   /** Highlight, then open the study dock on it so a thought can be written straight away. */
-  onAnnotate?: (range: { start: number; end: number }, accent: StudyHighlightAccentKey) => void;
+  onAnnotate?: (
+    range: { start: number; end: number },
+    accent: StudyHighlightAccentKey,
+    excerpt: string,
+  ) => void;
   /** Open a margin note, with its scripture dock already on the passage the bar marked. */
   onOpenNoteAtReference?: (noteId: string, reference: string) => void;
   /**
@@ -865,7 +880,7 @@ export default function PrototypeBibleReaderPane({
                       // Re-colours the existing row rather than adding one — the write is
                       // keyed on the passage, so trying colours leaves a single highlight.
                       setAccent(token);
-                      onHighlight({ start: selection[0], end: selection[1] }, token);
+                      onHighlight({ start: selection[0], end: selection[1] }, token, selectedText);
                     }}
                   >
                     <span className="dock-accent-swatch__choice-ring" aria-hidden />
@@ -889,7 +904,7 @@ export default function PrototypeBibleReaderPane({
                     // you guessed what it did. Committing on the first tap means the palette
                     // only ever appears attached to a highlight that already exists, so each
                     // colour is a change you can see rather than a choice you must predict.
-                    onHighlight({ start: selection[0], end: selection[1] }, accent);
+                    onHighlight({ start: selection[0], end: selection[1] }, accent, selectedText);
                     setPaletteOpen(true);
                   }}
                 />
@@ -903,7 +918,7 @@ export default function PrototypeBibleReaderPane({
                   icon="pen"
                   label="Annotate"
                   onClick={() => {
-                    onAnnotate({ start: selection[0], end: selection[1] }, accent);
+                    onAnnotate({ start: selection[0], end: selection[1] }, accent, selectedText);
                     setDock({
                       kind: 'highlight',
                       reference: selectionLabel,
@@ -1275,7 +1290,7 @@ export default function PrototypeBibleReaderPane({
                 entryKind="scriptureLink"
                 onAccentChange={(next) => {
                   setAccent(next);
-                  if (selection) onHighlight?.({ start: selection[0], end: selection[1] }, next);
+                  if (selection) onHighlight?.({ start: selection[0], end: selection[1] }, next, selectedText);
                   setDock({ ...dock, accent: next });
                 }}
                 onRemove={() => setDock(null)}

--- a/spa/src/pages/prototype/PrototypeReadPage.tsx
+++ b/spa/src/pages/prototype/PrototypeReadPage.tsx
@@ -106,7 +106,7 @@ export default function PrototypeReadPage() {
    * reading, or made in any note's scripture dock. The reader paints; it does not own.
    */
   const { data: chapterHighlights } = usePrototypeChapterHighlights(book, chapter, translation);
-  const createHighlight = useCreateChapterHighlight(book, chapter, translation);
+  const createHighlight = useCreateChapterHighlight(book, chapter, translation, homeSpaceId);
 
   /**
    * Fan the stored rows out to the verses they cover. A row is anchored to a reference, which
@@ -161,10 +161,14 @@ export default function PrototypeReadPage() {
   }, [search.ref, search.req, book, chapter, focusVerse]);
 
   const applyHighlight = useCallback(
-    ({ start, end }: { start: number; end: number }, accent: StudyHighlightAccentKey) => {
+    (
+      { start, end }: { start: number; end: number },
+      accent: StudyHighlightAccentKey,
+      excerpt: string,
+    ) => {
       const reference =
         start === end ? `${book} ${chapter}:${start}` : `${book} ${chapter}:${start}-${end}`;
-      createHighlight.mutate({ reference, accent });
+      createHighlight.mutate({ reference, accent, excerpt });
     },
     [book, chapter, createHighlight],
   );


### PR DESCRIPTION
## Summary
Four bugs stacked on the same path — highlight a verse in the Bible reader, check the sidebar's Highlights list — each hiding the next until the one before it was fixed:

- `useCreateChapterHighlight`'s `onSuccess` only ever refreshed the reader's own in-chapter view, never told the sidebar's Highlights list to refetch.
- `POST /api/scripture/highlights` wrote `spaceId: null` on every reader-made highlight, but the sidebar's list requires an exact space match for parentless rows — the row was structurally invisible regardless of invalidation. Now stamps the real space, matching the sibling `POST /api/scripture/references`; recoloring an old orphaned row also heals it.
- The reader never sent verse text as an `excerpt`, and `scriptureLink` rows need one to pass the list's eligibility filter. Threaded `selectedText` (already computed for the Annotate dock) through to the mutation.
- Found while cleaning up test data: deleting one of these highlights was also broken, same root cause — the delete endpoint's space-resolution always answers `null` for a parentless row, which used to coincidentally match a null-stamped row and now doesn't match the real one. Likely already made saved references undeletable too.

## Test plan
- [x] `tsc --noEmit` — 287 pre-existing errors, zero introduced
- [x] `vitest run` — 3981/3981 passing
- [x] `npm run build` + `perf:check` — clean, no budget regressions
- [x] Live-verified in browser: highlighted a fresh verse, confirmed it appears immediately in the sidebar's Highlights list with no reload; confirmed delete now works on a reader-made highlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)