### PR TITLE
fix(scripture-dock): enable Highlight on cross-reference passage cards

### DIFF
--- a/Changelog/2.72.5.md
+++ b/Changelog/2.72.5.md
@@ -1,0 +1,8 @@
+# Version 2.72.5
+
+**Release Date**: August 16, 2026
+
+## Fixes
+
+- Enable Highlight on cross-reference passage cards
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.72.4
+**Version:** 2.72.5
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.72.4",
+  "version": "2.72.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-72-4';
+const CACHE_NAME = 'harvous-cache-v2-72-5';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/src/components/react/ScripturePillChromeWeb.tsx
+++ b/src/components/react/ScripturePillChromeWeb.tsx
@@ -747,12 +747,20 @@ export default function ScripturePillChromeWeb({
     return { top, centerX };
   }, [passageSelection, onPassageQuoteToNote]);
 
+  /*
+   * `readOnly` means "no pill to write back to" — it says nothing about the passage itself,
+   * which is real Scripture either way. Highlighting selected text posts to
+   * `/api/notes/{sourceNoteId}/study-threads` keyed on the passage's own reference and
+   * translation, so a cross-reference card can do it exactly like a pill-backed one. Quote
+   * to note is the one action that genuinely needs a source pill to attribute back to — it
+   * stays gated by whether the caller passed `onPassageQuoteToNote` at all, which the
+   * cross-reference branch in TiptapEditor never does.
+   */
   const showMobilePassageActions =
     isCoarsePointer &&
     !!passageSelection &&
     !!sourceNoteId &&
     !!passageHtml &&
-    !readOnly &&
     isExpanded &&
     interactionActive;
 
@@ -982,7 +990,9 @@ export default function ScripturePillChromeWeb({
         </div>
       ) : null}
     </StudyDockCardShell>
-    {passageSelection && passageActionBarPos && sourceNoteId && passageHtml && !readOnly && !isCoarsePointer && typeof document !== 'undefined'
+    {/* Same readOnly carve-out as showMobilePassageActions above — Highlight works without a
+        source pill, Quote to note hides itself via the onPassageQuoteToNote check below. */}
+    {passageSelection && passageActionBarPos && sourceNoteId && passageHtml && !isCoarsePointer && typeof document !== 'undefined'
       ? createPortal(
           <div
             data-harvous-bottom-sheet-floating=""

--- a/src/components/react/TiptapEditor.tsx
+++ b/src/components/react/TiptapEditor.tsx
@@ -9690,7 +9690,10 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
                 const cardExpanded = isActive && entry.expanded;
                 if (entry.kind === 'scripture' && entry.session.readOnly) {
                   // Read-only passage card (opened from a cross-reference): no pill write-back,
-                  // no accent/highlight chrome. Cross-refs inside it can chain to more cards.
+                  // no accent swatch, no quote-to-note (nothing to attribute it back to). It IS
+                  // real Scripture though, so selecting text can still highlight it — that only
+                  // needs the passage's own reference, not a pill. Cross-refs inside it can
+                  // chain to more cards.
                   return (
                     <ScripturePillChromeWeb
                       key={entry.id}
@@ -9711,6 +9714,25 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
                       }}
                       onApply={() => {
                         /* read-only — no pill to write */
+                      }}
+                      onPassageHighlightCreated={(excerpt, threadId, accent) => {
+                        syncStudyThreadList(sourceNoteId);
+                        setStudyDockStack((s) =>
+                          openOrFocusHighlight(
+                            s,
+                            {
+                              studyThreadEntryId: threadId,
+                              accent: accent ?? 'warmAmber',
+                              excerpt,
+                              range: null,
+                              focusTitle: excerpt.slice(0, 80),
+                              entryKind: 'scriptureLink',
+                              scriptureReference: entry.session.reference,
+                              scripturePassageTranslation: entry.session.translation || 'NET',
+                            },
+                            { openedFromDockId: entry.id },
+                          ),
+                        );
                       }}
                       editorChromeMode={editorChromeMode}
                       onOpenScripturePassage={(ref, translation) =>


### PR DESCRIPTION
## Summary
- A scripture dock card opened from a cross-reference suggestion is rendered `readOnly`, and the floating selection menu (Highlight / Quote to note) was gated on `!readOnly` as a single unit — so selecting text in a cross-reference passage showed no floating actions at all, unlike a pill-backed dock.
- Highlight doesn't actually need a source pill — it posts to `/api/notes/{sourceNoteId}/study-threads` keyed on the passage's own reference/translation, which a cross-reference card already has. Removed the `!readOnly` gate for it in both the desktop and mobile action bars.
- Quote to note genuinely does need a source pill to attribute the insert back to, so it stays off for cross-reference cards — it already hides itself whenever the caller omits `onPassageQuoteToNote`, which the cross-reference branch in `TiptapEditor` does.
- Wired `onPassageHighlightCreated` into that branch too, so highlighting a cross-reference passage opens a highlight-dock card the same way a pill-backed highlight does, instead of only painting inline with no dock feedback.

## Test plan
- [x] Opened a note with a scripture pill (John 3:16), expanded cross-references, opened Romans 5:8 as a read-only card
- [x] Selected passage text in the read-only card — confirmed only "Highlight" appears (no "Quote to note")
- [x] Triggered Highlight — confirmed `POST /api/notes/{id}/study-threads` created a `scriptureLink` entry with `scriptureReference: "Romans 5:8"` and the correct excerpt
- [x] Confirmed a highlight-dock card opened in the carousel and the highlight appeared in the sidebar Highlights list
- [x] `tsc --noEmit` shows no new errors from this change (pre-existing errors elsewhere unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)