### PR TITLE
D-5: the margin indicator, and the two things actually wrong with it

### DIFF
--- a/docs/future/READER_MARGIN_INDICATORS.md
+++ b/docs/future/READER_MARGIN_INDICATORS.md
@@ -1,0 +1,218 @@
+# Reader Margin Indicators — Options
+
+**Status:** Decision doc.
+**Last Updated:** August 21, 2026
+**Audience:** Whoever decides how the reader says "you have written about this", and whoever
+implements it.
+**Covers:** improvement-list item #8 (the "In your note" margin indicator redesign) — design-track
+item D-5.
+
+---
+
+## Executive summary
+
+The margin already works, and the parts of it that look arbitrary turn out to be load-bearing.
+The two things actually wrong with it are not the shape.
+
+**Recommendation: Option B — keep the bar exactly as drawn, and give the signal a second,
+non-visual route.** The bar's length carries information no point marker can (a one-verse note is
+a tick, a five-verse note is a rule, two notes over the same verses are two bars side by side),
+and that is the whole reason dots were abandoned. What it lacks is any equivalent for someone not
+looking at it, and one honest defect in how it merges past three lanes.
+
+Two objective findings, both checkable, neither a matter of taste:
+
+> **1. The presence signal has no non-visual equivalent.** The margin layer is `aria-hidden`
+> and every bar is `tabIndex={-1}` (`PrototypeBibleReaderPane.tsx:1447-1462`). The reasoning in
+> that comment is sound — a screen reader walking a chapter should hear Scripture, not a list of
+> marks interleaved between verses. But nothing else *volunteers* the fact. The verse's own
+> action set is Highlight / Annotate / Passages / Note; none of them says a note already cites
+> this verse. The information is reachable (select the verse → Passages → the dock's related
+> notes, `PassageContextStrip.tsx:222-266`) but only by someone who already suspects.
+
+> **2. A merged bar's length stops being its span.** Past `MAX_LANES = 3`, a fourth concurrent
+> note folds into the innermost overlapping bar and that bar is *stretched to the union*:
+> `host.endVerse = Math.max(host.endVerse, span.endVerse)`
+> (`usePrototypeChapterNotes.ts:198-204`). The bar then spans verses neither note necessarily
+> cites, and the note card — which is sized from the bar — holds a passage wider than anything
+> you wrote about. Length is the property the entire design rests on, and this is the one case
+> where it lies.
+
+---
+
+## The alternatives
+
+| Option | Verdict | Trade-off |
+|---|---|---|
+| A. Leave it entirely | Honest, and closer to right than it looks | Keeps both defects; the second one quietly undermines the design's own premise |
+| **B. Keep the bar, add a non-visual route, fix the merge** | **Recommended** | Two contained changes and no visual redesign — but it declines the redesign #8 asked for |
+| C. Point markers (dots) | Not recommended | Already tried and abandoned; cannot express span or overlap, which is most of what the margin knows |
+| D. Inline glyph in the text | Not recommended | Competes with verse numbers, and puts editorial marks inside Scripture |
+| E. Move to the right-hand margin | Not recommended | Real cost, no benefit identified; the card mechanism assumes the gutter side |
+
+---
+
+## What exists today
+
+### The geometry
+
+| Piece | Value | Where |
+|---|---|---|
+| Gutter width | 28px, 20px on a narrow pane | `prototype-tokens.css:596`, `prototype-components.css:18074` |
+| Lane pitch | 9px, three lanes | `prototype-tokens.css:599`, `MAX_LANES` in `usePrototypeChapterNotes.ts:121` |
+| Drawn rule | 2px wide, 1px radius, 3px on hover | `prototype-components.css:18651-18676` |
+| Colour | grey (`--pds-text-tertiary`), never the highlight palette | `prototype-components.css:18639-18650` |
+| Weight ramp | discrete, `data-heat` 1–4 by merged count | `prototype-components.css:18663-18670` |
+
+The gutter is **reserved even when empty**, so text never reflows when the first margin note
+lands. Worth knowing before anything proposes reclaiming it.
+
+At the narrow width the three lanes still fit, but only just: lane 2's drawn rule lands exactly
+on the gutter's inner edge (18–20px of a 20px layer). Its *hit area* is 9px wide and so overhangs
+into the paper padding by 7px. Harmless today — a slightly generous target — but it means the
+gutter has no room for a fourth lane at any width, which is worth stating rather than
+rediscovering.
+
+### Why bars rather than dots
+
+Recorded at `usePrototypeChapterNotes.ts:124-133` and worth preserving, because it is the
+argument any redesign has to beat:
+
+> The reader's old dots asked "what is on verse 12?" and so fanned each anchor across every verse
+> it touched — which threw away the very thing a margin should show. A bar keeps the anchor
+> whole: its length IS the span, and two bars side by side ARE the overlap.
+
+There is a second rejection on record too: `prototype-components.css:18585-18587` still carries
+the dot-era description ("A dot means one note on this verse; a capsule of stacked dots means
+several"), left as a comment above the rule that replaced it. **That comment is now wrong and
+should be deleted** whichever option wins — it describes a design that has not existed for some
+time, directly above the one that did replace it.
+
+### Why the bars are measured rather than laid out
+
+`PrototypeBibleReaderPane.tsx:692-770`. A gutter cell in each block's grid only works in `lines`
+layout, where a block *is* a verse. In `prose` the chapter is one paragraph, so there is no
+per-verse box to sit beside. The bars therefore take their extent from client rects — the start
+verse's **first** rect to the end verse's **last**, not the bounding box, because a verse that
+wraps across four lines has four rects and a range beginning mid-paragraph would otherwise start
+at the wrong line.
+
+This is the real cost of the current design and the reason positional changes are not cheap:
+a `ResizeObserver` on the column plus a rAF pass, re-run on layout mode, text size, typeface and
+column width. Any option that changes *where* bars sit pays this again. Any option that changes
+only how they *look* is CSS.
+
+### The card
+
+`.pds-reader__note-card` sits **behind** the verses (`prototype-components.css:18330-18355`),
+sized to the bar plus `CARD_BLEED`, with its chrome floating above and flipping below when there
+is not enough clearance. The chrome names the notes — "In your note" for one, "In N of your
+notes" for several — and each row opens that note at its own reference, not the bar's.
+
+Note the merged case *is* handled correctly here: `host.notes.push(...span.notes)`, so every note
+folded past the lane cap appears in the card's list. The count is not tooltip-only. Only the
+bar's **length** is wrong for that case, not its contents.
+
+---
+
+## Option B in detail
+
+**Goal:** the margin keeps saying what it says, to everyone, and never draws a span nobody wrote.
+
+**Build — the non-visual route:**
+- Leave `aria-hidden` on `.pds-reader__margin`. It is correct: the bars are a visual index of
+  something the verses already contain, and interleaving them would make the chapter unreadable
+  aloud.
+- Put the fact on the **verse** instead, which is already a `role="option"` in the chapter's
+  listbox and already has an accessible name. A verse covered by a note gains a visually-hidden
+  suffix, so it announces as "…Verse 12, in one of your notes" rather than requiring the reader
+  to go asking.
+- Derive it from `anchorLanes`, which already knows the covered ranges — no second query, and no
+  dependency on the measured `bars`, which exist only once layout has settled.
+
+**Build — the merge:**
+- Stop stretching the host bar. Either draw the merged note at its own extent in lane 3 and
+  accept two bars in one lane (they overlap visually, which is honest — there genuinely is more
+  here than three lanes can show), or keep the host's own span and let the card's list carry the
+  extra note without the bar claiming its verses.
+- Prefer the second: it keeps every drawn length truthful, and the card already lists the merged
+  notes correctly. The bar stops promising a span it does not have.
+
+**Reuse:** `assignAnchorLanes` is pure and already unit-tested — the merge branch is four lines
+and the test can pin the invariant directly ("no bar's span exceeds the union of the spans it
+draws for").
+
+**Done when:** a screen reader hears which verses you have written about without hunting; no
+drawn bar covers a verse that no note it stands for cites; and the stale dot comment is gone.
+
+---
+
+## The options not taken
+
+**C. Point markers.** A dot can say "something is here" and nothing else. The margin's three most
+useful facts — how long the passage is, that two notes overlap, that one note swallows another —
+are all length or adjacency. This was the previous design and was replaced for exactly this
+reason; re-proposing it would be re-losing the argument. Included in the gallery scene so the
+comparison can be seen rather than taken on trust.
+
+**D. Inline glyph.** Putting a marker in the text competes with verse numbers, which the reader
+has just spent effort keeping clean (the highlight-underline fix moved decoration off the number
+precisely so the number stays a number). It also makes an editorial mark part of Scripture's
+line, which the reader's whole visual argument avoids.
+
+**E. Right-hand margin.** The gutter would have to be reserved on the other side, the card's
+`left`/`right` insets (`prototype-components.css:18345-18346`) inverted, and the measuring pass
+re-verified in both layouts — for no benefit anyone has named. Listed because it is the obvious
+"move it" idea, and rejecting it explicitly is cheaper than answering it twice.
+
+---
+
+## Native parity
+
+**There is no native chapter reader yet.** `native/Harvous/Views/` has the scripture hub, the
+passage view and the dock, but nothing that renders a chapter with a margin — so this decision
+carries no immediate Swift obligation, unlike the toolbar shape.
+
+It does carry a future one. Per `docs/design-parity/`, native is the visual source of truth, and
+the Bible reader is on the roadmap as a main-pane document type. Whatever is decided here becomes
+the thing the native reader has to match, so the *reasoning* matters more than usual: a margin
+whose justification is "length is the span" survives being rebuilt in SwiftUI, whereas one
+justified by CSS positioning does not.
+
+---
+
+## Risks / watch-items
+
+- **The gutter is reserved even when empty.** Any option that narrows or removes it makes text
+  reflow the moment a first note lands, which is the exact jitter the reservation prevents.
+- **The measured layer is re-run on four different triggers.** A change to `top`/`height`
+  semantics needs checking in both layouts, at several widths, and after a typeface change —
+  unit tests cannot cover it.
+- **`showMarginNotes` already exists** (`spa/src/lib/proto-reading-prefs.ts:49`), so the margin is
+  opt-out today. A redesign should not quietly become non-optional.
+- **The gallery clone is hand-maintained** (`DesignSystemScenePreview.tsx:625-649`, `:725`). It
+  restates the bar markup rather than rendering the pane, so a change to the real bars can pass
+  `design:check` while the scene drifts. Same class of problem as the paper-stack fixture.
+- **The stale dot comment** at `prototype-components.css:18585-18587` describes a design that no
+  longer exists, directly above the one that replaced it. Delete it with whatever lands.
+- **Collision with the dock carousel.** The reader can now hold several study docks in a band at
+  the bottom (`StudyDockCarouselWeb`). A pinned note card low in the chapter has not been checked
+  against that band — the same collision `HIGHLIGHT_REFERENCE_STYLING_SPEC.md` flags for the
+  selection toolbar.
+
+---
+
+## Related docs
+
+- `docs/future/HIGHLIGHT_REFERENCE_STYLING_SPEC.md` — D-4, the mark styling this sits beside
+- `docs/future/READER_PARTIAL_VERSE_HIGHLIGHTS.md` — D-1; sub-verse anchors would change what a
+  bar's length means
+- `docs/design-parity/HARVOUS_DESIGN_SYSTEM.md` — §5 accessibility baseline
+
+---
+
+## Decision log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| _pending_ | | |

--- a/docs/future/README.md
+++ b/docs/future/README.md
@@ -191,6 +191,15 @@ trade-offs, and a recommendation; each ends with a Decision log to fill in on re
 - **`READER_PARTIAL_VERSE_HIGHLIGHTS.md`** - Highlighting less than a whole verse (#7)
   - Recommends reusing the excerpt model the dock and native already share, painted imperatively
   - Names the blocking piece: the server upsert key is verse-granular and must gain the excerpt
+- **`READER_MARGIN_INDICATORS.md`** - How the reader says "you have written about this" (#8)
+  - Recommends keeping the bar: its length is the note's span, which no point marker can express
+  - Finds the presence signal has no non-visual equivalent, and that a bar merged past the
+    three-lane cap is stretched to a span no note actually cites
+  - Compare the options in the `ds-22-margin-indicators` gallery scene rather than from the prose
+
+Two of these are decided and built. `TOOLBAR_SHAPE_LANGUAGE_OPTIONS.md` (Option B: tile shape,
+glass kept) is decided and awaiting implementation; `SUGGESTION_ACTIONS_REDESIGN.md` (Option B)
+shipped in v2.78.0.
 
 ## 🎯 Implementation Priority
 

--- a/spa/src/pages/dev/design-system/DesignSystemScenePreview.tsx
+++ b/spa/src/pages/dev/design-system/DesignSystemScenePreview.tsx
@@ -1510,6 +1510,201 @@ function FloatingSurfacesScene() {
   );
 }
 
+/*
+ * Margin indicators — what the reader uses to say "you have written about this".
+ *
+ * A decision aid for `docs/future/READER_MARGIN_INDICATORS.md` (D-5), and it exists because the
+ * argument for bars over dots is entirely about *length*: a bar's extent is the note's span, and
+ * two bars side by side are an overlap. That is impossible to judge from a description, and the
+ * dot design was rejected once already without anyone seeing the two next to each other.
+ *
+ * Same three notes in every panel, over the same five verses, measured from the same rendered
+ * text — so the only variable is how the margin draws them. The bars panel uses the production
+ * classes; the others are specimens of designs that do not exist, which is the point.
+ *
+ * Delete this scene once D-5 is decided.
+ */
+const MARGIN_SPANS = [
+  { key: 'a', from: 1, to: 1, lane: 0, label: 'One note — John 1:1' },
+  { key: 'b', from: 3, to: 5, lane: 0, label: 'One note — John 1:3-5' },
+  { key: 'c', from: 3, to: 4, lane: 1, label: '3 notes — John 1:3-4' },
+];
+
+type MeasuredSpan = { key: string; top: number; height: number; lane: number; label: string; from: number; to: number };
+
+/** The shared specimen column. `render` draws whatever the variant puts in the gutter. */
+function MarginSpecimen({
+  title,
+  note,
+  render,
+}: {
+  title: string;
+  note: string;
+  render: (spans: MeasuredSpan[]) => React.ReactNode;
+}) {
+  const columnRef = useRef<HTMLDivElement | null>(null);
+  const [spans, setSpans] = useState<MeasuredSpan[]>([]);
+
+  useLayoutEffect(() => {
+    const column = columnRef.current;
+    if (!column) return;
+    // Same measure the pane runs: first rect of the start verse to the last rect of the end
+    // verse, so a range that begins mid-paragraph starts on the right line.
+    const measure = () => {
+      const base = column.getBoundingClientRect().top;
+      setSpans(
+        MARGIN_SPANS.flatMap((s) => {
+          const a = column.querySelector(`[data-verse="${s.from}"]`);
+          const b = column.querySelector(`[data-verse="${s.to}"]`);
+          if (!(a instanceof HTMLElement) || !(b instanceof HTMLElement)) return [];
+          const first = a.getClientRects()[0];
+          const rects = b.getClientRects();
+          const last = rects[rects.length - 1];
+          if (!first || !last) return [];
+          return [{
+            key: s.key,
+            top: Math.round(first.top - base),
+            height: Math.max(4, Math.round(last.bottom - first.top)),
+            lane: s.lane,
+            label: s.label,
+            from: s.from,
+            to: s.to,
+          }];
+        }),
+      );
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(column);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div>
+      <p className="pds-section-header" style={{ marginBottom: 2 }}>{title}</p>
+      <p className="pds-caption" style={{ marginBottom: 10 }}>{note}</p>
+      <div className="pds-reader pds-gallery-reader">
+        <div className="pds-reader__scroll">
+          <div className="pds-reader__column" ref={columnRef}>
+            {render(spans)}
+            <div role="listbox" aria-label="John 1 verses">
+              {READER_VERSES.map((verse) => (
+                <div className="pds-reader__block" role="none" key={verse.num}>
+                  <p className="pds-reader-text" role="none">
+                    <span className="pds-reader__verse" role="option" data-verse={verse.num} aria-selected={false}>
+                      <sup className="pds-reader-verse-num">{verse.num}</sup>
+                      <span className="pds-reader__verse-text">{verse.text}</span>
+                    </span>
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MarginIndicatorScene() {
+  return (
+    <div style={{ maxWidth: 900 }}>
+      <p className="pds-caption" style={{ marginBottom: 18 }}>
+        Three notes over John 1, drawn four ways. One covers verse 1 alone, one covers 3–5, and a
+        third — three notes on the same passage — covers 3–4. Watch what survives each treatment:
+        the length of a span, and the fact that two of them overlap.
+      </p>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20, marginBottom: 24 }}>
+        <MarginSpecimen
+          title="A — bars (today)"
+          note="Length is the span; the second lane is the overlap. Production classes, so this is live."
+          render={(spans) => (
+            <div className="pds-reader__margin" aria-hidden>
+              {spans.map((s) => (
+                <ReaderBar
+                  key={s.key}
+                  top={s.top}
+                  height={s.height}
+                  lane={s.lane}
+                  heat={s.key === 'c' ? 3 : 1}
+                  label={s.label}
+                />
+              ))}
+            </div>
+          )}
+        />
+
+        <MarginSpecimen
+          title="C — dots (the design bars replaced)"
+          note="A point marker can say something is here and nothing else. Both spans and the overlap are gone; verse 3 carries two dots that look like one busier verse."
+          render={(spans) => (
+            <div className="pds-reader__margin" aria-hidden>
+              {spans.map((s) => (
+                <span
+                  key={s.key}
+                  className="pds-gallery-margin-dot"
+                  style={{ top: s.top + 7, right: s.lane * 9 }}
+                />
+              ))}
+            </div>
+          )}
+        />
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
+        <MarginSpecimen
+          title="D — inline glyph"
+          note="Reachable by keyboard for free, and that is its only advantage. It competes with the verse number the reader just finished keeping clean, and puts an editorial mark inside Scripture's own line."
+          render={(spans) => (
+            <div className="pds-reader__margin" aria-hidden>
+              {spans.map((s) => (
+                <span
+                  key={s.key}
+                  className="pds-gallery-margin-glyph"
+                  style={{ top: s.top + 2, right: s.lane * 9 }}
+                >
+                  <Icon name="note-sticky" size={9} aria-hidden />
+                </span>
+              ))}
+            </div>
+          )}
+        />
+
+        <MarginSpecimen
+          title="The merge defect (finding 2)"
+          note="A fourth concurrent note folds into lane 3 and stretches that bar to the union of both spans. The outer bar here covers 1–5; no note cites 1–5. Length is the one thing the design promises, and this is where it lies."
+          render={(spans) => {
+            const stretched = spans.length
+              ? { ...spans[0], height: (spans[2]?.top ?? 0) + (spans[2]?.height ?? 0) - spans[0].top }
+              : null;
+            return (
+              <div className="pds-reader__margin" aria-hidden>
+                {stretched ? (
+                  <ReaderBar
+                    top={stretched.top}
+                    height={stretched.height}
+                    lane={0}
+                    heat={4}
+                    label="Stretched to the union — John 1:1 and John 1:3-4"
+                  />
+                ) : null}
+              </div>
+            );
+          }}
+        />
+      </div>
+
+      <p className="pds-caption" style={{ marginTop: 16 }}>
+        Not shown, because it is invisible by definition: the recommended change adds no pixels.
+        A verse covered by a note gains a visually-hidden suffix so the chapter&apos;s listbox
+        announces &ldquo;Verse 3, in three of your notes&rdquo; — the margin stays `aria-hidden`,
+        which is correct, and the fact stops being sight-only.
+      </p>
+    </div>
+  );
+}
+
 export default function DesignSystemScenePreview({ scene }: { scene: DesignSystemScene }) {
   switch (scene.id) {
     case 'ds-01-typography':
@@ -1554,6 +1749,8 @@ export default function DesignSystemScenePreview({ scene }: { scene: DesignSyste
       return <ToolbarShapeScene />;
     case 'ds-21-floating-shape':
       return <FloatingSurfacesScene />;
+    case 'ds-22-margin-indicators':
+      return <MarginIndicatorScene />;
     default:
       return <p className="pds-caption">Unknown design-system scene.</p>;
   }

--- a/spa/src/pages/dev/design-system/sceneRegistry.ts
+++ b/spa/src/pages/dev/design-system/sceneRegistry.ts
@@ -263,6 +263,22 @@ export const DESIGN_SYSTEM_CORE_SCENES: DesignSystemScene[] = [
     // that open from it. Production classes, not copies of their markup, so the "today" column
     // is whatever the CSS says today. Also a decision aid — delete it with ds-20.
   },
+  {
+    id: 'ds-22-margin-indicators',
+    title: 'Margin indicators — options',
+    phase: 'Patterns',
+    editFiles: [
+      'spa/src/pages/prototype/PrototypeBibleReaderPane.tsx',
+      'spa/src/hooks/queries/usePrototypeChapterNotes.ts',
+      'spa/src/styles/prototype-components.css',
+      'docs/future/READER_MARGIN_INDICATORS.md',
+    ],
+    screenshotSlug: 'ds-22-margin-indicators',
+    // The case for bars over dots is entirely about length, which cannot be judged from a
+    // description — dots were rejected once without the two being seen side by side. Also
+    // renders the lane-merge defect, which is easier to see than to read about. Decision aid;
+    // delete it once D-5 is settled.
+  },
 ];
 
 export function isDesignSystemCoreScene(id: string): boolean {

--- a/spa/src/styles/prototype-design-gallery.css
+++ b/spa/src/styles/prototype-design-gallery.css
@@ -479,3 +479,25 @@
   border: 0.5px solid var(--pds-border);
   border-radius: var(--pds-radius-card);
 }
+
+/*
+ * Margin-indicator specimens (ds-22).
+ *
+ * Deliberately NOT in prototype-components.css: these draw designs the product does not have
+ * and, on current recommendation, will not get. Keeping them in the gallery sheet means the
+ * comparison exists without a dot style sitting in the reader's stylesheet waiting to be
+ * mistaken for something in use. They go when the scene does.
+ */
+.pds-gallery-margin-dot {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background-color: var(--pds-text-tertiary);
+}
+
+.pds-gallery-margin-glyph {
+  position: absolute;
+  display: inline-flex;
+  color: var(--pds-text-tertiary);
+}


### PR DESCRIPTION
D-5, improvement-list item #8. A decision doc plus the gallery scene to decide it against —
the toolbar shape was settled by looking at `ds-20` rather than reading a description, and this
argument needs that more, not less.

## The recommendation is to keep the bar

Which is not what a "redesign" item expects, so the doc argues it instead of asserting it.

A bar's **length is the note's span**, and two bars side by side **are** the overlap. Those are
most of what a margin knows, and a point marker can express neither. Dots were the previous
design and were rejected once already — without anyone seeing the two next to each other.
`ds-22-margin-indicators` renders the same three notes over the same five verses four ways, so
the call can be made by looking.

## Two objective findings

**1. The presence signal has no non-visual equivalent.** The margin layer is `aria-hidden` with
every bar `tabIndex={-1}`, and that is *correct* — a screen reader walking a chapter should hear
Scripture, not a list of marks interleaved between verses. But nothing else volunteers the fact.
A verse's own actions are Highlight / Annotate / Passages / Note; none says a note already cites
it. The information is reachable — verse → Passages → the dock's related notes — but only by
someone who already suspects it is there.

The proposed fix adds no pixels. The verse is already a `role="option"` with an accessible name,
so it can carry "in one of your notes" itself and the margin can stay hidden.

**2. A merged bar's length stops being its span.** Past the three-lane cap, a fourth concurrent
note folds into the innermost overlapping bar and stretches it to the union
(`host.endVerse = Math.max(...)`, `usePrototypeChapterNotes.ts:198-204`). The bar then covers
verses no note cites, and the card sized from it holds a passage wider than anything written.
Length is the one property the whole design promises. The scene renders this case, because it is
easier to see than to read about.

## One correction made while writing

I first took the merged count to be tooltip-only and therefore invisible on touch, and was going
to report it as a third defect. It is not: `host.notes.push(...span.notes)` means the card lists
every merged note. Only the bar's *length* is wrong, not its contents. Noting it because the
wrong version was the more dramatic finding.

## Also recorded, so it is not rediscovered

- The gutter is **reserved even when empty**, so text never reflows when the first note lands —
  anything proposing to reclaim it is proposing that jitter.
- The three lanes only just fit the 20px narrow gutter; there is no room for a fourth at any width.
- The measured-layer approach (client rects, `ResizeObserver`, rAF) is what makes *positional*
  changes expensive and purely visual ones cheap.
- A stale comment above the bar rule still describes the dot design it replaced.
- The pinned note card has not been checked against the reader's new dock carousel band.

## Native

There is no native chapter reader yet, so no immediate Swift obligation — unlike the toolbar
shape. But the Bible reader is on the roadmap as a main-pane document type, so whatever is decided
here becomes what SwiftUI has to match. That makes the *reasoning* matter more than the pixels: a
margin justified by "length is the span" survives being rebuilt; one justified by CSS positioning
does not.

## Gates

4119 tests, `tsc --noEmit` at the 281 baseline, `design:check` 22 core + 27 shared-spaces scenes,
`check:color-tokens` clean, `perf:check` 1109.6 KB with no regressions.

No product code changed — the doc, the gallery scene, its specimen styles, and the docs index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
