### PR TITLE
fix(paper-stack): keep the peeking edge proportional at every width

### DIFF
--- a/Changelog/2.72.4.md
+++ b/Changelog/2.72.4.md
@@ -1,0 +1,8 @@
+# Version 2.72.4
+
+**Release Date**: August 16, 2026
+
+## Fixes
+
+- Keep the peeking edge proportionally inset at every pane width
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.72.3
+**Version:** 2.72.4
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.72.3",
+  "version": "2.72.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-72-3';
+const CACHE_NAME = 'harvous-cache-v2-72-4';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -18503,10 +18503,24 @@ html.harvous-prototype-route button[class*="proto-"].proto-settings-danger__btn:
  *
  * Matched here rather than in the reader, because here is where they are compared — a
  * chapter read on its own keeps its full measure.
+ *
+ * `width`, not just `max-width`. The note's paper loses its 24px through padding on the
+ * wrap around it (`--pds-editor-paper-inset-x` in prototype-editor.css), which comes off
+ * at every pane width, not only while the wrap is still hitting its 720px ceiling. A
+ * `max-width` alone only pulls the column in while it would otherwise be wider than 696 —
+ * on a pane already narrower than that (a phone), it does nothing and the column reverts
+ * to full bleed, 24px wider than the note sharing its stack. The scale below then reads as
+ * the *whole* difference between the two papers at 744px, where both start from 720 and
+ * only the scale separates them, but as barely any difference at all on a phone, where the
+ * column had already given up its 24px for free. `min(cap, 100% - 24px)` — the same shape
+ * already used for the edge-row and the shadow-strip below — keeps the reduction constant
+ * down to the smallest panes instead of losing it once the ceiling stops being the binding
+ * constraint.
  */
 @container pds-paper-stack (max-width: 760px) {
   .pds-paper-stack__base .pds-reader__column,
   .pds-paper-stack__sheet .pds-reader__column {
+    width: calc(100% - 24px);
     max-width: calc(var(--pds-paper-column) - 24px);
   }
 }


### PR DESCRIPTION
## Summary
- The narrow-pane rule for `.pds-reader__column` only used `max-width`, which stops binding once the pane drops below 696px (i.e. any phone) — the column reverted to full bleed there while the note paper stacked in front of it kept losing 24px via padding at every width.
- That mismatch meant the 0.96 "peeking" scale had a much smaller effective inset to work with on a phone than on desktop, so the stacked-paper edge didn't shrink proportionally on small screens even though it looked right on desktop.
- Switched to `width: calc(100% - 24px)` with `max-width` as the ceiling — the same `min(cap, 100% - 24px)` shape already used by the edge-row and shadow-strip rules right below it.

## Test plan
- [x] Verified via `getBoundingClientRect()` at 1280px, 744px, and 390px panes — inset is a constant 2% of paper width at all three (14.4px / 13.9px / 7px)
- [x] Screenshotted the stacked paper at 390px width to confirm the peeking edge visually narrows to match the desktop look

🤖 Generated with [Claude Code](https://claude.com/claude-code)