### PR TITLE
D-1's main case never worked: dragging inside one verse

### DIFF
--- a/Changelog/2.84.3.md
+++ b/Changelog/2.84.3.md
@@ -1,0 +1,8 @@
+# Version 2.84.3
+
+**Release Date**: August 21, 2026
+
+## Fixes
+
+- D-1's main case never worked — dragging inside one verse
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.84.2
+**Version:** 2.84.3
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.84.2",
+  "version": "2.84.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-84-2';
+const CACHE_NAME = 'harvous-cache-v2-84-3';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/spa/src/pages/prototype/PrototypeBibleReaderPane.tsx
+++ b/spa/src/pages/prototype/PrototypeBibleReaderPane.tsx
@@ -1156,6 +1156,41 @@ export default function PrototypeBibleReaderPane({
 
   const handleVerseActivate = useCallback(
     (n: number, e: ReactMouseEvent<HTMLSpanElement>) => {
+      /*
+       * The click that ends a drag is not a tap.
+       *
+       * A browser fires `click` after `mouseup` even when the pointer moved, so dragging across
+       * a phrase inside ONE verse used to arrive here as a tap on that verse — and
+       * `nextVerseSelection` reads a tap on the sole selected verse as "the way back out",
+       * returning null. The drag selected [20,20], the trailing click cleared it, and the
+       * toolbar never appeared. Highlighting part of a single verse is the whole point of the
+       * feature, so this was the primary case failing while a cross-verse drag worked: clicking
+       * verse 18 of [17,18] narrows to [18,18] rather than clearing, which left a selection
+       * behind and made the bug look like it did not exist.
+       *
+       * Read from the live selection rather than tracked in a ref, so this stays one
+       * self-contained condition and the callback keeps the stable identity that
+       * `VerseSpan`'s memo depends on. A genuine tap always arrives with the selection already
+       * collapsed — mousedown collapses it before click — so "there is still a selection" is
+       * exactly the thing that distinguishes the two.
+       *
+       * Shift is let through: shift-click extends the verse range on purpose, and it drags the
+       * DOM selection along with it, so the same test would suppress the one gesture whose
+       * whole job is to extend.
+       */
+      if (!e.shiftKey) {
+        const active = document.getSelection();
+        const column = columnRef.current;
+        if (
+          active &&
+          !active.isCollapsed &&
+          active.rangeCount > 0 &&
+          active.toString().trim() &&
+          column?.contains(active.getRangeAt(0).commonAncestorContainer)
+        ) {
+          return;
+        }
+      }
       // A dotted word is its own target: tapping it asks "who/what is this?", which is a
       // different question from "I want to act on this verse". Selecting the verse as well
       // would answer both at once and open the format bar over the dock.

--- a/spa/src/pages/prototype/__tests__/reader-drag-click-guard.test.ts
+++ b/spa/src/pages/prototype/__tests__/reader-drag-click-guard.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The click that ends a drag must not be read as a tap.
+ *
+ * D-1 let you drag across part of a verse to highlight a phrase. It worked across a verse
+ * boundary and silently failed inside a single verse — which is the case the feature is for.
+ * The cause is the interaction between two things that are each correct alone:
+ *
+ *   1. A browser fires `click` after `mouseup` even when the pointer moved, so a drag inside
+ *      verse 20 ends with a click on verse 20.
+ *   2. `nextVerseSelection` reads a tap on the sole selected verse as "the way back out" and
+ *      returns null — deliberately, and the test below pins that it still does.
+ *
+ * So the drag set [20,20] and the trailing click cleared it before the toolbar could render.
+ * A cross-verse drag hid the bug: clicking verse 18 of [17,18] narrows to [18,18] rather than
+ * clearing, so a selection survived and everything looked fine.
+ *
+ * Asserted against the source rather than by rendering the pane. The guard reads
+ * `document.getSelection()` inside a React callback whose whole design point is a stable
+ * identity — reproducing that needs a chapter query, a shell context and a real layout, none of
+ * which is what this is about. What must not regress is that the guard exists, that it is
+ * skipped for shift, and that it runs before the verse is selected.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { nextVerseSelection } from '../reader-verse-selection';
+
+const pane = readFileSync(
+  resolve(process.cwd(), 'spa/src/pages/prototype/PrototypeBibleReaderPane.tsx'),
+  'utf8',
+);
+
+/** `handleVerseActivate`'s body, up to the next top-level `const` after it. */
+const activate = (() => {
+  const start = pane.indexOf('const handleVerseActivate = useCallback(');
+  expect(start).toBeGreaterThan(-1);
+  const end = pane.indexOf('const handleVerseKeys', start);
+  expect(end).toBeGreaterThan(start);
+  return pane.slice(start, end);
+})();
+
+describe('a drag does not end by deselecting what it selected', () => {
+  it('the two correct behaviours that combine into the bug are both still here', () => {
+    // If this ever stops returning null, the guard is protecting nothing and can go.
+    expect(nextVerseSelection([20, 20], 20, false)).toBeNull();
+    // And the reason a cross-verse drag looked fine, which is why the bug was easy to miss.
+    expect(nextVerseSelection([17, 18], 18, false)).toEqual([18, 18]);
+  });
+
+  it('ignores a click that arrives with a live selection in the column', () => {
+    expect(activate).toContain('document.getSelection()');
+    expect(activate).toMatch(/isCollapsed/);
+    // Scoped to the reader column: a selection somewhere else on the page is not this drag.
+    expect(activate).toMatch(/columnRef\.current/);
+    expect(activate).toMatch(/contains\(/);
+  });
+
+  it('lets shift through, since shift-click extends on purpose', () => {
+    // Shift-click drags the DOM selection along with it, so an unguarded test would suppress
+    // the one gesture whose whole job is to extend the range.
+    expect(activate).toMatch(/if\s*\(\s*!e\.shiftKey\s*\)/);
+  });
+
+  it('guards before selecting, not after', () => {
+    const guard = activate.indexOf('document.getSelection()');
+    const select = activate.indexOf('selectVerse(n, e.shiftKey)');
+    expect(guard).toBeGreaterThan(-1);
+    expect(select).toBeGreaterThan(-1);
+    // A guard that runs after the selection has already been toggled is not a guard.
+    expect(guard).toBeLessThan(select);
+  });
+});

--- a/src/styles/__tests__/reader-subverse-mark.test.ts
+++ b/src/styles/__tests__/reader-subverse-mark.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The chapter's sub-verse marks are styled by the same rule as the dock's, not a copy of it.
+ *
+ * D-1 paints a highlighted phrase into the chapter with the same helper that paints the dock's,
+ * producing a `<mark>` with the same attributes. The dock's rule was ancestor-scoped, so the
+ * chapter matched nothing and fell through to the user-agent default — a raw yellow `<mark>`
+ * block, in a product whose highlight language is an accent underline. It shipped that way and
+ * was caught by reading the computed style rather than by looking, because a yellow highlight
+ * looks deliberate.
+ *
+ * The fix grew the selector list rather than the rule count. This pins that choice: the failure
+ * mode is someone "tidying" the reader's selector into its own block in the reader's sheet,
+ * which restores the drift `mark-spotlight.css` was created to prevent — the two would then
+ * disagree the first time either changed.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const dock = readFileSync(
+  resolve(process.cwd(), 'src/styles/scripture-pill-chrome.css'),
+  'utf8',
+);
+const reader = readFileSync(
+  resolve(process.cwd(), 'spa/src/styles/prototype-components.css'),
+  'utf8',
+);
+
+/** The declaration block whose selector list contains `sel`. */
+function blockFor(sel: string): string {
+  const i = dock.indexOf(sel);
+  expect(i, `selector not found: ${sel}`).toBeGreaterThan(-1);
+  const open = dock.indexOf('{', i);
+  const close = dock.indexOf('}', open);
+  return dock.slice(open, close);
+}
+
+describe('the reader shares the dock mark rule', () => {
+  it('resets the user-agent yellow for a chapter mark', () => {
+    const block = blockFor('.pds-reader__verse-text mark[data-reference]');
+    // The whole point: without this the chapter renders `background: yellow` from the UA sheet.
+    expect(block).toMatch(/background:\s*transparent\s*!important/);
+    expect(block).toMatch(/text-decoration:\s*underline/);
+    // Through the variable, so a dim pass has something to override.
+    expect(block).toContain('var(--mark-accent');
+  });
+
+  it('gives a highlight the scriptureLink weight in the chapter too', () => {
+    const block = blockFor('.pds-reader__verse-text mark[data-entry-kind="scriptureLink"]');
+    expect(block).toMatch(/text-decoration-thickness:\s*2px/);
+    expect(block).toMatch(/text-underline-offset:\s*2px/);
+  });
+
+  it('carries every accent colour, so a recoloured phrase is not silently amber', () => {
+    for (const c of ['neutral', 'warmAmber', 'skyBlue', 'violet', 'mintGreen', 'coralRose']) {
+      expect(dock).toContain(`.pds-reader__verse-text mark[data-color="${c}"]`);
+    }
+  });
+
+  it('shares the declarations rather than duplicating them into the reader sheet', () => {
+    // One rule, two surfaces. A second copy in the reader's own sheet is the regression.
+    expect(reader).not.toMatch(/\.pds-reader__verse-text\s+mark\[data-reference\]/);
+    const block = blockFor('.pds-reader__verse-text mark[data-reference]');
+    expect(dock.slice(dock.indexOf('.pds-reader__verse-text mark[data-reference]') - 200))
+      .toContain('.scripture-pill-chrome__passage-html mark[data-reference]');
+    expect(block.length).toBeGreaterThan(0);
+  });
+});

--- a/src/styles/scripture-pill-chrome.css
+++ b/src/styles/scripture-pill-chrome.css
@@ -371,7 +371,18 @@ button .scripture-pill-chrome__trans-chip {
   background: color-mix(in srgb, var(--pds-text-tertiary) 12%, transparent);
 }
 
-/* Saved passage reference — solid underline (parity with note-body mark[data-reference]). */
+/*
+ * Saved passage reference — solid underline (parity with note-body mark[data-reference]).
+ *
+ * The reader's verse text is on this rule rather than in a sheet of its own. D-1 gave the chapter
+ * sub-verse highlights, painted by the same helper that paints the dock's, carrying exactly the
+ * same attributes — `data-reference`, `data-color`, `data-study-thread-id`, `data-entry-kind`.
+ * Only the ancestor differed, so the chapter matched nothing here and fell through to the UA
+ * default: a raw yellow `<mark>` block, in a product whose highlight language is an accent
+ * underline. Copying the declarations into the reader's sheet would have re-created the drift
+ * `mark-spotlight.css` exists to prevent, so the selector list grew instead of the rule count.
+ */
+.pds-reader__verse-text mark[data-reference],
 .scripture-pill-chrome__passage-html mark[data-reference] {
   background: transparent !important;
   color: inherit !important;
@@ -394,6 +405,7 @@ button .scripture-pill-chrome__trans-chip {
    everything comes down to 2 and native comes with it, so the chapter's thickness — the
    most-looked-at text in the product — never changes. See
    docs/future/HIGHLIGHT_REFERENCE_STYLING_SPEC.md. */
+.pds-reader__verse-text mark[data-entry-kind="scriptureLink"],
 .scripture-pill-chrome__passage-html mark[data-entry-kind="scriptureLink"] {
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
@@ -402,11 +414,17 @@ button .scripture-pill-chrome__trans-chip {
 /* Accent through a variable, not written straight onto `text-decoration-color`.
    The direct declaration is why the dock could not take part in a dim/spotlight pass at all:
    there was nothing to override. Same route the reader and note body already use. */
+.pds-reader__verse-text mark[data-color="neutral"],
 .scripture-pill-chrome__passage-html mark[data-color="neutral"] { --mark-accent: var(--pds-highlight-neutral); }
+.pds-reader__verse-text mark[data-color="warmAmber"],
 .scripture-pill-chrome__passage-html mark[data-color="warmAmber"] { --mark-accent: var(--pds-highlight-warm-amber); }
+.pds-reader__verse-text mark[data-color="skyBlue"],
 .scripture-pill-chrome__passage-html mark[data-color="skyBlue"] { --mark-accent: var(--pds-highlight-sky-blue); }
+.pds-reader__verse-text mark[data-color="violet"],
 .scripture-pill-chrome__passage-html mark[data-color="violet"] { --mark-accent: var(--pds-highlight-violet); }
+.pds-reader__verse-text mark[data-color="mintGreen"],
 .scripture-pill-chrome__passage-html mark[data-color="mintGreen"] { --mark-accent: var(--pds-highlight-mint-green); }
+.pds-reader__verse-text mark[data-color="coralRose"],
 .scripture-pill-chrome__passage-html mark[data-color="coralRose"] { --mark-accent: var(--pds-highlight-coral-rose); }
 
 .scripture-pill-chrome__passage-html {


### PR DESCRIPTION
Found by exercising the feature end-to-end for the first time. Two defects, the second only visible once the first was fixed.

## 1. The toolbar never appeared for a single-verse drag

Dragging across a phrase inside one verse selected the text and then offered nothing to do with it — which is the case D-1 exists for.

Two correct behaviours combined:

- A browser fires `click` after `mouseup` even when the pointer moved, so a drag inside verse 20 ends with a click on verse 20.
- `nextVerseSelection` reads a tap on the sole selected verse as the way back out, returning `null` — deliberately.

The drag set `[20,20]`; the trailing click cleared it a frame later.

**A cross-verse drag hid this entirely**, which is why it survived being built: clicking verse 18 of `[17,18]` narrows to `[18,18]` rather than clearing, so a selection remained and the toolbar appeared. The only drag that had been tried spanned verses.

The guard reads the live selection instead of tracking a ref, keeping it one self-contained condition and preserving the stable callback identity `VerseSpan`'s memo depends on. A genuine tap always arrives with the selection already collapsed — mousedown collapses it before click — so "there is still a selection" is exactly what separates the two. Shift is let through, since shift-click extends on purpose and drags the DOM selection with it.

## 2. The highlight then rendered as a raw yellow block

With the toolbar reachable, the write path turned out to be entirely correct:

```
scriptureReference:       "John 3:20"
scripturePassageExcerpt:  "hate the light"
scriptureSpanKey:         "s:f30a5e20"
```

It survived a reload and painted exactly one `<mark>` containing only the dragged phrase, with `data-highlighted` unset on the verse — a real sub-verse mark, not the old whole-verse underline.

But it rendered `background: rgb(255,255,0)` — the user-agent default. The chapter's mark carries the same attributes as the dock's and is painted by the same helper, but the dock's rule is ancestor-scoped, so the chapter matched nothing. **Reading the computed style is what caught this; a yellow highlight looks deliberate.**

Fixed by growing the selector list rather than the rule count — copying the declarations into the reader's sheet would rebuild the drift `mark-spotlight.css` exists to prevent. The chapter now renders a 2px accent underline at 2px offset, the `scriptureLink` weight, identical to the dock.

## Verification

Both fixes were checked by reverting each and confirming the new tests fail — 5 failures across the two files. A source-reading test that passes either way is worse than none.

Full suite 4154 passing (403 files, +8). Typecheck at the 281 baseline. `design:check`, `check:color-tokens`, and `perf:check` (1110.4 KB) all pass.