### PR TITLE
One spotlight contract, and the reason it could never be one selector

### DIFF
--- a/Changelog/2.82.0.md
+++ b/Changelog/2.82.0.md
@@ -1,0 +1,8 @@
+# Version 2.82.0
+
+**Release Date**: August 21, 2026
+
+## Features
+
+- One spotlight contract, and the reason it could never be one selector
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.81.0
+**Version:** 2.82.0
 **Status:** Official 1.0 Released January 8, 2026

--- a/docs/future/HIGHLIGHT_REFERENCE_STYLING_SPEC.md
+++ b/docs/future/HIGHLIGHT_REFERENCE_STYLING_SPEC.md
@@ -1,8 +1,9 @@
 # Highlights, References and the Selected Verse — Styling Spec
 
-**Status:** **Decided; mostly built** (August 21, 2026). The weights, the offset distinction and
-the dock's variable route shipped. **Outstanding: the single spotlight mechanism** and a
-device measurement of native's underline weight — see [Outstanding](#outstanding).
+**Status:** **Decided and built** (August 21, 2026) — weights, offsets, the dock's variable route
+and the single spotlight contract all shipped. **Outstanding: a device measurement of native's
+underline weight**, and one open design question about the reader — see
+[Outstanding](#outstanding).
 **Last Updated:** August 21, 2026
 **Audience:** Whoever settles what a mark means visually, across reader, note body, dock and native.
 **Covers:** improvement-list items #5 (the selected/highlighted verse experience) and the second half
@@ -183,7 +184,32 @@ bottom would enter the dock band, reusing the same flip logic
 
 Two pieces of this spec are decided but not built. Everything else shipped August 21, 2026.
 
-### 1. One spotlight mechanism across all four surfaces
+### 1. One spotlight mechanism — built, with one question left open
+
+**Built August 21, 2026.** `src/styles/mark-spotlight.css` is now the contract: put
+`data-dim-highlights="<id>"` on any container, everything mark-like inside dims to tertiary, and a
+per-id restore rule (injected by whichever surface owns the container) gives the active one its
+accent back. The note body's driver in `TiptapEditor.tsx` is unchanged in behaviour; what changed
+is that neither the dim nor the restore carries a surface prefix any more, so the dock — which can
+now be overridden, because its accents route through `--mark-accent` — is spotlit by the same pair.
+
+**One selector was never going to be possible, and finding that out is the useful part.** The
+reader draws no `<mark>` elements at all: a highlighted verse is `data-highlighted` on
+`.pds-reader__verse` with the decoration on an inner text span, and a saved reference is a
+`.reference-suggestion` span. So the surfaces share an attribute, a dim colour and a restore rule
+— three selector lists, one idea — rather than one rule. That is the honest version of "one
+mechanism", and it is written at the top of the file so nobody tries to collapse it further.
+
+**Still open:** the reader's rule exists in that file and is deliberately **inert** — nothing sets
+the attribute on a reader container. Whether the chapter should gain a per-mark dim *in addition
+to* its whole-verse focus fade is a design question, not a plumbing one: the fade already answers
+"what am I looking at" at a different granularity, and two dimming systems on one surface could
+easily read as a bug. Having the rule ready means answering it is one attribute rather than a
+fourth mechanism.
+
+Native keeps `StudyHighlightUnderlineGrayscale`, and has to — a UIKit text view has no CSS.
+
+### (superseded) The original framing
 
 The decision was a single dim model everywhere, native included — the parity spec §5 would have
 permitted native keeping its greyscale, and that was the recommendation; the call went the other

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.81.0",
+  "version": "2.82.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-81-0';
+const CACHE_NAME = 'harvous-cache-v2-82-0';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/spa/src/main.tsx
+++ b/spa/src/main.tsx
@@ -76,6 +76,7 @@ import '../../src/styles/global.css';
 /* After global.css so Clerk Manage account modal beats late `button` typography rules. */
 import '../../src/styles/clerk-user-profile.css';
 import '../../src/styles/delete-confirm-bar.css';
+import '../../src/styles/mark-spotlight.css';
 import '../../src/styles/tiptap-editor.css';
 import '../../src/styles/card-full-editable.css';
 import '../../src/styles/auth-gradient.css';

--- a/spa/src/styles/prototype-editor.css
+++ b/spa/src/styles/prototype-editor.css
@@ -620,10 +620,10 @@ html.harvous-prototype-route .proto-editor-surface .scripture-pill-draft__confir
  * its color — every other highlight underline dims to neutral gray so the active one stands out.
  * `data-dim-highlights="<studyThreadEntryId>"` is set on the ProseMirror root by TiptapEditor, and a
  * per-id restore rule is injected alongside it (see `dim-highlights` effect). */
-.proto-editor-surface .ProseMirror[data-dim-highlights] mark {
-  text-decoration-color: var(--pds-text-tertiary) !important;
-  text-shadow: none !important;
-}
+/* The dim itself now lives in src/styles/mark-spotlight.css, which applies to any container
+   carrying the attribute rather than to the note body alone — the dock can join it, and the
+   reader could. Only the note body's *driver* is still here (TiptapEditor's dim-highlights
+   effect); the rule it drives is shared. */
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-color-scheme="light"]) .proto-editor-surface .ProseMirror mark,

