### PR TITLE
fix(scripture-dock): enable Quote to note on cross-reference cards

### DIFF
--- a/Changelog/2.72.6.md
+++ b/Changelog/2.72.6.md
@@ -1,0 +1,8 @@
+# Version 2.72.6
+
+**Release Date**: August 16, 2026
+
+## Fixes
+
+- Enable Quote to note on cross-reference cards
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.72.5
+**Version:** 2.72.6
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.72.5",
+  "version": "2.72.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-72-5';
+const CACHE_NAME = 'harvous-cache-v2-72-6';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/src/components/react/TiptapEditor.tsx
+++ b/src/components/react/TiptapEditor.tsx
@@ -6021,7 +6021,13 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
 
   const handlePassageQuoteToNote = useCallback(
     (payload: { excerpt: string; reference: string; translation: string }, session: ScripturePillDockSession) => {
-      if (!editor || !isEditorValid(editor) || !sourceNoteId || session.readOnly) return;
+      if (!editor || !isEditorValid(editor) || !sourceNoteId) return;
+      // `session.readOnly` (a cross-reference card) used to block this outright — but
+      // `insertScriptureQuoteAt` doesn't need an existing pill to attribute to: with no
+      // `boundaries`, `findScripturePillBoundariesInDoc` below simply won't find one (there
+      // isn't one, this passage was never embedded), `shouldOmitScriptureQuoteAttribution`
+      // has nothing adjacent to dedupe against, and the quote gets its own fresh scripture
+      // pill for `session.reference` instead of pointing at a pill that doesn't exist.
 
       let boundaries = session.boundaries;
       if (boundaries) {
@@ -9734,6 +9740,7 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
                           ),
                         );
                       }}
+                      onPassageQuoteToNote={(payload) => handlePassageQuoteToNote(payload, entry.session)}
                       editorChromeMode={editorChromeMode}
                       onOpenScripturePassage={(ref, translation) =>
                         openScripturePassage(ref, translation, entry.id)
@@ -9972,11 +9979,7 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
                           ),
                         );
                       }}
-                      onPassageQuoteToNote={
-                        entry.session.readOnly
-                          ? undefined
-                          : (payload) => handlePassageQuoteToNote(payload, entry.session)
-                      }
+                      onPassageQuoteToNote={(payload) => handlePassageQuoteToNote(payload, entry.session)}
                       editorChromeMode={editorChromeMode}
                       onOpenPassageReference={(word, opts) => {
                         if (!sourceNoteId) return;


### PR DESCRIPTION
## Summary
- `handlePassageQuoteToNote` blocked entirely on `session.readOnly`, on the assumption that quoting needs an existing source pill in the note to attribute back to. It doesn't — `insertScriptureQuoteAt` already handles the no-matching-pill case: `sourcePillBoundaries` stays null, `shouldOmitScriptureQuoteAttribution` has nothing adjacent to dedupe against, and the quote gets its own fresh scripture pill for the quoted reference.
- So quoting a cross-reference passage (e.g. 1 John 4:9-10, cross-referenced from a John 3:16 pill) now inserts the blockquote *plus* a new scripture pill for that passage — same as quoting a pill-backed one, just without an existing pill to be redundant with.
- Wired `onPassageQuoteToNote` into the read-only dock branch in `TiptapEditor.tsx` to match the highlight wiring from #31, and dropped a now-dead `readOnly` ternary around the same prop in the non-readOnly branch (it always evaluated true there — that branch only renders after the readOnly early-return above it).

## Test plan
- [x] Opened John 3:16 pill dock, expanded cross-references, opened 1 John 4:9-10 as a read-only card
- [x] Selected passage text — confirmed both "Highlight" and "Add selected passage to note" appear
- [x] Triggered Quote — confirmed the note saved (`POST /api/notes/update`) with a new blockquote (`data-scripture-quote-reference="1 John 4:9-10"`) and a fresh scripture pill (`data-scripture-reference="1 John 4:9-10"`) inserted right after it
- [x] Screenshotted the result in the note body
- [x] `tsc --noEmit` shows no new errors from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)