### PR TITLE
infra: run the API on Fly.io instead of Netlify Functions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# The build needs package*.json, server/, src/, shared/, scripts/, tsconfig.json
+# and nothing else — everything below is either huge, platform-specific, or secret.
+
+node_modules
+dist
+dist-spa
+dist-server
+
+# Native clients
+ios
+android
+native
+apps
+
+# Tests, tooling, docs
+e2e
+test-results
+playwright-report
+docs
+help
+release-notes
+supabase
+netlify
+public
+spa
+.github
+.claude
+.git
+
+# Secrets and local state
+.env
+.env.*
+*.log
+
+# Large data the server never reads at runtime (bundled JSON is imported from
+# src/ and server/data by esbuild only for the files that are actually imported)
+server/data/bibles/*.json

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy API to Fly.io
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'server/**'
+      # The server bundles these through the @=src alias and shared imports.
+      - 'src/**'
+      - 'shared/**'
+      - 'scripts/generate-founder-letter.js'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'fly.toml'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/fly-deploy.yml'
+  workflow_dispatch: # Allow manual redeploy from the Actions UI
+
+concurrency:
+  group: fly-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: fly deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # build output
 dist/
 dist-spa/
+dist-server/
 
 # generated types
 .astro/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Harvous API — the Hono server (server/fly.ts) as a long-lived process.
+#
+# Two stages: the builder holds the full dependency tree only long enough for
+# esbuild to produce one self-contained bundle, so the runtime image carries no
+# node_modules at all — just Node, Chromium, and dist-server/api.cjs.
+
+# ── builder ───────────────────────────────────────────────────────────────────
+FROM node:22-slim AS builder
+
+WORKDIR /build
+
+COPY package.json package-lock.json ./
+RUN npm ci --prefer-offline --no-audit --ignore-scripts
+
+# Everything build:fly touches: the server, the shared/src code it imports via
+# the @=src alias, and scripts/generate-founder-letter.js (which generates
+# server/routes/founder-letter.inline.generated.ts from src/data before esbuild).
+COPY server ./server
+COPY src ./src
+COPY shared ./shared
+COPY scripts ./scripts
+COPY tsconfig.json ./
+
+RUN npm run build:fly
+
+# ── runtime ───────────────────────────────────────────────────────────────────
+FROM node:22-slim AS runtime
+
+# Chromium for OG screenshots. On Netlify this was @sparticuz/chromium plus a
+# 22-entry included_files list; a real image just installs the browser.
+# og-screenshot.ts picks it up via CHROME_EXECUTABLE_PATH.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        chromium \
+        ca-certificates \
+        fonts-liberation \
+        fonts-noto-color-emoji \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV NODE_ENV=production \
+    API_PORT=8080 \
+    CHROME_EXECUTABLE_PATH=/usr/bin/chromium
+
+WORKDIR /app
+COPY --from=builder /build/dist-server/api.cjs ./api.cjs
+
+USER node
+EXPOSE 8080
+
+CMD ["node", "api.cjs"]

--- a/docs/FLY_MIGRATION.md
+++ b/docs/FLY_MIGRATION.md
@@ -1,0 +1,163 @@
+# Moving the API to Fly.io
+
+The Hono API leaves Netlify Functions and runs as one always-on process on Fly.
+Netlify keeps everything else — the SPA, redirects, headers, and the `shared-og`
+edge function — and rewrites `/api/*` to Fly. Clients never learn about it: the
+origin they call is still `app.harvous.com`, so the web SPA, the native Swift
+app, and the offline mutation queue are unchanged.
+
+## Why
+
+Netlify's free plan is a single hard-capped pool of 300 credits/month covering
+deploys (15 each), bandwidth (20/GB), and function compute (10/GB-hour).
+Exceeding it does not throttle — the site goes offline until the 1st of the next
+month. The `og-image` function ran at `memory = 3008` / `timeout = 26`, about
+0.21 credits per full-length render, so roughly 1,400 crawler-triggered renders
+would have consumed the entire month. That is the same traffic shape as the
+August 2026 bot flood.
+
+One `shared-cpu-1x` 1GB machine is ~$5.70/month flat, has no per-request billing
+to weaponize, no invocation cap, no execution-time ceiling, a Postgres pool that
+stays warm, and real Chromium instead of `@sparticuz/chromium`.
+
+**This does not make the app feel faster to tap.** Optimistic mutations and the
+offline queue already paint before the network. Server latency shows up in
+first-load data readiness, offline-queue replay, and cold-start tail latency.
+
+## What changed in the repo
+
+| File | Purpose |
+|---|---|
+| `server/fly.ts` | Production entry point. Serves `server/app.ts` via `@hono/node-server`, warms the pool, starts the scheduler, drains on SIGTERM. |
+| `server/scheduler.ts` | Runs the two `@daily` jobs in-process, replacing the Netlify scheduled functions. Calls their already-exported inner functions. |
+| `server/utils/user-export-backup-store.ts` | Supabase Storage replacement for `@netlify/blobs` (which only has a context inside a Netlify Function). |
+| `Dockerfile` / `.dockerignore` | Two-stage build: esbuild produces one self-contained bundle; the runtime image is Node + Chromium + `api.cjs`, no `node_modules`. |
+| `fly.toml` | One always-on machine in `iad` (colocated with Supabase `aws-1-us-east-1`). |
+| `.github/workflows/fly-deploy.yml` | `flyctl deploy --remote-only` on pushes to `main` that touch server code. |
+| `scripts/fly-secrets-import.sh` | Pushes the server-side subset of `.env` into Fly. |
+
+Behavior fixes that were latent Netlify couplings:
+
+- `server/routes/og.ts` — all five origins now come from `getPublicAppOrigin()`
+  instead of the request URL. Behind the proxy the request host is the API's, so
+  canonical/image URLs and screenshot targets would otherwise point at a host
+  with no app on it. `PUBLIC_APP_ORIGIN` in `fly.toml` pins it.
+- `server/routes/notes.ts` — the dev note-save trail was gated on
+  `process.env.NETLIFY`, which is unset on Fly; it would have appended a line to
+  the container filesystem on every note save. Now gated on
+  `isDeployedProductionLike()`.
+- `server/constants/dev-featured-samples.ts` — `isDeployedProductionLike()` also
+  recognizes `FLY_APP_NAME`, and `isTestRoutesForbidden()` now delegates to it
+  rather than repeating the checks.
+
+## Phase 2 — create the app (needs your Fly account)
+
+Fly has no free tier; a card is required. Then, from the repo root:
+
+```bash
+fly launch --no-deploy --name harvous-api --region iad
+```
+
+Push the secrets:
+
+```bash
+DRY_RUN=1 bash scripts/fly-secrets-import.sh
+```
+
+That prints which variables it found and which it could not. **`.env` is not the
+full production environment** — the cron secrets the GitHub scheduled workflows
+authenticate with (`VOTD_CRON_SECRET`, `BACKUP_CRON_SECRET`,
+`HMC_SYNC_CRON_SECRET`, `AUTO_ARCHIVE_SECRET_TOKEN`, `INBOX_RESET_SECRET_TOKEN`,
+`SUPPORT_NOTIFY_SECRET_TOKEN`) live only in the Netlify dashboard. Copy them from
+Netlify → Site settings → Environment variables, then:
+
+```bash
+bash scripts/fly-secrets-import.sh
+```
+
+Set anything still missing with `fly secrets set NAME=value`, then deploy:
+
+```bash
+fly deploy
+```
+
+One-time manual step: create a **private** `user-exports` bucket in the Supabase
+dashboard (Storage → New bucket), or the nightly backup job returns 503.
+
+For the GitHub Action, create a deploy token and add it as the `FLY_API_TOKEN`
+repository secret:
+
+```bash
+fly tokens create deploy --name github-actions
+```
+
+## Phase 3 — bake before cutover
+
+Nothing points at Fly yet, so this is all non-destructive.
+
+```bash
+curl -s -w " | %{http_code} %{time_total}s\n" https://harvous-api.fly.dev/api/health
+```
+
+Run the real SPA against it — the Vite proxy keeps it same-origin, so auth and
+cookies behave as in production:
+
+```bash
+VITE_API_PROXY_TARGET=https://harvous-api.fly.dev npm run dev:spa
+```
+
+Exercise sign-in, note create/edit with scripture pills, spaces, billing pages,
+and an OG render (`/api/og/image/note/<token>`). Watch `fly logs` for the
+scheduler line — it prints `[scheduler] next run in Nm` at boot and logs each
+job's result at 00:00 UTC.
+
+Worth confirming specifically: webhook signature verification still passes.
+`server/routes/webhooks.ts` carries workarounds for Netlify duplicating headers
+into `"v, v"`; Fly does not do this, and the workarounds take the first
+comma-split value, so they are inert rather than wrong — but this is the code
+path that silently disabled CSRF for months, so verify rather than assume.
+
+## Phase 4 — cutover
+
+One commit, reverting cleanly. In `public/_redirects`, point the two API rules at
+Fly, keeping their order and the `/assets/*` rule below them:
+
+```
+/api/og/image/*  https://harvous-api.fly.dev/api/og/image/:splat  200
+/api/*           https://harvous-api.fly.dev/api/:splat           200
+/assets/*        /assets/:splat                                   404
+/*               /index.html                                      200
+```
+
+The `/assets/* → 404` rule is load-bearing: hashed chunks from a previous deploy
+must 404 rather than fall through to `index.html`, or the service worker caches
+HTML under a `.js` URL permanently.
+
+Merge, let Netlify deploy, then smoke production: sign in, save a note, and
+unfurl a share link with a crawler user-agent. The GitHub cron workflows keep
+calling `app.harvous.com/api/...` and are proxied through transparently.
+
+Rollback is `git revert` of that commit.
+
+## Phase 5 — Netlify cleanup (after a quiet week)
+
+- Drop `build:api` from the `netlify.toml` build command.
+- Remove `[functions]`, both `schedule` entries, and the entire `og-image`
+  `included_files` block.
+- Delete `server/netlify.ts`, `server/og-image-function.ts`,
+  `server/netlify-purge-shared-spaces.ts`,
+  `server/netlify-audienceful-activity-sync.ts` (the scheduler imports their
+  inner functions — move those first), and the `netlify/functions/*` outputs.
+- Drop `@netlify/blobs` and `@sparticuz/chromium` from dependencies.
+- Consider re-enabling the CSRF middleware in `server/app.ts` — it was disabled
+  because Netlify's proxy headers caused false 403s. The proxy is still in the
+  path until the SPA calls `api.harvous.com` directly, so this is not yet a free
+  win.
+
+## Not doing (yet)
+
+Pointing the SPA at `api.harvous.com` directly would remove the Netlify proxy
+entirely (and with it the duplicate-header quirk), but it needs CORS
+configuration, Clerk cross-origin token handling, and a native-app base-URL
+change. The proxy keeps this migration invisible to all three clients, which is
+worth more than the extra hop.

--- a/docs/FLY_MIGRATION.md
+++ b/docs/FLY_MIGRATION.md
@@ -50,60 +50,66 @@ Behavior fixes that were latent Netlify couplings:
   recognizes `FLY_APP_NAME`, and `isTestRoutesForbidden()` now delegates to it
   rather than repeating the checks.
 
-## Phase 2 — create the app (needs your Fly account)
+## Phase 2 — the app (done 2026-08-21)
 
-Fly has no free tier; a card is required. Then, from the repo root:
+App **`harvous`** in org `testament-made`, region `iad`, one `shared-cpu-1x`
+machine with 1GB, live at **https://harvous.fly.dev**. Nothing in production
+points at it yet.
 
-```bash
-fly launch --no-deploy --name harvous-api --region iad
-```
+Deployed from the working directory (`fly deploy --remote-only`) rather than
+through Fly's GitHub launch flow — that flow clones the repo's default branch,
+which has no Dockerfile until this branch merges. Deploying locally is also the
+right order of operations: prove the image, then cut over, then let CI take it.
 
-Push the secrets:
+Verified on the deployed machine:
 
-```bash
-DRY_RUN=1 bash scripts/fly-secrets-import.sh
-```
+| Check | Result |
+|---|---|
+| `/api/health` | 200 in ~100ms (Netlify production measured 250-280ms) |
+| `/api/votd/today` | 200 with real data — Postgres reachable |
+| Scheduler | `[scheduler] next run in 155m` at boot |
+| SIGTERM/SIGINT drain | `draining` → `drained cleanly` when a machine was destroyed |
+| OG screenshot | 200, real 1200×630 PNG, `x-og-source: screenshot` |
+| Image size | 319 MB |
 
-That prints which variables it found and which it could not. **`.env` is not the
-full production environment** — the cron secrets the GitHub scheduled workflows
-authenticate with (`VOTD_CRON_SECRET`, `BACKUP_CRON_SECRET`,
-`HMC_SYNC_CRON_SECRET`, `AUTO_ARCHIVE_SECRET_TOKEN`, `INBOX_RESET_SECRET_TOKEN`,
-`SUPPORT_NOTIFY_SECRET_TOKEN`) live only in the Netlify dashboard. Copy them from
-Netlify → Site settings → Environment variables, then:
+Two things worth knowing:
 
-```bash
-bash scripts/fly-secrets-import.sh
-```
+- **Fly auto-creates a second machine for HA on first deploy**, doubling the
+  cost. Scaled back with `fly scale count 1`. Reverse it with `fly scale count 2`
+  if zero-downtime deploys become worth ~$5.70/mo.
+- **OG renders take ~6s warm and ~36s cold.** The cold case would have exceeded
+  Netlify's `timeout = 26` and returned nothing, so that path was likely already
+  failing there intermittently. 6s is still slow for a crawler; each render boots
+  a fresh Chromium and loads the full SPA bundle. Reusing a browser instance
+  across renders is the obvious fix — tracked separately, not a blocker.
 
-Set anything still missing with `fly secrets set NAME=value`, then deploy:
+### Still to do before cutover
 
-```bash
-fly deploy
-```
-
-One-time manual step: create a **private** `user-exports` bucket in the Supabase
-dashboard (Storage → New bucket), or the nightly backup job returns 503.
-
-For the GitHub Action, create a deploy token and add it as the `FLY_API_TOKEN`
-repository secret:
-
-```bash
-fly tokens create deploy --name github-actions
-```
+1. **The 13 Netlify-only secrets.** `DRY_RUN=1 bash scripts/fly-secrets-import.sh`
+   reports them. 21 of 34 came from `.env`; the rest — including every cron secret
+   the GitHub scheduled workflows authenticate with (`VOTD_CRON_SECRET`,
+   `BACKUP_CRON_SECRET`, `HMC_SYNC_CRON_SECRET`, `INBOX_RESET_SECRET_TOKEN`,
+   `SUPPORT_NOTIFY_SECRET_TOKEN`) — live only in the Netlify dashboard under Site
+   settings → Environment variables. Copy them there, then re-run the script
+   without `DRY_RUN`. Those endpoints 401 after cutover otherwise.
+2. **A private `user-exports` bucket** in Supabase (Storage → New bucket, not
+   public), or the nightly backup job returns 503.
+3. **`FLY_API_TOKEN`** as a GitHub repository secret, so `fly-deploy.yml` can
+   deploy once this merges: `fly tokens create deploy --name github-actions`.
 
 ## Phase 3 — bake before cutover
 
 Nothing points at Fly yet, so this is all non-destructive.
 
 ```bash
-curl -s -w " | %{http_code} %{time_total}s\n" https://harvous-api.fly.dev/api/health
+curl -s -w " | %{http_code} %{time_total}s\n" https://harvous.fly.dev/api/health
 ```
 
 Run the real SPA against it — the Vite proxy keeps it same-origin, so auth and
 cookies behave as in production:
 
 ```bash
-VITE_API_PROXY_TARGET=https://harvous-api.fly.dev npm run dev:spa
+VITE_API_PROXY_TARGET=https://harvous.fly.dev npm run dev:spa
 ```
 
 Exercise sign-in, note create/edit with scripture pills, spaces, billing pages,
@@ -123,10 +129,10 @@ One commit, reverting cleanly. In `public/_redirects`, point the two API rules a
 Fly, keeping their order and the `/assets/*` rule below them:
 
 ```
-/api/og/image/*  https://harvous-api.fly.dev/api/og/image/:splat  200
-/api/*           https://harvous-api.fly.dev/api/:splat           200
-/assets/*        /assets/:splat                                   404
-/*               /index.html                                      200
+/api/og/image/*  https://harvous.fly.dev/api/og/image/:splat  200
+/api/*           https://harvous.fly.dev/api/:splat           200
+/assets/*        /assets/:splat                               404
+/*               /index.html                                  200
 ```
 
 The `/assets/* → 404` rule is load-bearing: hashed chunks from a previous deploy

--- a/docs/FLY_MIGRATION.md
+++ b/docs/FLY_MIGRATION.md
@@ -8,21 +8,74 @@ app, and the offline mutation queue are unchanged.
 
 ## Why
 
-Netlify's free plan is a single hard-capped pool of 300 credits/month covering
-deploys (15 each), bandwidth (20/GB), and function compute (10/GB-hour).
-Exceeding it does not throttle — the site goes offline until the 1st of the next
-month. The `og-image` function ran at `memory = 3008` / `timeout = 26`, about
-0.21 credits per full-length render, so roughly 1,400 crawler-triggered renders
-would have consumed the entire month. That is the same traffic shape as the
-August 2026 bot flood.
+This section was rewritten after two claims in the original version turned out to
+be false. Both are recorded here rather than deleted, because the corrected case
+is weaker than the original pitch and anyone revisiting this decision deserves
+the real one.
 
-One `shared-cpu-1x` 1GB machine is ~$5.70/month flat, has no per-request billing
-to weaponize, no invocation cap, no execution-time ceiling, a Postgres pool that
-stays warm, and real Chromium instead of `@sparticuz/chromium`.
+**Retracted 1 — the billing-catastrophe argument does not apply.** The original
+rationale described Netlify's 300-credit shared pool and a hard cap that takes
+the site offline until the 1st. This account is not on that plan. Verified via
+`netlify api listAccountsForUser` (team "Harvous", `type_name: Free`,
+`credit_features: {'included': False}`):
+
+| capability | included |
+|---|---|
+| `bandwidth` | 100 GB |
+| `functions` | 125,000 invocations |
+| `edge_functions` | 1,000,000 invocations |
+| `build_minutes` | 300 |
+| `background_functions` | **True** |
+| `block_builds_when_usage_exceeded` | True |
+
+Separate allowances, not one pool, and **overage blocks builds rather than taking
+the site down**. `background_functions` are also available, so OG render-to-cache
+and longer cron were both achievable on Netlify.
+
+**Retracted 2 — OG rendering was never broken on Netlify.** The original claimed
+the ~35s cold render exceeded `timeout = 26` and silently returned nothing. That
+number was measured on *Fly*, and the Netlify behavior was inferred from it, not
+tested. Measured against live Netlify: **12.9s cold, 6.8s warm, HTTP 200, real
+PNG.** Netlify's function had 3008MB — and therefore more Lambda CPU — than
+Fly's `shared-cpu-1x`, so it is genuinely faster on a cold render.
+
+### The case that actually holds
+
+Measured, both hosts, same method (`curl` `time_total`, distinct unknown tokens):
+
+| | Netlify | Fly |
+|---|---|---|
+| `/api/health` warm | 250–280ms | **~100ms** |
+| OG render, warm | 6.8s | **2.18s** |
+| OG render, cold | **12.9s** | ~35s, prewarmed at boot so unseen |
+| Monthly | **$0** | ~$5.70 |
+
+The one win that reaches users is **warm OG renders, 6.8s → 2.18s**. Unfurlers
+commonly give up in the 5–10s window, so that is the difference between link
+previews usually working and reliably working. It comes from retaining a browser
+across renders, which is impossible under per-request functions at any price.
+
+Secondary: no 26s ceiling, cron that is not shaped around a 25s Lambda budget, a
+Postgres pool that stays warm, and workarounds deleted rather than added — on
+Netlify the same OG outcome needs a render-to-cache pipeline with an invalidation
+story; here it was ~20 lines and no new state.
 
 **This does not make the app feel faster to tap.** Optimistic mutations and the
 offline queue already paint before the network. Server latency shows up in
 first-load data readiness, offline-queue replay, and cold-start tail latency.
+
+### Honest verdict
+
+A close call, not a rescue. Staying on Netlify was defensible: nothing was
+broken and nothing was at risk. The migration buys measurably better link
+previews, lower API latency, and simpler code, for ~$5.70/month and one machine
+to own.
+
+**The number that should have decided it was never measured:** actual function
+invocations against the 125,000/month allowance, readable only from the Netlify
+dashboard. If usage is a small fraction of that, the headroom argument is moot
+and this is purely a latency-and-code-quality decision. Check it before
+revisiting.
 
 ## What changed in the repo
 
@@ -159,6 +212,16 @@ Rollback is `git revert` of that commit.
   because Netlify's proxy headers caused false 403s. The proxy is still in the
   path until the SPA calls `api.harvous.com` directly, so this is not yet a free
   win.
+
+## Do not "upgrade" the Netlify plan
+
+Netlify may offer to move the account onto its newer credit-based free tier.
+Decline. The legacy plan is more generous on every comparable axis — roughly 6.7×
+the bandwidth (100 GB vs ~15 GB) and ~3× the deploys — and its overage blocks
+builds rather than taking the site offline. The switch is very likely one-way.
+
+Cutting `/api/*` over to Fly makes Netlify usage almost purely static bandwidth,
+which makes the legacy allowance roomier still.
 
 ## Not doing (yet)
 

--- a/fly.toml
+++ b/fly.toml
@@ -4,7 +4,7 @@
 # rewrites /api/* here. Clients (web, native, offline queue) see no change —
 # the origin they call is still app.harvous.com.
 
-app = 'harvous-api'
+app = 'harvous'
 # Colocated with Supabase (aws-1-us-east-1) so the DB round-trip stays short.
 primary_region = 'iad'
 

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,42 @@
+# Harvous API on Fly.io.
+#
+# Netlify keeps serving the SPA and fronting the domain; public/_redirects
+# rewrites /api/* here. Clients (web, native, offline queue) see no change —
+# the origin they call is still app.harvous.com.
+
+app = 'harvous-api'
+# Colocated with Supabase (aws-1-us-east-1) so the DB round-trip stays short.
+primary_region = 'iad'
+
+[build]
+
+[env]
+  API_PORT = '8080'
+  NODE_ENV = 'production'
+  # Every URL the OG routes emit or screenshot belongs to the SPA, which this
+  # host does not serve. Without this they would derive the Fly hostname from
+  # the proxied request and capture a page that does not exist here.
+  PUBLIC_APP_ORIGIN = 'https://app.harvous.com'
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  # One always-on machine: stopping it would reintroduce the cold starts this
+  # move exists to remove.
+  auto_stop_machines = 'off'
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ['app']
+
+  [[http_service.checks]]
+    grace_period = '20s'
+    interval = '30s'
+    method = 'GET'
+    timeout = '5s'
+    path = '/api/health'
+
+[[vm]]
+  size = 'shared-cpu-1x'
+  # 1GB rather than 512MB because OG screenshots run Chromium in this process.
+  memory = '1gb'
+  cpus = 1

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build:api": "node scripts/generate-founder-letter.js && esbuild server/netlify.ts --bundle --platform=node --target=node22 --format=cjs --alias:@=src --alias:punycode=./node_modules/punycode/punycode.js --loader:.md=text --outfile=netlify/functions/api.cjs && esbuild server/netlify-purge-shared-spaces.ts --bundle --platform=node --target=node22 --format=cjs --alias:@=src --alias:punycode=./node_modules/punycode/punycode.js --loader:.md=text --outfile=netlify/functions/purge-shared-spaces.cjs && esbuild server/netlify-audienceful-activity-sync.ts --bundle --platform=node --target=node22 --format=cjs --alias:@=src --alias:punycode=./node_modules/punycode/punycode.js --loader:.md=text --outfile=netlify/functions/audienceful-activity-sync.cjs && esbuild server/og-image-function.ts --bundle --platform=node --target=node22 --format=cjs --external:@sparticuz/chromium --outfile=netlify/functions/og-image.cjs",
     "dev:spa": "node scripts/sync-appearance-image-presets.js && vite",
     "dev:prod-spa": "VITE_CLERK_PUBLISHABLE_KEY=pk_live_Y2xlcmsuaGFydm91cy5jb20k VITE_API_PROXY_TARGET=https://app.harvous.com vite",
+    "build:fly": "node scripts/generate-founder-letter.js && esbuild server/fly.ts --bundle --platform=node --target=node22 --format=cjs --alias:@=src --alias:punycode=./node_modules/punycode/punycode.js --loader:.md=text --external:@sparticuz/chromium --outfile=dist-server/api.cjs",
     "build:spa": "vite build",
     "preview:spa": "vite preview",
     "build:native": "npm run build:spa && node_modules/.bin/cap sync",

--- a/scripts/fly-secrets-from-netlify.sh
+++ b/scripts/fly-secrets-from-netlify.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Copy the server secrets that live only in Netlify straight into the Fly app.
+#
+# Netlify's dashboard masks these (last 4 characters only) and `netlify
+# env:list` reports them empty, but `netlify env:get NAME --context production`
+# returns the real value — they are scoped to the production context, and the
+# CLI's default context does not carry them.
+#
+# Values are piped from one CLI to the other and never printed. The script
+# reports names and outcomes only.
+#
+# Usage:  bash scripts/fly-secrets-from-netlify.sh            # copy them
+#         DRY_RUN=1 bash scripts/fly-secrets-from-netlify.sh  # report only
+#
+# Requires: netlify + fly CLIs, both authenticated. Safe to re-run.
+
+set -uo pipefail
+
+CONTEXT="${NETLIFY_CONTEXT:-production}"
+FLY_APP="${FLY_APP:-harvous}"
+
+# Server variables that were NOT found in .env — see scripts/fly-secrets-import.sh.
+NETLIFY_ONLY_VARS=(
+  VOTD_CRON_SECRET
+  HMC_SYNC_CRON_SECRET
+  SUPPORT_NOTIFY_SECRET_TOKEN
+  INBOX_RESET_SECRET_TOKEN
+  BACKUP_CRON_SECRET
+  CLERK_AUTHORIZED_PARTIES
+  MIGRATION_KEY
+  SUPPORT_SLACK_WEBHOOK_URL
+  BILLING_TIER_DB_ONLY
+  BACKUP_RETENTION_DAYS
+  LOG_LEVEL
+)
+
+payload=""
+copied=()
+absent=()
+
+for name in "${NETLIFY_ONLY_VARS[@]}"; do
+  value="$(netlify env:get "$name" --context "$CONTEXT" 2>/dev/null | tail -n 1)"
+
+  # A miss prints a sentence ("No value set in the ... context for ..."), so a
+  # real value is distinguished by containing no whitespace and being non-empty.
+  if [[ -z "$value" || "$value" == *" "* ]]; then
+    absent+=("$name")
+    continue
+  fi
+
+  payload+="${name}=${value}"$'\n'
+  copied+=("$name")
+done
+
+echo "Context: ${CONTEXT}   Fly app: ${FLY_APP}"
+echo "Found in Netlify (${#copied[@]}): ${copied[*]:-none}"
+echo "Not set in Netlify (${#absent[@]}): ${absent[*]:-none}"
+
+if [[ ${#absent[@]} -gt 0 ]]; then
+  echo
+  echo "Those are not in Netlify either — they exist nowhere. If a job depends on"
+  echo "one (BACKUP_CRON_SECRET does), generate a value and set it on BOTH sides:"
+  echo "  openssl rand -hex 32"
+  echo "  fly secrets set NAME=value --app ${FLY_APP}"
+  echo "  ...and the same value as a GitHub Actions repository secret."
+fi
+
+if [[ ${#copied[@]} -eq 0 ]]; then
+  echo
+  echo "Nothing to copy."
+  exit 0
+fi
+
+if [[ "${DRY_RUN:-}" == "1" ]]; then
+  echo
+  echo "DRY_RUN=1 — nothing sent."
+  exit 0
+fi
+
+printf '%s' "$payload" | fly secrets import --app "$FLY_APP"
+echo "Done. Verify with: fly secrets list --app ${FLY_APP}"

--- a/scripts/fly-secrets-from-netlify.sh
+++ b/scripts/fly-secrets-from-netlify.sh
@@ -2,10 +2,15 @@
 #
 # Copy the server secrets that live only in Netlify straight into the Fly app.
 #
-# Netlify's dashboard masks these (last 4 characters only) and `netlify
-# env:list` reports them empty, but `netlify env:get NAME --context production`
-# returns the real value — they are scoped to the production context, and the
-# CLI's default context does not carry them.
+# Values come from `netlify env:list --json`, which returns the real value for
+# variables Netlify will disclose.
+#
+# Do NOT use `netlify env:get` here. For secret-marked variables it returns a
+# 20-character masked stand-in rather than the value, with no error and no
+# visible difference — an earlier version of this script used it and wrote
+# masks into Fly. Anything env:list reports as empty is genuinely unreadable and
+# must be rotated instead of copied; this script reports those rather than
+# writing a placeholder.
 #
 # Values are piped from one CLI to the other and never printed. The script
 # reports names and outcomes only.
@@ -35,40 +40,47 @@ NETLIFY_ONLY_VARS=(
   LOG_LEVEL
 )
 
-payload=""
-copied=()
-absent=()
+payload="$(
+  netlify env:list --json 2>/dev/null | NAMES="${NETLIFY_ONLY_VARS[*]}" python3 -c '
+import json, os, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+readable, unreadable = [], []
+lines = []
+for name in os.environ["NAMES"].split():
+    v = d.get(name)
+    if isinstance(v, str) and v:
+        lines.append(f"{name}={v}")
+        readable.append(name)
+    else:
+        unreadable.append(name)
+sys.stderr.write("READABLE=" + " ".join(readable) + "\n")
+sys.stderr.write("UNREADABLE=" + " ".join(unreadable) + "\n")
+sys.stdout.write("\n".join(lines) + ("\n" if lines else ""))
+' 2>/tmp/fly-secrets-report.txt
+)"
 
-for name in "${NETLIFY_ONLY_VARS[@]}"; do
-  value="$(netlify env:get "$name" --context "$CONTEXT" 2>/dev/null | tail -n 1)"
+readable="$(grep '^READABLE=' /tmp/fly-secrets-report.txt 2>/dev/null | cut -d= -f2-)"
+unreadable="$(grep '^UNREADABLE=' /tmp/fly-secrets-report.txt 2>/dev/null | cut -d= -f2-)"
+rm -f /tmp/fly-secrets-report.txt
 
-  # A miss prints a sentence ("No value set in the ... context for ..."), so a
-  # real value is distinguished by containing no whitespace and being non-empty.
-  if [[ -z "$value" || "$value" == *" "* ]]; then
-    absent+=("$name")
-    continue
-  fi
+echo "Fly app: ${FLY_APP}"
+echo "Readable from Netlify: ${readable:-none}"
+echo "NOT readable:          ${unreadable:-none}"
 
-  payload+="${name}=${value}"$'\n'
-  copied+=("$name")
-done
-
-echo "Context: ${CONTEXT}   Fly app: ${FLY_APP}"
-echo "Found in Netlify (${#copied[@]}): ${copied[*]:-none}"
-echo "Not set in Netlify (${#absent[@]}): ${absent[*]:-none}"
-
-if [[ ${#absent[@]} -gt 0 ]]; then
+if [[ -n "${unreadable// }" ]]; then
   echo
-  echo "Those are not in Netlify either — they exist nowhere. If a job depends on"
-  echo "one (BACKUP_CRON_SECRET does), generate a value and set it on BOTH sides:"
-  echo "  openssl rand -hex 32"
-  echo "  fly secrets set NAME=value --app ${FLY_APP}"
-  echo "  ...and the same value as a GitHub Actions repository secret."
+  echo "Those are write-only in Netlify — the real value cannot be retrieved by"
+  echo "anyone, so they cannot be copied. Rotate each one instead: generate a new"
+  echo "value and set it in every place that uses it (GitHub if a workflow sends"
+  echo "it, Netlify, and Fly), the way scripts/set-backup-cron-secret.sh does."
 fi
 
-if [[ ${#copied[@]} -eq 0 ]]; then
+if [[ -z "${payload// }" ]]; then
   echo
-  echo "Nothing to copy."
+  echo "Nothing readable to copy."
   exit 0
 fi
 

--- a/scripts/fly-secrets-import.sh
+++ b/scripts/fly-secrets-import.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Push the server-side secrets from .env into the Fly app.
+#
+# Only the variables the API actually reads are sent — VITE_* are build-time SPA
+# values that belong in Netlify, and anything not on this list is either unused
+# by the server or set declaratively in fly.toml (NODE_ENV, API_PORT,
+# PUBLIC_APP_ORIGIN, CHROME_EXECUTABLE_PATH).
+#
+# Usage:  bash scripts/fly-secrets-import.sh [path-to-env]   # default: .env
+#         DRY_RUN=1 bash scripts/fly-secrets-import.sh       # list names only
+#
+# Safe to re-run: `fly secrets import` upserts. It restarts the machine once for
+# the whole batch rather than once per secret.
+#
+# IMPORTANT: .env is NOT the full production environment. Several variables —
+# notably the cron secrets the GitHub scheduled workflows authenticate with
+# (VOTD_CRON_SECRET, BACKUP_CRON_SECRET, HMC_SYNC_CRON_SECRET,
+# AUTO_ARCHIVE_SECRET_TOKEN, INBOX_RESET_SECRET_TOKEN, SUPPORT_NOTIFY_SECRET_TOKEN)
+# — are set only in the Netlify dashboard. This script reports what it could not
+# find; copy those from Netlify → Site settings → Environment variables and set
+# them with `fly secrets set NAME=value` before cutover, or those jobs 401.
+
+set -euo pipefail
+
+ENV_FILE="${1:-.env}"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "error: $ENV_FILE not found" >&2
+  exit 1
+fi
+
+# Every process.env.* the server reads, minus the ones fly.toml sets.
+SERVER_VARS=(
+  ANTHROPIC_API_KEY
+  AUDIENCEFUL_API_KEY
+  AUTO_ARCHIVE_SECRET_TOKEN
+  BACKUP_CRON_SECRET
+  BACKUP_RETENTION_DAYS
+  BETTERSTACK_STATUS_JSON_URL
+  BILLING_TIER_DB_ONLY
+  CLERK_AUTHORIZED_PARTIES
+  CLERK_SECRET_KEY
+  CLERK_WEBHOOK_SECRET
+  HARVOUS_ADMIN_EMAILS
+  HARVOUS_ADMIN_SECRET
+  HARVOUS_ADMIN_USER_IDS
+  HARVOUS_SYSTEM_USER_ID
+  HERESMYCHURCH_ANON_KEY
+  HERESMYCHURCH_API_BASE
+  HERESMYCHURCH_PARTNER_API_KEY
+  HMC_SYNC_CRON_SECRET
+  INBOX_RESET_SECRET_TOKEN
+  LOG_LEVEL
+  MIGRATION_KEY
+  POLAR_ACCESS_TOKEN
+  POLAR_ENV
+  POLAR_WEBHOOK_SECRET
+  POLAR_WEBHOOK_URL
+  SUBJECTS_BIBLE
+  SUBJECTS_MODEL
+  SUPABASE_DATABASE_URL
+  SUPABASE_DIRECT_URL
+  SUPABASE_SERVICE_ROLE_KEY
+  SUPABASE_URL
+  SUPPORT_NOTIFY_SECRET_TOKEN
+  SUPPORT_SLACK_WEBHOOK_URL
+  VOTD_CRON_SECRET
+)
+
+payload=""
+found=0
+missing=()
+
+for name in "${SERVER_VARS[@]}"; do
+  # Last definition wins, matching dotenv; strip optional surrounding quotes.
+  line="$(grep -E "^${name}=" "$ENV_FILE" | tail -n 1 || true)"
+  if [[ -z "$line" ]]; then
+    missing+=("$name")
+    continue
+  fi
+  value="${line#*=}"
+  value="${value%\"}"; value="${value#\"}"
+  value="${value%\'}"; value="${value#\'}"
+  payload+="${name}=${value}"$'\n'
+  found=$((found + 1))
+done
+
+echo "Found ${found}/${#SERVER_VARS[@]} server variables in ${ENV_FILE}."
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "Not set locally (skipped): ${missing[*]}"
+fi
+
+if [[ "${DRY_RUN:-}" == "1" ]]; then
+  echo "DRY_RUN=1 — names only, no values sent:"
+  printf '%s\n' "$payload" | cut -d= -f1 | sed '/^$/d' | sed 's/^/  /'
+  exit 0
+fi
+
+printf '%s' "$payload" | fly secrets import
+echo "Done. Verify with: fly secrets list"

--- a/scripts/rotate-shared-secret.sh
+++ b/scripts/rotate-shared-secret.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Rotate one shared secret to a fresh value everywhere it is used.
+#
+# A "shared secret" here is a bearer token a caller sends and a server checks —
+# the GitHub scheduled workflows and the /api/admin/* endpoints they hit. Every
+# copy must be byte-identical or the call 401s.
+#
+# Rotation, rather than copying, is the only option for Netlify variables marked
+# secret: `netlify env:list --json` reports them empty and `netlify env:get`
+# returns a 20-character MASK rather than the value, with no error. Nobody can
+# read them back, so a new value is the only way to make all sides agree.
+#
+# Generated once into a shell variable and pushed to each target, so no manual
+# copy/paste can make them disagree. The value is never printed.
+#
+# Usage:
+#   bash scripts/rotate-shared-secret.sh VOTD_CRON_SECRET
+#   bash scripts/rotate-shared-secret.sh VOTD_CRON_SECRET --no-github
+#
+# Requires gh, netlify and fly CLIs, all authenticated.
+
+set -euo pipefail
+
+NAME="${1:-}"
+if [[ -z "$NAME" ]]; then
+  echo "usage: bash scripts/rotate-shared-secret.sh <SECRET_NAME> [--no-github]" >&2
+  exit 1
+fi
+
+REPO="${REPO:-harvouscom/harvous}"
+FLY_APP="${FLY_APP:-harvous}"
+WITH_GITHUB=1
+[[ "${2:-}" == "--no-github" ]] && WITH_GITHUB=0
+
+SECRET="$(openssl rand -hex 32)"
+
+echo "Rotating ${NAME} to a fresh 64-character value…"
+
+if [[ "$WITH_GITHUB" == "1" ]]; then
+  echo "  GitHub Actions…"
+  gh secret set "$NAME" --repo "$REPO" --body "$SECRET"
+else
+  echo "  GitHub… skipped (--no-github)"
+fi
+
+# Output is never suppressed: netlify env:set prompts before overwriting, and
+# hiding that makes this look hung.
+echo "  Netlify (production context)…"
+netlify env:set "$NAME" "$SECRET" --context production --force
+
+echo "  Fly (restarts the machine, ~40s)…"
+fly secrets set "${NAME}=${SECRET}" --app "$FLY_APP"
+
+unset SECRET
+
+echo
+echo "Done. ${NAME} now holds the same fresh value in each target."
+echo
+echo "Netlify Functions capture env vars at deploy time, so the live site keeps"
+echo "the OLD value until its next deploy. Fly picked this up on restart."

--- a/scripts/set-backup-cron-secret.sh
+++ b/scripts/set-backup-cron-secret.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Set BACKUP_CRON_SECRET to one fresh value in all three places that must agree:
+#
+#   GitHub  — the nightly workflow that SENDS it
+#   Netlify — the server that CHECKS it today
+#   Fly     — the server that CHECKS it after the /api/* cutover
+#
+# Generated once into a shell variable and pushed to all three, so no manual
+# copy/paste can make them disagree. The value is never printed.
+#
+# Requires gh, netlify and fly CLIs, all authenticated.
+# Usage:  bash scripts/set-backup-cron-secret.sh
+
+set -euo pipefail
+
+REPO="${REPO:-harvouscom/harvous}"
+FLY_APP="${FLY_APP:-harvous}"
+
+SECRET="$(openssl rand -hex 32)"
+
+echo "Generated a 64-character secret. Setting it in three places…"
+
+echo "  1/3 GitHub Actions…"
+gh secret set BACKUP_CRON_SECRET --repo "$REPO" --body "$SECRET"
+
+echo "  2/3 Netlify (production context)…"
+netlify env:set BACKUP_CRON_SECRET "$SECRET" --context production >/dev/null
+
+echo "  3/3 Fly (restarts the machine)…"
+fly secrets set "BACKUP_CRON_SECRET=$SECRET" --app "$FLY_APP" >/dev/null
+
+unset SECRET
+
+echo
+echo "Done — all three now hold the same value."
+echo
+echo "NOTE: Netlify Functions read env vars captured at deploy time, so the live"
+echo "site keeps the OLD value until the next deploy. Trigger one, or wait for"
+echo "your next push, before expecting the nightly job to succeed against Netlify."
+echo
+echo "Verify against Fly (already live, no redeploy needed):"
+echo "  bash scripts/verify-backup-cron-secret.sh"

--- a/scripts/set-backup-cron-secret.sh
+++ b/scripts/set-backup-cron-secret.sh
@@ -21,14 +21,17 @@ SECRET="$(openssl rand -hex 32)"
 
 echo "Generated a 64-character secret. Setting it in three places…"
 
+# Output is deliberately NOT suppressed on any of these: netlify env:set prompts
+# before overwriting an existing value, and hiding that makes the script look
+# hung. --force skips the prompt; the visible output is the backstop.
 echo "  1/3 GitHub Actions…"
 gh secret set BACKUP_CRON_SECRET --repo "$REPO" --body "$SECRET"
 
 echo "  2/3 Netlify (production context)…"
-netlify env:set BACKUP_CRON_SECRET "$SECRET" --context production >/dev/null
+netlify env:set BACKUP_CRON_SECRET "$SECRET" --context production --force
 
-echo "  3/3 Fly (restarts the machine)…"
-fly secrets set "BACKUP_CRON_SECRET=$SECRET" --app "$FLY_APP" >/dev/null
+echo "  3/3 Fly (restarts the machine, takes ~40s)…"
+fly secrets set "BACKUP_CRON_SECRET=$SECRET" --app "$FLY_APP"
 
 unset SECRET
 

--- a/scripts/verify-backup-cron-secret.sh
+++ b/scripts/verify-backup-cron-secret.sh
@@ -1,34 +1,58 @@
 #!/usr/bin/env bash
 #
-# Check that BACKUP_CRON_SECRET actually works, without printing it.
+# Verify the nightly backup job actually runs.
 #
-# Reads the value from Netlify (the one place it is readable) and calls both
-# backup endpoints with it. 401 means that host holds a different value; 200
-# means it matches and the job ran.
+# This CANNOT be done by reading the secret and calling the endpoint yourself:
+# Netlify returns a 20-character mask for secret-marked variables via
+# `netlify env:get`, and an earlier version of this script did exactly that and
+# reported two false 401s. GitHub and Fly are write-only, so no copy is readable.
+#
+# The only honest test is to let a party that holds the real value make the call.
+# GitHub Actions does, so this triggers the workflow and reports its outcome.
 #
 # Usage:  bash scripts/verify-backup-cron-secret.sh
 
 set -uo pipefail
 
-FLY_HOST="${FLY_HOST:-https://harvous.fly.dev}"
-NETLIFY_HOST="${NETLIFY_HOST:-https://app.harvous.com}"
+REPO="${REPO:-harvouscom/harvous}"
+WORKFLOW="${WORKFLOW:-backup-user-exports.yml}"
 
-value="$(netlify env:get BACKUP_CRON_SECRET --context production 2>/dev/null | tail -n 1)"
-if [[ -z "$value" || "$value" == *" "* ]]; then
-  echo "BACKUP_CRON_SECRET is not set in Netlify's production context — nothing to test."
+echo "Triggering ${WORKFLOW}…"
+gh workflow run "$WORKFLOW" --repo "$REPO" >/dev/null || {
+  echo "Could not trigger the workflow." >&2
+  exit 1
+}
+
+echo "Waiting for the run to start…"
+sleep 8
+RUN_ID="$(gh run list --repo "$REPO" --workflow "$WORKFLOW" --limit 1 --json databaseId --jq '.[0].databaseId')"
+if [[ -z "$RUN_ID" ]]; then
+  echo "Could not find the run." >&2
   exit 1
 fi
-echo "Read the value from Netlify (${#value} chars). Testing both hosts…"
+echo "Run ${RUN_ID} — waiting for it to finish…"
 
-for host in "$FLY_HOST" "$NETLIFY_HOST"; do
-  body=$(mktemp)
-  code=$(curl -s -o "$body" -w "%{http_code}" -X POST "${host}/api/admin/backup-exports" \
-    -H "Authorization: Bearer $value" --max-time 300)
-  case "$code" in
-    200) echo "  $host → 200 OK: $(head -c 200 "$body")" ;;
-    401) echo "  $host → 401: this host holds a DIFFERENT value (Netlify Functions need a redeploy to pick up env changes)" ;;
-    503) echo "  $host → 503: secret matched, but storage is unconfigured — check the private user-exports bucket" ;;
-    *)   echo "  $host → $code: $(head -c 200 "$body")" ;;
-  esac
-  rm -f "$body"
+while true; do
+  state="$(gh run view "$RUN_ID" --repo "$REPO" --json status,conclusion \
+            --jq '.status+" "+(.conclusion // "")' 2>/dev/null)"
+  [[ "$state" == completed* ]] && break
+  sleep 10
 done
+echo "Result: ${state}"
+echo
+
+gh run view "$RUN_ID" --repo "$REPO" --log 2>/dev/null \
+  | grep -iE "skipping backup|exported|usersWithNotes|HTTP [0-9]{3}|Unauthorized|not configured" \
+  | head -5
+
+cat <<'EOF'
+
+Reading the result:
+  "exported": N            the job ran and wrote to the user-exports bucket
+  "skipping backup"        BACKUP_CRON_SECRET is missing from GitHub
+  HTTP 401                 GitHub's value and the server's do not match. If you
+                           only just changed it, Netlify Functions capture env
+                           vars at DEPLOY time — redeploy, then retry.
+  HTTP 503                 secret matched, but storage is unconfigured: check
+                           the private user-exports bucket exists in Supabase
+EOF

--- a/scripts/verify-backup-cron-secret.sh
+++ b/scripts/verify-backup-cron-secret.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Check that BACKUP_CRON_SECRET actually works, without printing it.
+#
+# Reads the value from Netlify (the one place it is readable) and calls both
+# backup endpoints with it. 401 means that host holds a different value; 200
+# means it matches and the job ran.
+#
+# Usage:  bash scripts/verify-backup-cron-secret.sh
+
+set -uo pipefail
+
+FLY_HOST="${FLY_HOST:-https://harvous.fly.dev}"
+NETLIFY_HOST="${NETLIFY_HOST:-https://app.harvous.com}"
+
+value="$(netlify env:get BACKUP_CRON_SECRET --context production 2>/dev/null | tail -n 1)"
+if [[ -z "$value" || "$value" == *" "* ]]; then
+  echo "BACKUP_CRON_SECRET is not set in Netlify's production context — nothing to test."
+  exit 1
+fi
+echo "Read the value from Netlify (${#value} chars). Testing both hosts…"
+
+for host in "$FLY_HOST" "$NETLIFY_HOST"; do
+  body=$(mktemp)
+  code=$(curl -s -o "$body" -w "%{http_code}" -X POST "${host}/api/admin/backup-exports" \
+    -H "Authorization: Bearer $value" --max-time 300)
+  case "$code" in
+    200) echo "  $host → 200 OK: $(head -c 200 "$body")" ;;
+    401) echo "  $host → 401: this host holds a DIFFERENT value (Netlify Functions need a redeploy to pick up env changes)" ;;
+    503) echo "  $host → 503: secret matched, but storage is unconfigured — check the private user-exports bucket" ;;
+    *)   echo "  $host → $code: $(head -c 200 "$body")" ;;
+  esac
+  rm -f "$body"
+done

--- a/server/constants/dev-featured-samples.ts
+++ b/server/constants/dev-featured-samples.ts
@@ -27,9 +27,13 @@ export const ALL_SAMPLE_FEATURED_IDS = [
 /** Same IDs; used by featured feed filter */
 export const DEV_SAMPLE_FEATURED_ITEM_IDS: string[] = [...ALL_SAMPLE_FEATURED_IDS];
 
