### PR TITLE
Fix paper-stack peeking edge width mismatch on narrow panes

### DIFF
--- a/Changelog/2.72.3.md
+++ b/Changelog/2.72.3.md
@@ -1,0 +1,8 @@
+# Version 2.72.3
+
+**Release Date**: August 16, 2026
+
+## Fixes
+
+- The collapsed origin's peeking edge matches the paper's own width
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.72.2
+**Version:** 2.72.3
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.72.2",
+  "version": "2.72.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-72-2';
+const CACHE_NAME = 'harvous-cache-v2-72-3';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -18606,6 +18606,18 @@ html.harvous-prototype-route button[class*="proto-"].proto-settings-danger__btn:
   height: var(--pds-paper-stack-peek);
 }
 
+/* Same 24px the papers give up at a narrow pane (see "Both papers, the same width" above,
+   and the matching shadow-strip override below). This edge IS one of those two papers,
+   peeking — at 687px measured on a real note-over-reader stack the row still ran the full
+   687px while the note's own `.proto-editor-paper` had already narrowed to 663px, so the
+   peek read as wider than the paper it belonged to instead of the same sheet continuing
+   underneath it. */
+@container pds-paper-stack (max-width: 760px) {
+  .pds-paper-stack__edge-row {
+    width: min(calc(var(--pds-paper-column) - 24px), 100% - 24px);
+  }
+}
+
 .pds-paper-stack__edge {
   position: absolute;
   /* Fills the band: the whole strip of paper is the way back, and the dismiss sits over


### PR DESCRIPTION
## Summary
`.pds-paper-stack__edge-row` — the collapsed origin's peeking strip (e.g. "Exodus 5" showing behind a stacked note) — always rendered at the full `--pds-paper-column` width, but the paper it represents narrows by 24px at a narrow pane (the same "both papers, the same width" rule already applied to `.pds-reader__column` and the shadow strip in this file). Measured on a real note-over-reader stack: the edge sat at 687px while the note's own `.proto-editor-paper` had already narrowed to 663px — the peek read as wider than the sheet it belonged to, breaking the width proportions the user was looking at on desktop.

Added the same narrow-pane reduction already used by its sibling rules, so the edge tracks the paper's width at every size.

## Test plan
- [x] `tsc --noEmit` — 287 pre-existing errors, zero introduced
- [x] `npm run build:spa` + `perf:check` — clean, no budget regressions
- [x] Live-verified in browser on a real note-over-reader paper stack: edge and paper widths now match exactly at desktop (720=720), a narrow pane (663=663), and mobile (335=335) — all previously mismatched except desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)