--- a/src/components/react/TiptapEditor.tsx
+++ b/src/components/react/TiptapEditor.tsx
@@ -6535,11 +6535,21 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
     runSelectionEvalRef.current();
   }, [studyDockStack]);
 
-  // Spotlight the expanded highlight: while a highlight/reference dock is expanded, dim every other
-  // highlight underline to neutral so only the active one keeps its color (prototype only). We tag the
-  // ProseMirror root with `data-dim-highlights="<id>"` (CSS dims all marks) and inject a per-id restore
-  // rule — driving it via attribute + injected style survives ProseMirror re-renders without mutating
-  // individual mark nodes. Scripture docks don't apply: pills aren't `<mark>` elements.
+  /*
+   * Spotlight the expanded highlight: while a highlight/reference dock is expanded, dim every
+   * other highlight underline to neutral so only the active one keeps its colour.
+   *
+   * Tag a container with `data-dim-highlights="<id>"` and inject a per-id restore rule. Driving
+   * it by attribute plus an injected style survives ProseMirror re-rendering its own DOM, which
+   * mutating each mark node would not.
+   *
+   * The dim rule itself is NOT here — it lives in `src/styles/mark-spotlight.css` and applies to
+   * any container carrying the attribute, not to the note body alone. That file is the contract;
+   * this effect is one of its drivers. The restore rule injected below is deliberately written
+   * without a surface prefix for the same reason: the dock can now be spotlit by the same pair,
+   * because its accents route through `--mark-accent` instead of being written straight onto
+   * `text-decoration-color`.
+   */
   const dimHighlightStyleRef = useRef<HTMLStyleElement | null>(null);
   useEffect(() => {
     if (!editor || !isEditorValid(editor)) return;
@@ -6562,8 +6572,11 @@ const TiptapEditor: React.FC<TiptapEditorProps> = ({
       }
       const esc =
         typeof CSS !== 'undefined' && CSS.escape ? CSS.escape(activeHighlightId) : activeHighlightId;
+      /* No surface prefix: any container with this id restores its own mark. `!important` to
+         match the dim it is undoing — the two must be equally weighted or which one wins would
+         depend on sheet order. */
       dimHighlightStyleRef.current.textContent =
-        `.proto-editor-surface .ProseMirror[data-dim-highlights="${esc}"] mark[data-study-thread-id="${esc}"]` +
+        `[data-dim-highlights="${esc}"] [data-study-thread-id="${esc}"]` +
         `{text-decoration-color:var(--mark-accent)!important}`;
     } else {
       dom.removeAttribute('data-dim-highlights');

--- a/src/styles/__tests__/mark-spotlight.test.ts
+++ b/src/styles/__tests__/mark-spotlight.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The spotlight contract, asserted against the stylesheet itself.
+ *
+ * There were three mechanisms for one idea and the dock could not join any of them. What makes
+ * this one mechanism is not a selector — the surfaces genuinely draw different elements — it is
+ * that they share an attribute, a dim colour and a restore rule. Those are the things that can
+ * drift apart silently, so those are what this pins.
+ *
+ * Read as text rather than rendered: the failure mode is a rule being narrowed back to one
+ * surface (which is what it was before), and that is visible in the source and invisible in a
+ * screenshot.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const sheet = readFileSync(resolve(process.cwd(), 'src/styles/mark-spotlight.css'), 'utf8');
+const editor = readFileSync(
+  resolve(process.cwd(), 'src/components/react/TiptapEditor.tsx'),
+  'utf8',
+);
+
+describe('the spotlight is one contract, not one selector', () => {
+  it('dims by attribute alone, with no surface prefix', () => {
+    // `.proto-editor-surface .ProseMirror[data-dim-highlights]` is what this replaced. A prefix
+    // creeping back is the regression: it would silently exclude the dock again.
+    const dimBlock = sheet.slice(sheet.indexOf('[data-dim-highlights] mark'));
+    expect(dimBlock).not.toMatch(/\.proto-editor-surface[^\n]*\[data-dim-highlights\]/);
+    expect(sheet).toContain('[data-dim-highlights] mark');
+  });
+
+  it('covers the mark surfaces and the reader, which draws no marks at all', () => {
+    // The note body and dock use <mark>; a highlighted verse is a decorated span and a saved
+    // reference is `.reference-suggestion`. One idea, three element shapes.
+    expect(sheet).toContain('[data-dim-highlights] mark');
+    expect(sheet).toContain('[data-dim-highlights] .pds-reader__verse-text');
+    expect(sheet).toContain('[data-dim-highlights] .reference-suggestion');
+  });
+
+  it('dims to tertiary and kills the accent glow', () => {
+    expect(sheet).toMatch(/text-decoration-color:\s*var\(--pds-text-tertiary\)\s*!important/);
+    // A dimmed mark keeping its dark-mode glow would leave the one thing meant to stand out as
+    // the only thing not glowing.
+    expect(sheet).toMatch(/text-shadow:\s*none\s*!important/);
+  });
+
+  it('injects a restore rule with no surface prefix either', () => {
+    // The dim and the restore must be weighted the same, or which wins depends on sheet order.
+    expect(editor).toContain('`[data-dim-highlights="${esc}"] [data-study-thread-id="${esc}"]`');
+    expect(editor).toContain('{text-decoration-color:var(--mark-accent)!important}');
+  });
+
+  /**
+   * The dock's accents had to stop being written straight onto `text-decoration-color` before any
+   * of this could work — there was no variable to override. If that regresses, the dock silently
+   * stops dimming and nothing else fails.
+   */
+  it('leaves the dock with a variable to override', () => {
+    const dock = readFileSync(
+      resolve(process.cwd(), 'src/styles/scripture-pill-chrome.css'),
+      'utf8',
+    );
+    expect(dock).not.toMatch(
+      /mark\[data-color="[a-zA-Z]+"\]\s*\{\s*text-decoration-color:\s*var\(--pds-highlight/,
+    );
+    expect(dock).toMatch(/mark\[data-color="violet"\]\s*\{\s*--mark-accent:/);
+  });
+});

--- a/src/styles/mark-spotlight.css
+++ b/src/styles/mark-spotlight.css
@@ -1,0 +1,51 @@
+/**
+ * Spotlight — dim every mark on a surface except the one you are looking at.
+ *
+ * One contract, in one file, because there were three mechanisms for one idea: the note body
+ * dimmed marks via an injected `[data-dim-highlights]` rule, the reader faded whole verses by
+ * opacity, and the scripture dock could not dim at all — it wrote `text-decoration-color`
+ * straight onto each `data-color`, so there was no variable to override. That last one is fixed
+ * (the dock routes through `--mark-accent` now), which is what made this file possible.
+ *
+ * ── The contract ──
+ *
+ *   1. Put `data-dim-highlights="<studyThreadEntryId>"` on a container.
+ *   2. Everything mark-like inside it dims to tertiary.
+ *   3. Anything carrying `data-study-thread-id="<that id>"` keeps its own accent.
+ *
+ * Step 3 is a per-id rule injected at runtime by whichever surface owns the container — see
+ * `TiptapEditor.tsx`'s dim-highlights effect. It is injected rather than written here because a
+ * static sheet cannot know the id, and driving it by attribute rather than by mutating each mark
+ * is what survives ProseMirror re-rendering its own DOM.
+ *
+ * ── Why the selectors differ per surface, when the mechanism does not ──
+ *
+ * The note body and the dock both draw highlights as `<mark>`. The reader draws none at all: a
+ * highlighted verse is `data-highlighted` on `.pds-reader__verse` with the decoration on an inner
+ * text span, and a saved reference is a `.reference-suggestion` span. So "one selector everywhere"
+ * was never available — what is shared is the attribute, the tertiary colour and the restore rule.
+ * Three selector lists, one idea, instead of three ideas.
+ *
+ * The reader's rule is written here and is deliberately INERT: nothing sets the attribute on a
+ * reader container today, because whether the chapter should gain a per-mark dim *in addition to*
+ * its whole-verse focus fade is an open design question
+ * (docs/future/HIGHLIGHT_REFERENCE_STYLING_SPEC.md §Outstanding). Having the rule ready means
+ * answering that question is one attribute, not a fourth mechanism.
+ *
+ * Native keeps `StudyHighlightUnderlineGrayscale`. Same idea, and it has to be — a UIKit text
+ * view has no CSS to hand.
+ */
+
+/* ── Dim ── everything mark-like inside a spotlit container. */
+[data-dim-highlights] mark,
+[data-dim-highlights] .pds-reader__verse-text,
+[data-dim-highlights] .reference-suggestion {
+  /* `!important` because each surface's own accent rule is equally specific and would otherwise
+     win by source order — which of the two sheets loads last is not something this should depend
+     on. The runtime restore rule below is also `!important` for the same reason, so the pair
+     stays symmetrical. */
+  text-decoration-color: var(--pds-text-tertiary) !important;
+  /* The note body's dark-mode marks carry an accent glow; a dimmed mark must not keep it, or the
+     one thing that is supposed to stand out is the only thing that does not glow. */
+  text-shadow: none !important;
+}


### PR DESCRIPTION
D-4's last piece. Three mechanisms for one idea become one contract in `src/styles/mark-spotlight.css`.

## The contract

Put `data-dim-highlights="<id>"` on any container → everything mark-like inside dims to tertiary → an injected per-id rule gives the active one its accent back.

Neither half carries a surface prefix any more. The dim was `.proto-editor-surface .ProseMirror[data-dim-highlights] mark` and the injected restore matched it; both are attribute-only now. That is what lets the scripture dock be spotlit by the same pair — it could not participate at all until this branch's predecessor stopped it writing `text-decoration-color` straight onto each `data-color`, leaving nothing to override.

## One selector was never available, and that is the finding

The reader draws **no `<mark>` elements**. A highlighted verse is `data-highlighted` on `.pds-reader__verse` with the decoration on an inner text span; a saved reference is a `.reference-suggestion` span.

So what the surfaces share is an attribute, a dim colour and a restore rule — **three selector lists, one idea** — not one rule. That is the honest version of "one mechanism", and it is written at the top of the file so nobody tries to collapse it further and quietly drops a surface doing it.

## The reader's rule is there, and deliberately inert

Nothing sets the attribute on a reader container. Whether the chapter should gain a per-mark dim *in addition to* its whole-verse focus fade is a design question rather than plumbing — the fade already answers "what am I looking at" at a different granularity, and two dimming systems on one surface could easily read as a bug.

Having the rule ready means answering that is one attribute, not a fourth mechanism. Recorded as the one open item in the doc.

Native keeps `StudyHighlightUnderlineGrayscale` and has to: a UIKit text view has no CSS.

## Testing

Against the stylesheet **as text**, because the regression here is a rule being narrowed back to one surface — visible in source, invisible in a screenshot. Five cases pin the attribute-only dim, the three element shapes, the tertiary colour and killed glow, the prefix-free restore, and that the dock still has a variable to override.

4130 tests (+5), typecheck at the 281 baseline, design:check 19 core + 27 shared-spaces scenes, perf 1109.9 KB with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)