-/** Netlify Functions or explicit production Node build — never treat as local dev. */
+/** Any deployed host (Netlify, Fly) or explicit production build — never treat as local dev. */
 export function isDeployedProductionLike(): boolean {
-  return process.env.NODE_ENV === 'production' || process.env.NETLIFY === 'true';
+  return (
+    process.env.NODE_ENV === 'production' ||
+    process.env.NETLIFY === 'true' ||
+    !!process.env.FLY_APP_NAME
+  );
 }
 
 export function getInboundHost(c: Context): string {
@@ -78,16 +82,10 @@ export function featuredSampleSeedForbiddenResponse(c: Context): Response | null
   return null;
 }
 
-/** Block destructive / non-featured test routes (stricter than NODE_ENV alone — Netlify may omit it). */
+/** Block destructive / non-featured test routes (stricter than NODE_ENV alone — a host may omit it). */
 export function isTestRoutesForbidden(): boolean {
   if (process.env.HARVOUS_ALLOW_TEST_API_ROUTES === 'true') {
     return false;
   }
-  if (process.env.NODE_ENV === 'production') {
-    return true;
-  }
-  if (process.env.NETLIFY === 'true') {
-    return true;
-  }
-  return false;
+  return isDeployedProductionLike();
 }

--- a/server/fly.ts
+++ b/server/fly.ts
@@ -17,12 +17,22 @@ async function main() {
   const { default: app } = await import('./app');
   const { warmPostgresConnection } = await import('./db/client');
   const { startScheduler } = await import('./scheduler');
+  const { prewarmOgRenderer } = await import('./utils/og-screenshot');
 
   await warmPostgresConnection();
 
   const server = serve({ fetch: app.fetch, port, hostname: '0.0.0.0' }, () => {
     console.log(`[fly] Hono API listening on 0.0.0.0:${port}`);
   });
+
+  // Deliberately after listen and deliberately not awaited: a cold OG render
+  // takes ~34s, which would fail the health check if it gated startup. The
+  // token is well-formed but unknown, so this renders the error card through
+  // the real path — warming Chromium, the SPA fetch, and V8's code cache.
+  const appOrigin = process.env.PUBLIC_APP_ORIGIN?.trim();
+  if (appOrigin) {
+    void prewarmOgRenderer(`${appOrigin}/shared/note/aaaaaaaaaaaa?ogCapture=1`);
+  }
 
   const stopScheduler = startScheduler();
 

--- a/server/fly.ts
+++ b/server/fly.ts
@@ -1,0 +1,59 @@
+/**
+ * Production server entry point (Fly.io).
+ *
+ * The long-lived counterpart to server/netlify.ts: instead of wrapping the Hono
+ * app in a per-request function handler, it serves the app from one Node process
+ * and runs the daily jobs in-process (see server/scheduler.ts).
+ *
+ * Secrets come from the platform, so there is no dotenv step — but the dynamic
+ * imports from server/dev.ts are kept anyway: several modules read config during
+ * module init, and importing them lazily keeps startup ordering explicit.
+ */
+
+const port = Number(process.env.API_PORT ?? 8080);
+
+async function main() {
+  const { serve } = await import('@hono/node-server');
+  const { default: app } = await import('./app');
+  const { warmPostgresConnection } = await import('./db/client');
+  const { startScheduler } = await import('./scheduler');
+
+  await warmPostgresConnection();
+
+  const server = serve({ fetch: app.fetch, port, hostname: '0.0.0.0' }, () => {
+    console.log(`[fly] Hono API listening on 0.0.0.0:${port}`);
+  });
+
+  const stopScheduler = startScheduler();
+
+  // Fly sends SIGTERM and waits before killing the machine. Stop accepting new
+  // connections and let in-flight requests finish; a stuck drain must not
+  // outlive the grace period, hence the timer.
+  let shuttingDown = false;
+  const shutdown = (signal: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`[fly] ${signal} received, draining`);
+    stopScheduler();
+
+    const force = setTimeout(() => {
+      console.warn('[fly] drain timed out, exiting anyway');
+      process.exit(0);
+    }, 10_000);
+    force.unref();
+
+    server.close(() => {
+      clearTimeout(force);
+      console.log('[fly] drained cleanly');
+      process.exit(0);
+    });
+  };
+
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+}
+
+main().catch((error) => {
+  console.error('[fly] fatal startup error:', error);
+  process.exit(1);
+});

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -29,7 +29,12 @@
 
 import { Hono } from 'hono';
 import { repairMissingNoteThreadJunctionsForUser } from '../utils/thread-junction-repair';
