### PR TITLE
fix(reader): annotation notes typed from the Bible reader now save

### DIFF
--- a/Changelog/2.72.7.md
+++ b/Changelog/2.72.7.md
@@ -1,0 +1,8 @@
+# Version 2.72.7
+
+**Release Date**: August 17, 2026
+
+## Fixes
+
+- Annotation notes typed from the Bible reader now save
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.72.6
+**Version:** 2.72.7
 **Status:** Official 1.0 Released January 8, 2026

--- a/netlify/functions/api.cjs
+++ b/netlify/functions/api.cjs
@@ -249655,7 +249655,8 @@ route10.patch("/api/study-threads/:id", requireAuth, rateLimit("write"), async (
           contextSpaceId,
           lock: true
         });
-        if (locked.spaceId !== context2.spaceId) {
+        const effectiveSpaceId = locked.parentNoteId ? context2.spaceId : locked.spaceId;
+        if (locked.spaceId !== effectiveSpaceId) {
           throw new SharedStudyThreadAccessError(404, "Response not found");
         }
         if (context2.isShared) {
@@ -249721,7 +249722,7 @@ route10.patch("/api/study-threads/:id", requireAuth, rateLimit("write"), async (
             and(
               eq(StudyThreadEntries.id, id),
               locked.parentNoteId ? eq(StudyThreadEntries.parentNoteId, locked.parentNoteId) : isNull(StudyThreadEntries.parentNoteId),
-              context2.spaceId ? eq(StudyThreadEntries.spaceId, context2.spaceId) : isNull(StudyThreadEntries.spaceId),
+              effectiveSpaceId ? eq(StudyThreadEntries.spaceId, effectiveSpaceId) : isNull(StudyThreadEntries.spaceId),
               eq(StudyThreadEntries.userId, auth.userId)
             )
           ).returning()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.72.6",
+  "version": "2.72.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-72-6';
+const CACHE_NAME = 'harvous-cache-v2-72-7';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/release-notes/2026-08-17.md
+++ b/release-notes/2026-08-17.md
@@ -1,0 +1,40 @@
+# What's New in Harvous — August 17, 2026
+
+**Release Date:** August 17, 2026
+**Version:** v2.72.7
+
+> DRAFT — generated from commit subjects, not written for users yet.
+> Rewrite each line as what changed for the reader, then delete this banner.
+> See release-notes/README.md for tone, or run /marketing-agent.
+
+---
+
+## Updates in This Release
+
+### General improvements
+
+**What changed:**
+- Annotation notes typed from the Bible reader now save
+
+**How it helps you:**
+- Smoother, more reliable experience
+
+---
+
+## Tips for Using New Features
+
+- **Explore the changes:** Try clicking around to discover the improvements
+- **Check tooltips:** Hover over buttons to see what they do
+- **Visit /help:** Detailed guides for all features
+
+---
+
+## Need Help?
+
+If you have questions about these updates:
+- Check the `/help` folder for detailed guides
+- Most features have hover tooltips that explain what they do
+
+---
+
+*This release note focuses on user experience improvements. For technical details, see the `Changelog/` folder.*

--- a/server/routes/study-threads.ts
+++ b/server/routes/study-threads.ts
@@ -625,7 +625,12 @@ route.patch('/api/study-threads/:id', requireAuth, rateLimit('write'), async (c)
           contextSpaceId,
           lock: true,
         });
-        if (locked.spaceId !== context.spaceId) {
+        // Same gap as the DELETE handler below: `resolveStudyEntryParentContext` always
+        // answers `spaceId: null` for a parentless row (made while reading, no note to derive
+        // a space from), so comparing straight against `context.spaceId` 404s every edit to a
+        // reading-made highlight or reference — the row's own `spaceId` is authoritative there.
+        const effectiveSpaceId = locked.parentNoteId ? context.spaceId : locked.spaceId;
+        if (locked.spaceId !== effectiveSpaceId) {
           throw new SharedStudyThreadAccessError(404, 'Response not found');
         }
         if (context.isShared) {
@@ -707,8 +712,8 @@ route.patch('/api/study-threads/:id', requireAuth, rateLimit('write'), async (c)
                 locked.parentNoteId
                   ? eq(StudyThreadEntries.parentNoteId, locked.parentNoteId)
                   : isNull(StudyThreadEntries.parentNoteId),
-                context.spaceId
-                  ? eq(StudyThreadEntries.spaceId, context.spaceId)
+                effectiveSpaceId
+                  ? eq(StudyThreadEntries.spaceId, effectiveSpaceId)
                   : isNull(StudyThreadEntries.spaceId),
                 eq(StudyThreadEntries.userId, auth.userId),
               ),

--- a/spa/src/pages/prototype/PrototypeBibleReaderPane.tsx
+++ b/spa/src/pages/prototype/PrototypeBibleReaderPane.tsx
@@ -86,7 +86,14 @@ type ReaderDockState =
       newly started note returns the reader to, and a passage has no single one. */
   | { kind: 'reference'; query: string; anchor: string; verse?: number }
   | { kind: 'passage'; reference: string }
-  | { kind: 'highlight'; reference: string; excerpt: string; accent: StudyHighlightAccentKey }
+  | {
+      kind: 'highlight';
+      reference: string;
+      excerpt: string;
+      accent: StudyHighlightAccentKey;
+      /** Null until `onAnnotate`'s create request resolves — see the click handler below. */
+      studyThreadEntryId: string | null;
+    }
   | null;
 
 /** Breathing room above and below the passage a note card holds up. */
@@ -230,12 +237,18 @@ export interface PrototypeBibleReaderPaneProps {
     accent: StudyHighlightAccentKey,
     excerpt: string,
   ) => void;
-  /** Highlight, then open the study dock on it so a thought can be written straight away. */
+  /**
+   * Highlight, then open the study dock on it so a thought can be written straight away.
+   *
+   * Returns the created row's id (or `null` on failure) — the dock opens before this settles,
+   * so the reader threads the id back in once it resolves, letting the dock's own pending-edit
+   * flush pick up whatever was typed in the meantime.
+   */
   onAnnotate?: (
     range: { start: number; end: number },
     accent: StudyHighlightAccentKey,
     excerpt: string,
-  ) => void;
+  ) => Promise<string | null> | void;
   /** Open a margin note, with its scripture dock already on the passage the bar marked. */
   onOpenNoteAtReference?: (noteId: string, reference: string) => void;
   /**
@@ -918,12 +931,25 @@ export default function PrototypeBibleReaderPane({
                   icon="pen"
                   label="Annotate"
                   onClick={() => {
-                    onAnnotate({ start: selection[0], end: selection[1] }, accent, selectedText);
+                    // Open on the id-less state right away — the id arrives after the network
+                    // round trip, and HighlightDockWeb already knows how to hold onto whatever
+                    // gets typed before then and flush it once `studyThreadEntryId` shows up.
                     setDock({
                       kind: 'highlight',
                       reference: selectionLabel,
                       excerpt: selectedText,
                       accent,
+                      studyThreadEntryId: null,
+                    });
+                    void Promise.resolve(
+                      onAnnotate({ start: selection[0], end: selection[1] }, accent, selectedText),
+                    ).then((id) => {
+                      if (!id) return;
+                      setDock((prev) =>
+                        prev && prev.kind === 'highlight' && prev.reference === selectionLabel
+                          ? { ...prev, studyThreadEntryId: id }
+                          : prev,
+                      );
                     });
                   }}
                 />
@@ -1288,6 +1314,8 @@ export default function PrototypeBibleReaderPane({
                 excerpt={dock.excerpt}
                 focusTitle={dock.reference}
                 entryKind="scriptureLink"
+                studyThreadEntryId={dock.studyThreadEntryId}
+                contextSpaceId={homeSpaceId}
                 onAccentChange={(next) => {
                   setAccent(next);
                   if (selection) onHighlight?.({ start: selection[0], end: selection[1] }, next, selectedText);

--- a/spa/src/pages/prototype/PrototypeReadPage.tsx
+++ b/spa/src/pages/prototype/PrototypeReadPage.tsx
@@ -160,15 +160,26 @@ export default function PrototypeReadPage() {
     };
   }, [search.ref, search.req, book, chapter, focusVerse]);
 
+  /**
+   * `onAnnotate` needs the created row's id back — it opens the highlight dock straight away,
+   * and the mini-note textarea there has nothing to PATCH against until one arrives (see
+   * `HighlightDockWeb`'s `studyThreadEntryId` handling). `onHighlight` doesn't care and just
+   * lets the promise run; `mutateAsync` over `mutate` is what makes the id available to await.
+   */
   const applyHighlight = useCallback(
-    (
+    async (
       { start, end }: { start: number; end: number },
       accent: StudyHighlightAccentKey,
       excerpt: string,
-    ) => {
+    ): Promise<string | null> => {
       const reference =
         start === end ? `${book} ${chapter}:${start}` : `${book} ${chapter}:${start}-${end}`;
-      createHighlight.mutate({ reference, accent, excerpt });
+      try {
+        const result = await createHighlight.mutateAsync({ reference, accent, excerpt });
+        return result?.highlight?.id ?? null;
+      } catch {
+        return null;
+      }
     },
     [book, chapter, createHighlight],
   );


### PR DESCRIPTION
## Summary
Two bugs stacked on the same path — select a verse in the Bible reader, tap the annotate (pen) action, type a note:

- **Client**: the reader's own `HighlightDockWeb` never received the created highlight's `studyThreadEntryId`, so it had nothing to PATCH against. `HighlightDockWeb` already handles this exact race (dock opens before the create request resolves, holds pending edits locally, flushes them once an id shows up) — it just never got the id in the first place. `applyHighlight` now uses `mutateAsync` and returns the created row's id; the reader threads it back into dock state once the promise resolves.
- **Server**: even with the id wired up, `PATCH /api/study-threads/:id` 404s for every highlight made straight from the reader (no parent note). `resolveStudyEntryParentContext` always answers `spaceId: null` for a parentless row — it has no note to derive a space from — so comparing against `context.spaceId` always failed the row's own real `spaceId`. This is the identical gap already worked around in the `DELETE` handler (`effectiveSpaceId`, landed in an earlier PR this session); `PATCH` gets the same fix.

## Test plan
- [x] Selected a verse in Genesis 8, tapped Annotate, typed a note — confirmed `POST /api/scripture/highlights` created the row and `PATCH /api/study-threads/:id` initially 404'd (pre-fix)
- [x] After the server fix, re-triggered the same PATCH — 200 OK, `miniNoteBody` persisted
- [x] Fresh end-to-end pass: opened a new dock, typed immediately (deliberately hitting the create-in-flight race) — PATCH succeeded on the first attempt, no 404
- [x] `tsc --noEmit` shows no new errors from this change
- [x] `npm run build` — bundled `netlify/functions/api.cjs` alongside the server route change

🤖 Generated with [Claude Code](https://claude.com/claude-code)