### PR TITLE
fix(reader): Passages icon, auto-expand cross-refs, close toolbar after action

### DIFF
--- a/Changelog/2.72.8.md
+++ b/Changelog/2.72.8.md
@@ -1,0 +1,8 @@
+# Version 2.72.8
+
+**Release Date**: August 17, 2026
+
+## Fixes
+
+- Passages icon, auto-expand cross-refs, close toolbar after action
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.72.7
+**Version:** 2.72.8
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.72.7",
+  "version": "2.72.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-72-7';
+const CACHE_NAME = 'harvous-cache-v2-72-8';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/release-notes/2026-08-17.md
+++ b/release-notes/2026-08-17.md
@@ -1,7 +1,7 @@
 # What's New in Harvous — August 17, 2026
 
 **Release Date:** August 17, 2026
-**Version:** v2.72.7
+**Versions:** v2.72.7–v2.72.8
 
 > DRAFT — generated from commit subjects, not written for users yet.
 > Rewrite each line as what changed for the reader, then delete this banner.
@@ -15,6 +15,7 @@
 
 **What changed:**
 - Annotation notes typed from the Bible reader now save
+- Passages icon, auto-expand cross-refs, close toolbar after action
 
 **How it helps you:**
 - Smoother, more reliable experience

--- a/spa/src/pages/prototype/PrototypeBibleReaderPane.tsx
+++ b/spa/src/pages/prototype/PrototypeBibleReaderPane.tsx
@@ -951,6 +951,10 @@ export default function PrototypeBibleReaderPane({
                           : prev,
                       );
                     });
+                    // Same as Passages: the dock now owns this passage, so keep it in focus
+                    // without the toolbar left floating over the note field underneath it.
+                    setLanding(selection);
+                    setSelection(null);
                   }}
                 />
                 <Divider />
@@ -958,9 +962,15 @@ export default function PrototypeBibleReaderPane({
             ) : null}
 
             <MenuAction
-              icon="arrows-turn-to-dots"
+              icon="shuffle"
               label="Passages"
-              onClick={() => setDock({ kind: 'passage', reference: selectionLabel })}
+              onClick={() => {
+                setDock({ kind: 'passage', reference: selectionLabel });
+                // The dock now shows what the selection was for — keep the passage in focus
+                // (the fade on the rest of the chapter) without the toolbar sitting over it.
+                setLanding(selection);
+                setSelection(null);
+              }}
             />
 
             {onStartNote ? (
@@ -1300,6 +1310,10 @@ export default function PrototypeBibleReaderPane({
                 // No pill to write back to: the passage is already the document behind this
                 // dock, so editing the reference here would mean editing what you are reading.
                 readOnly
+                // "Passages" is the shuffle icon precisely because this dock is for cross-
+                // references — opening on the plain verse text would make the button's own
+                // promise a second tap away.
+                initialShowCrossRefs
                 editorChromeMode="prototypeNative"
                 onDone={() => setDock(null)}
                 onApply={() => undefined}

--- a/src/components/react/ScripturePillChromeWeb.tsx
+++ b/src/components/react/ScripturePillChromeWeb.tsx
@@ -134,6 +134,13 @@ export interface ScripturePillChromeWebProps {
   onOpenScripturePassage?: (reference: string, translation: string) => void;
   /** Read-only passage card (e.g. a cross-reference) — no pill write-back or highlight chrome. */
   readOnly?: boolean;
+  /**
+   * Open with cross-references already showing. For a card opened specifically to browse
+   * related passages (the reader's own "Passages" action), starting on the plain verse text
+   * meant a second tap to see the thing the button promised — the toggle is still there for
+   * closing it, just not the first thing you have to do.
+   */
+  initialShowCrossRefs?: boolean;
 }
 
 /**
@@ -160,6 +167,7 @@ export default function ScripturePillChromeWeb({
   onPassageShown,
   onOpenScripturePassage,
   readOnly = false,
+  initialShowCrossRefs = false,
 }: ScripturePillChromeWebProps) {
   const books = useMemo(() => orderedCanonBooks(), []);
   const { data: eastonsIndex } = useEastonsSlugIndex();
@@ -194,7 +202,7 @@ export default function ScripturePillChromeWeb({
   // render and never re-evaluated, so the footer-vs-floating-capsule choice could not respond to
   // a resize or to an iPad picking up a trackpad.
   const isCoarsePointer = useCoarsePointer();
-  const [showCrossRefs, setShowCrossRefs] = useState(false);
+  const [showCrossRefs, setShowCrossRefs] = useState(initialShowCrossRefs);
   // Parity with cross-references: "Your notes" used to be unconditional, so there was a switch for
   // other people's passages but none for your own. Per-dock, like showCrossRefs — resets on remount.
   const [showRelatedNotes, setShowRelatedNotes] = useState(false);


### PR DESCRIPTION
## Summary
Three small usability issues on the reader's verse-selection toolbar, all on the "Passages" button:

- It used the generic `arrows-turn-to-dots` icon. It always opens a card to browse cross-references — the same job the `shuffle` icon already does inside the scripture dock's own toolbar — so it now uses that icon too, matching the concept it shares.
- Opening that card landed on the plain verse text with cross-references collapsed, even though showing them is the entire point of the button. New `initialShowCrossRefs` prop on `ScripturePillChromeWeb` seeds the toggle open; only the reader's Passages dock passes it, so every other caller (cross-reference cards, pill-backed docks) is unaffected.
- Annotate and Passages both left the floating selection toolbar sitting over the newly-opened dock. Both now clear the selection once the dock takes over — moving the range into `landing` first so the passage stays in focus (rest of the chapter dimmed) without the toolbar floating on top. Highlight's own toolbar-stays-open behavior (for its colour palette) is untouched.

## Test plan
- [x] Selected a verse, tapped Passages — dock opens directly on "Related passages," toolbar is gone, verse stays in focus
- [x] Selected a verse, tapped Annotate — highlight dock opens with the note field, toolbar is gone, verse stays in focus
- [x] `tsc --noEmit` shows no new errors from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)