-import { getStore } from '@netlify/blobs';
+import {
+  deleteUserExports,
+  isUserExportBackupConfigured,
+  listUserExportKeys,
+  putUserExport,
+} from '../utils/user-export-backup-store';
 import { getAuth, getAuthenticatedAuth, requireAuth } from '../middleware/auth';
 import {
   db,
@@ -403,10 +408,10 @@ app.post('/api/admin/aggregate-analytics', handleAggregateAnalytics);
 app.get('/api/admin/aggregate-analytics', handleAggregateAnalytics);
 
 // ─── POST /api/admin/backup-exports ────────────────────────────────────
-// Scheduled job: export each user with notes to Netlify Blob (CSV), then run retention.
+// Scheduled job: export each user with notes to the private `user-exports`
+// Supabase bucket (CSV), then run retention.
 // Env: BACKUP_CRON_SECRET. Retention: BACKUP_RETENTION_DAYS (default 30).
 
-const BACKUP_STORE_NAME = 'user-exports';
 const DEFAULT_RETENTION_DAYS = 30;
 
 app.post('/api/admin/backup-exports', async (c) => {
@@ -421,7 +426,10 @@ app.post('/api/admin/backup-exports', async (c) => {
     const retentionDays = Math.max(1, parseInt(process.env.BACKUP_RETENTION_DAYS || String(DEFAULT_RETENTION_DAYS), 10) || DEFAULT_RETENTION_DAYS);
     const date = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
 
-    const store = getStore({ name: BACKUP_STORE_NAME });
+    if (!isUserExportBackupConfigured()) {
+      return c.json({ error: 'Backup storage is not configured', success: false }, 503);
+    }
+
     const userIdRows = await db.select({ userId: Notes.userId }).from(Notes);
     const userIds = [...new Set(userIdRows.map((r) => r.userId))];
 
@@ -431,7 +439,7 @@ app.post('/api/admin/backup-exports', async (c) => {
       try {
         const { content, fileExtension } = await generateUserExport(userId, 'csv-threads');
         const key = `${userId}/${date}.${fileExtension}`;
-        await store.set(key, content, { metadata: { contentType: 'text/csv' } });
+        await putUserExport(key, content);
         exported++;
       } catch (e) {
         errors.push(`${userId}: ${e instanceof Error ? e.message : String(e)}`);
@@ -441,16 +449,12 @@ app.post('/api/admin/backup-exports', async (c) => {
     const cutoff = new Date();
     cutoff.setDate(cutoff.getDate() - retentionDays);
     const cutoffStr = cutoff.toISOString().split('T')[0];
-    let deleted = 0;
-    const listResult = await store.list();
-    for (const blob of listResult.blobs ?? []) {
-      const key = blob.key;
+    const expired = (await listUserExportKeys()).filter((key) => {
       const match = key.match(/^[^/]+\/(\d{4}-\d{2}-\d{2})\.(csv|md)$/);
-      if (match && match[1] < cutoffStr) {
-        await store.delete(key);
-        deleted++;
-      }
-    }
+      return !!match && match[1] < cutoffStr;
+    });
+    await deleteUserExports(expired);
+    const deleted = expired.length;
 
     return c.json({
       success: true,

--- a/server/routes/notes.ts
+++ b/server/routes/notes.ts
@@ -29,6 +29,7 @@
 
 import { appendFileSync } from 'node:fs';
 import { Hono } from 'hono';
+import { isDeployedProductionLike } from '../constants/dev-featured-samples';
 import { getAuthenticatedAuth, requireAuth, requireParam } from '../middleware/auth';
 import {
   db, Notes, Threads, NoteThreads, StudyThreadEntries, Comments, Tags, NoteTags,
@@ -898,11 +899,12 @@ route.post('/api/notes/create', requireAuth, rateLimitNoteCreate(), async (c) =>
  * `origin` is threaded from the client (e.g. "proto-autosave#k3f9a2") so two writers
  * from different editor instances are distinguishable from one instance double-firing.
  *
- * Gated off on Netlify; no-ops silently if the file isn't writable.
+ * Gated off on any deployed host — a container filesystem is not a place to
+ * append a line per note save. No-ops silently if the file isn't writable.
  */
 const NOTE_SAVE_TRAIL_PATH = '.dev-note-saves.log';
 function logNoteSaveTrail(entry: Record<string, unknown>): void {
-  if (process.env.NETLIFY) return;
+  if (isDeployedProductionLike()) return;
   try {
     appendFileSync(
       NOTE_SAVE_TRAIL_PATH,

--- a/server/routes/og.ts
+++ b/server/routes/og.ts
@@ -8,7 +8,14 @@
  *   GET /api/og/image/thread/:shareToken  — 1200×630 PNG (screenshot only)
  *
  * Production Netlify prefers the dedicated `og-image` function (Chromium) via
- * public/_redirects. These Hono routes power local `dev:api`.
+ * public/_redirects. These Hono routes power local `dev:api`, and become the
+ * production path once /api/* proxies to Fly.
+ *
+ * Origins here come from getPublicAppOrigin(), never from the request URL: every
+ * URL these routes emit or screenshot belongs to the SPA, which is served by a
+ * different host than the API once the API is proxied. The request host is the
+ * API's, so deriving from it would produce canonical/image URLs and capture
+ * targets pointing at a host with no app on it.
  *
  * No generated-card fallback — if the screenshot fails, the image route 404s
  * (crawlers unfurl title/description without a preview image).
@@ -31,6 +38,7 @@ import {
 import { isValidShareToken } from '@/utils/ids';
 import { rateLimit } from '@/utils/rate-limit';
 import { renderShareOgHtml, renderNotFoundOgHtml } from '../utils/og-html';
+import { getPublicAppOrigin } from '../utils/public-app-origin';
 import {
   noteOgDescription,
   noteOgTitle,
@@ -152,7 +160,7 @@ function noImageResponse(): Response {
 
 route.get('/api/og/share/note/:shareToken', rateLimit('read'), async (c) => {
   const shareToken = c.req.param('shareToken');
-  const origin = new URL(c.req.url).origin;
+  const origin = getPublicAppOrigin(c);
   const canonicalUrl = `${origin}/shared/note/${shareToken}`;
 
   if (!isValidShareToken(shareToken)) {
@@ -182,7 +190,7 @@ route.get('/api/og/share/note/:shareToken', rateLimit('read'), async (c) => {
 
 route.get('/api/og/share/thread/:shareToken', rateLimit('read'), async (c) => {
   const shareToken = c.req.param('shareToken');
-  const origin = new URL(c.req.url).origin;
+  const origin = getPublicAppOrigin(c);
   const canonicalUrl = `${origin}/shared/thread/${shareToken}`;
 
   if (!isValidShareToken(shareToken)) {
@@ -212,7 +220,7 @@ route.get('/api/og/share/thread/:shareToken', rateLimit('read'), async (c) => {
 
 route.get('/api/og/image/note/:shareToken', rateLimit('read'), async (c) => {
   const shareToken = c.req.param('shareToken');
-  const origin = new URL(c.req.url).origin;
+  const origin = getPublicAppOrigin(c);
 
   if (!isValidShareToken(shareToken)) {
     return noImageResponse();
@@ -224,7 +232,7 @@ route.get('/api/og/image/note/:shareToken', rateLimit('read'), async (c) => {
 
 route.get('/api/og/image/thread/:shareToken', rateLimit('read'), async (c) => {
   const shareToken = c.req.param('shareToken');
-  const origin = new URL(c.req.url).origin;
+  const origin = getPublicAppOrigin(c);
 
   if (!isValidShareToken(shareToken)) {
     return noImageResponse();

--- a/server/scheduler.ts
+++ b/server/scheduler.ts
@@ -1,0 +1,81 @@
+/**
+ * In-process daily jobs.
+ *
+ * On Netlify these were two separate scheduled functions declared in netlify.toml
+ * (`purge-shared-spaces`, `audienceful-activity-sync`). A long-lived process runs
+ * them itself, which also lifts the 25s Lambda time budgets both were written
+ * around — see the timeBudgetMs override below.
+ *
+ * Jobs are fire-and-forget: a throw is logged and the schedule continues. Missing
+ * a run is tolerable for both (@daily, both idempotent).
+ */
+
+import { runAudiencefulActivitySync } from './netlify-audienceful-activity-sync';
+import { createPurgeSharedSpacesHandler } from './netlify-purge-shared-spaces';
+
+/** Netlify ran both at 00:00 UTC (`schedule = "@daily"`). Keep that. */
+const DAILY_UTC_HOUR = 0;
+
+/** No Lambda ceiling here, so let the Clerk→Audienceful pagination finish. */
+const AUDIENCEFUL_TIME_BUDGET_MS = 5 * 60_000;
+
+type Job = { name: string; run: () => Promise<unknown> };
+
+const JOBS: Job[] = [
+  {
+    name: 'purge-shared-spaces',
+    run: createPurgeSharedSpacesHandler(),
+  },
+  {
+    name: 'audienceful-activity-sync',
+    run: () => runAudiencefulActivitySync({ timeBudgetMs: AUDIENCEFUL_TIME_BUDGET_MS }),
+  },
+];
+
+function msUntilNextRun(now = new Date()): number {
+  const next = new Date(now);
+  next.setUTCHours(DAILY_UTC_HOUR, 0, 0, 0);
+  if (next <= now) next.setUTCDate(next.getUTCDate() + 1);
+  return next.getTime() - now.getTime();
+}
+
+async function runAll(): Promise<void> {
+  for (const job of JOBS) {
+    const startedAt = Date.now();
+    try {
+      await job.run();
+      console.log(`[scheduler] ${job.name} ok in ${Date.now() - startedAt}ms`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`[scheduler] ${job.name} failed after ${Date.now() - startedAt}ms:`, message);
+    }
+  }
+}
+
+/**
+ * Arm the daily timer. Returns a stop function for shutdown.
+ *
+ * Timers are unref'd so a pending wake-up never holds the process open during
+ * a SIGTERM drain.
+ */
+export function startScheduler(): () => void {
+  let timer: NodeJS.Timeout;
+  let stopped = false;
+
+  const arm = () => {
+    if (stopped) return;
+    const delay = msUntilNextRun();
+    timer = setTimeout(() => {
+      void runAll().finally(arm);
+    }, delay);
+    timer.unref();
+    console.log(`[scheduler] next run in ${Math.round(delay / 60_000)}m`);
+  };
+
+  arm();
+
+  return () => {
+    stopped = true;
+    clearTimeout(timer);
+  };
+}

--- a/server/utils/og-screenshot.ts
+++ b/server/utils/og-screenshot.ts
@@ -1,14 +1,39 @@
 /**
  * Capture a 1200×630 PNG of a public share page for Open Graph.
  *
- * Production (Netlify og-image function): puppeteer-core + @sparticuz/chromium
- * Local (Hono / tsx): system Chrome via CHROME_EXECUTABLE_PATH or platform default
+ * Fly (long-lived process): system Chromium via CHROME_EXECUTABLE_PATH, and the
+ * browser is kept alive between renders — booting one per request cost several
+ * seconds and is the single largest slice of a render.
+ *
+ * Netlify function (still the production path until the /api/* cutover):
+ * puppeteer-core + @sparticuz/chromium, one browser per invocation as before.
+ * Reuse is deliberately not applied there — the process is short-lived, and
+ * changing behavior on the host currently serving production is not worth the
+ * risk during the migration.
+ *
+ * Failure contract: this throws rather than returning a placeholder. Callers
+ * (server/routes/og.ts) turn that into a 404 with X-Og-Source: none, because a
+ * wrong preview image is worse than none.
  */
 
 import puppeteer, { type Browser } from 'puppeteer-core';
 
 const OG_SHOT_WIDTH = 1200;
 const OG_SHOT_HEIGHT = 630;
+
+/**
+ * Concurrent renders. One, deliberately: measured on the 1GB machine, an idle
+ * retained browser already leaves only ~300MB available, and each additional
+ * page holds its own renderer process. OG rendering is crawler traffic, not a
+ * hot path — queueing is cheaper than an OOM kill that takes the API with it.
+ */
+const MAX_CONCURRENT_RENDERS = 1;
+
+/**
+ * Relaunch the browser after this many renders. Long-lived Chromium leaks
+ * slowly; recycling bounds RSS without anyone having to watch it.
+ */
+const RENDERS_BEFORE_RECYCLE = 100;
 
 function isServerlessRuntime(): boolean {
   return !!(
@@ -50,49 +75,164 @@ async function launchBrowser(): Promise<Browser> {
       height: OG_SHOT_HEIGHT,
       deviceScaleFactor: 1,
     },
-    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+    args: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      // Trim what a screenshot-only browser never needs. Matters on a 1GB
+      // machine where the browser is now resident rather than per-request.
+      '--disable-gpu',
+      '--disable-extensions',
+      '--disable-background-networking',
+      '--disable-default-apps',
+      '--disable-sync',
+      '--metrics-recording-only',
+      '--mute-audio',
+      '--no-first-run',
+      '--hide-scrollbars',
+    ],
   });
+}
+
+/**
+ * Warm the render path at startup so the first crawler does not pay for it.
+ *
+ * Measured cold: ~34s, against ~2.5s warm — that is Chromium's first boot plus
+ * the first uncached fetch and parse of the SPA bundle. A throwaway render at
+ * boot moves all of it off the request path. `pageUrl` should be a well-formed
+ * but unknown share URL, which renders the error card through the same code.
+ *
+ * Never throws: warming is an optimization, not a startup requirement.
+ */
+export async function prewarmOgRenderer(pageUrl: string): Promise<void> {
+  if (isServerlessRuntime()) return;
+  // Log on entry as well as exit: a warm takes ~34s, so without this an absent
+  // completion line is ambiguous between skipped, still running, and died.
+  console.log('[og-screenshot] prewarm starting');
+  const startedAt = Date.now();
+  try {
+    await captureShareOgScreenshot(pageUrl);
+    console.log(`[og-screenshot] prewarm ok in ${Date.now() - startedAt}ms`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[og-screenshot] prewarm failed after ${Date.now() - startedAt}ms:`, message);
+  }
+}
+
+// ─── Retained browser (non-serverless only) ──────────────────────────────────
+
+let browserPromise: Promise<Browser> | null = null;
+let rendersOnCurrentBrowser = 0;
+
+async function getRetainedBrowser(): Promise<Browser> {
+  if (browserPromise) {
+    const existing = await browserPromise.catch(() => null);
+    if (existing?.connected && rendersOnCurrentBrowser < RENDERS_BEFORE_RECYCLE) {
+      return existing;
+    }
+    // Crashed, disconnected, or due for recycling. Closing is best-effort; a
+    // dead browser cannot be closed and must not block the relaunch.
+    browserPromise = null;
+    rendersOnCurrentBrowser = 0;
+    if (existing) await existing.close().catch(() => {});
+  }
+
+  const launching = launchBrowser();
+  browserPromise = launching;
+  try {
+    return await launching;
+  } catch (error) {
+    // Never cache a failed launch — the next request should retry.
+    if (browserPromise === launching) browserPromise = null;
+    throw error;
+  }
+}
+
+// ─── Render concurrency ──────────────────────────────────────────────────────
+
+let activeRenders = 0;
+const waiting: Array<() => void> = [];
+
+function acquireRenderSlot(): Promise<void> {
+  if (activeRenders < MAX_CONCURRENT_RENDERS) {
+    activeRenders++;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    waiting.push(() => {
+      activeRenders++;
+      resolve();
+    });
+  });
+}
+
+function releaseRenderSlot(): void {
+  activeRenders--;
+  waiting.shift()?.();
 }
 
 /**
  * Screenshot the top of a public share URL (pass ?ogCapture=1 for clean chrome).
  */
 export async function captureShareOgScreenshot(pageUrl: string): Promise<Buffer> {
-  const browser = await launchBrowser();
+  await acquireRenderSlot();
+
+  // Everything past the acquire must run inside this try, including obtaining
+  // the browser: a throw there would otherwise leak the slot, and after
+  // MAX_CONCURRENT_RENDERS failures the route would wedge for good.
   try {
-    const page = await browser.newPage();
-    await page.setViewport({
-      width: OG_SHOT_WIDTH,
-      height: OG_SHOT_HEIGHT,
-      deviceScaleFactor: 1,
-    });
+    const reuseBrowser = !isServerlessRuntime();
+    const browser = reuseBrowser ? await getRetainedBrowser() : await launchBrowser();
+    if (reuseBrowser) rendersOnCurrentBrowser++;
 
-    // Emulate a normal browser so edge bot-rewrite does not intercept.
-    await page.setUserAgent(
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 HarvousOgCapture/1.0',
-    );
+    try {
+      const page = await browser.newPage();
+      try {
+        await page.setViewport({
+          width: OG_SHOT_WIDTH,
+          height: OG_SHOT_HEIGHT,
+          deviceScaleFactor: 1,
+        });
 
-    await page.goto(pageUrl, {
-      waitUntil: 'networkidle2',
-      timeout: 25_000,
-    });
+        // Emulate a normal browser so edge bot-rewrite does not intercept.
+        await page.setUserAgent(
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 HarvousOgCapture/1.0',
+        );
 
-    await page.waitForSelector(
-      '.public-paper-stack, .public-card, .public-error-card, .public-content',
-      { timeout: 15_000 },
-    );
+        // domcontentloaded, not networkidle2: the SPA keeps connections busy
+        // well past the point the card is on screen, and waitForSelector below
+        // is the real readiness signal.
+        await page.goto(pageUrl, {
+          waitUntil: 'domcontentloaded',
+          timeout: 25_000,
+        });
 
-    // Let webfonts / layout settle
-    await new Promise((r) => setTimeout(r, 400));
+        await page.waitForSelector(
+          '.public-paper-stack, .public-card, .public-error-card, .public-content',
+          { timeout: 15_000 },
+        );
 
-    const png = await page.screenshot({
-      type: 'png',
-      clip: { x: 0, y: 0, width: OG_SHOT_WIDTH, height: OG_SHOT_HEIGHT },
-      captureBeyondViewport: false,
-    });
+        // Webfonts settle. Waiting on the font set beats a blind sleep — it
+        // returns as soon as the faces are ready instead of always costing
+        // 400ms, and it is correct on a slow render where 400ms was not.
+        await page
+          .evaluate(() => document.fonts.ready.then(() => undefined))
+          .catch(() => {});
 
-    return Buffer.from(png);
+        const png = await page.screenshot({
+          type: 'png',
+          clip: { x: 0, y: 0, width: OG_SHOT_WIDTH, height: OG_SHOT_HEIGHT },
+          captureBeyondViewport: false,
+        });
+
+        return Buffer.from(png);
+      } finally {
+        await page.close().catch(() => {});
+      }
+    } finally {
+      if (!reuseBrowser) await browser.close().catch(() => {});
+    }
   } finally {
-    await browser.close().catch(() => {});
+    releaseRenderSlot();
   }
 }

--- a/server/utils/user-export-backup-store.ts
+++ b/server/utils/user-export-backup-store.ts
@@ -1,0 +1,85 @@
+/**
+ * Nightly user-export backup storage — private `user-exports` Supabase bucket.
+ *
+ * Replaces @netlify/blobs, which only has a context to run in inside a Netlify
+ * Function. Same three operations the blob store was used for (set / list /
+ * delete), so the calling route keeps its shape.
+ *
+ * Follows the pattern in library-file-upload.ts: service-role client, private
+ * bucket, no RLS reliance — these objects are never served to users, only
+ * written by the cron job and pruned by retention.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+export const USER_EXPORTS_BUCKET = 'user-exports';
+
+/** Supabase list() paginates; exports are one object per user per day. */
+const LIST_PAGE_SIZE = 1000;
+
+let adminClient: SupabaseClient | null = null;
+
+export function isUserExportBackupConfigured(): boolean {
+  return Boolean(process.env.SUPABASE_URL?.trim() && process.env.SUPABASE_SERVICE_ROLE_KEY?.trim());
+}
+
+function getAdminClient(): SupabaseClient | null {
+  if (adminClient) return adminClient;
+  const url = process.env.SUPABASE_URL?.trim();
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+  if (!url || !key) return null;
+  adminClient = createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  return adminClient;
+}
+
+function requireClient(): SupabaseClient {
+  const client = getAdminClient();
+  if (!client) throw new Error('User export backup storage is not configured');
+  return client;
+}
+
+/** Write one export. Overwrites a same-day rerun rather than erroring. */
+export async function putUserExport(
+  key: string,
+  content: string,
+  contentType = 'text/csv',
+): Promise<void> {
+  const { error } = await requireClient()
+    .storage.from(USER_EXPORTS_BUCKET)
+    .upload(key, content, { contentType, upsert: true });
+  if (error) throw new Error(`upload ${key} failed: ${error.message}`);
+}
+
+/**
+ * All object keys in the bucket, as `<userId>/<date>.<ext>`.
+ *
+ * Supabase list() is per-prefix and does not recurse, so this walks the user
+ * folders — unlike the blob store's flat list().
+ */
+export async function listUserExportKeys(): Promise<string[]> {
+  const client = requireClient();
+  const store = client.storage.from(USER_EXPORTS_BUCKET);
+
+  const { data: folders, error: foldersError } = await store.list('', { limit: LIST_PAGE_SIZE });
+  if (foldersError) throw new Error(`list failed: ${foldersError.message}`);
+
+  const keys: string[] = [];
+  for (const folder of folders ?? []) {
+    // Supabase reports folders as entries with no id; real objects have one.
+    if (folder.id) continue;
+    const { data: files, error } = await store.list(folder.name, { limit: LIST_PAGE_SIZE });
+    if (error) throw new Error(`list ${folder.name} failed: ${error.message}`);
+    for (const file of files ?? []) {
+      if (file.id) keys.push(`${folder.name}/${file.name}`);
+    }
+  }
+  return keys;
+}
+
+export async function deleteUserExports(keys: string[]): Promise<void> {
+  if (keys.length === 0) return;
+  const { error } = await requireClient().storage.from(USER_EXPORTS_BUCKET).remove(keys);
+  if (error) throw new Error(`delete failed: ${error.message}`);
+}


### PR DESCRIPTION
Moves the Hono API off Netlify Functions onto one always-on Fly machine. **Merging this does not cut over** — `public/_redirects` is untouched, so production keeps serving `/api/*` from Netlify Functions exactly as today. The cutover is a separate four-line commit.

The app is already deployed and healthy at **https://harvous.fly.dev** (app `harvous`, org `testament-made`, region `iad`, one `shared-cpu-1x`/1GB machine).

## Why

⚠️ **This section was rewritten.** The original rationale rested on two claims that turned out to be false. Both are recorded rather than deleted — see `docs/FLY_MIGRATION.md`.

**Retracted 1 — the billing argument does not apply.** This account is not on Netlify's 300-credit plan. Verified via `netlify api listAccountsForUser`: `type_name: Free`, `credit_features: {'included': False}`, with separate allowances (100 GB bandwidth, 125,000 function invocations, 1M edge invocations, 300 build minutes). **Overage blocks builds, not the live site.** `background_functions` are available too, so OG render-to-cache and longer cron were achievable there.

**Retracted 2 — OG rendering was never broken on Netlify.** The ~35s cold render was measured on Fly; Netlify's behavior was inferred, not tested. Measured live: **12.9s cold, 6.8s warm, HTTP 200, real PNG** — comfortably inside the 26s timeout, and faster cold than Fly (3008MB Lambda has more CPU than `shared-cpu-1x`).

### The case that holds

| | Netlify | Fly |
|---|---|---|
| `/api/health` warm | 250–280ms | **~100ms** |
| OG render, warm | 6.8s | **2.18s** |
| OG render, cold | **12.9s** | ~35s, prewarmed at boot so unseen |
| Monthly | **$0** | ~$5.70 |

The one win that reaches users is **warm OG renders, 6.8s → 2.18s** — unfurlers commonly give up in the 5–10s window, and that comes from retaining a browser across renders, which per-request functions cannot do at any price. Secondary: no 26s ceiling, cron not shaped around a 25s Lambda budget, a warm Postgres pool, and workarounds deleted rather than a caching pipeline added.

**Not a speed win for users in the app itself** — optimistic mutations and the offline queue already paint before the network.

**Honest verdict: a close call, not a rescue.** Staying was defensible. The deciding number — actual invocations against the 125K allowance — was never measured and is readable only from the Netlify dashboard.

## What's here

| File | Purpose |
|---|---|
| `server/fly.ts` | Production entry: serves `server/app.ts` via `@hono/node-server`, warms the pool, drains on SIGTERM |
| `server/scheduler.ts` | The two `@daily` jobs in-process, calling the inner functions the Netlify scheduled functions already exported |
| `server/utils/user-export-backup-store.ts` | Supabase Storage in place of `@netlify/blobs`, which only has a context inside a Netlify Function |
| `Dockerfile` / `.dockerignore` / `fly.toml` | Two-stage build; runtime image is Node + Chromium + one self-contained bundle, no `node_modules` |
| `.github/workflows/fly-deploy.yml` | `flyctl deploy` on server-touching pushes to main |
| `scripts/fly-secrets-import.sh` | Pushes the server-side subset of `.env` |
| `docs/FLY_MIGRATION.md` | Runbook for cutover and cleanup |

### Three latent Netlify couplings, fixed

- **`server/routes/og.ts`** derived all five origins from `new URL(c.req.url).origin`. Behind the proxy that is the *API* host, so canonical URLs, OG image URLs and Chromium's screenshot target would point at a host serving no app. Now uses the existing `getPublicAppOrigin()`.
- **`server/routes/notes.ts`** gated its dev note-save trail on `process.env.NETLIFY`, unset on Fly — it would have appended a line to the container filesystem on every note save.
- **`server/constants/dev-featured-samples.ts`** now recognizes `FLY_APP_NAME` as deployed, and `isTestRoutesForbidden()` delegates to `isDeployedProductionLike()` rather than repeating its checks.

### OG render performance

Measured on the deployed machine (distinct unknown tokens, so nothing cached):

| | Before | After |
|---|---|---|
| Warm render | 6.30–6.49s (mean **6.42s**) | 1.93–2.29s (mean **2.18s**) |
| First render after deploy | ~36s | **~2s** |
| Memory available, idle | 298 MB | 332–418 MB |

Retains one Chromium across renders (impossible under per-request functions), navigates with `domcontentloaded` rather than `networkidle2` since `waitForSelector` was always the real readiness signal, and prewarms at boot so the ~35s cold cost lands off the request path. Concurrency is capped at 1: an idle retained browser leaves ~300MB of the 1GB machine, and an OOM would take the whole API down.

The rendered PNG is byte-identical to before (59,731 bytes) and a malformed token still 404s with `X-Og-Source: none`.

## Verified

- The bundle runs with **no `node_modules` present** (as in the runtime image), reaching Postgres and bundled JSON
- SIGTERM drains cleanly — confirmed in production when a machine was destroyed
- Scheduler arms at boot; prewarm logs start and completion
- 115 server test files / 1091 tests pass; full `npm run precommit` passes

## Before merging

Add a `FLY_API_TOKEN` repository secret or the `fly-deploy` workflow will fail:

```bash
fly tokens create deploy --name github-actions
```

## After merging, before cutover

1. Copy the five cron secrets from Netlify → Fly: `VOTD_CRON_SECRET`, `HMC_SYNC_CRON_SECRET`, `SUPPORT_NOTIFY_SECRET_TOKEN`, `BACKUP_CRON_SECRET`, `INBOX_RESET_SECRET_TOKEN`. `.env` held only 21 of 34 server variables; the rest live in the Netlify dashboard.
2. Create a **private** `user-exports` bucket in Supabase Storage, or the nightly backup job 503s.
3. Bake: `VITE_API_PROXY_TARGET=https://harvous.fly.dev npm run dev:spa`

## Unrelated finding

`BACKUP_CRON_SECRET` is not set in GitHub, and `backup-user-exports.yml` skips and exits **green** when it is missing. Every nightly run logs `BACKUP_CRON_SECRET not set; skipping backup` — there are no user-export backups, and there have not been. Predates this branch, but it means the storage path replaced here was never exercised in production. Worth making that guard `exit 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
