### PR TITLE
Three defects in a suggestion row's trailing controls

### DIFF
--- a/Changelog/2.84.4.md
+++ b/Changelog/2.84.4.md
@@ -1,0 +1,12 @@
+# Version 2.84.4
+
+**Release Date**: August 22, 2026
+
+## Fixes
+
+- Three defects in a suggestion row's trailing controls
+
+## Other Changes
+
+- D-6: correct the brief — the Home placement already exists (#47)
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.84.3
+**Version:** 2.84.4
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.84.3",
+  "version": "2.84.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-84-3';
+const CACHE_NAME = 'harvous-cache-v2-84-4';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/release-notes/2026-08-22.md
+++ b/release-notes/2026-08-22.md
@@ -1,0 +1,44 @@
+# What's New in Harvous — August 22, 2026
+
+**Release Date:** August 22, 2026
+**Version:** v2.84.4
+
+---
+
+## Updates in This Release
+
+### Highlighting part of a verse
+
+**What changed:**
+- Dragging across a phrase inside a single verse now brings up the highlight actions. It already
+  worked when a selection ran across two verses; inside one verse the selection was cleared the
+  moment you let go, so nothing was offered.
+- A highlighted phrase now looks like every other highlight — an underline in your chosen colour.
+  It had been rendering as a plain yellow block.
+
+**How it helps you:**
+- You can mark the words that matter rather than the whole verse they sit in, and the chapter
+  still reads as a chapter.
+
+### Suggestion rows
+
+**What changed:**
+- The overflow menu on a suggestion no longer appears underneath the rows below it.
+- Its dots now match the weight of the dismiss mark beside them, instead of sitting darker than
+  everything else in the row.
+- Titles and descriptions have more room, so fewer of them cut off early.
+
+**How it helps you:**
+- Less squinting at a truncated title to work out which suggestion is which.
+
+---
+
+## Need Help?
+
+If you have questions about these updates:
+- Check the `/help` folder for detailed guides
+- Most features have hover tooltips that explain what they do
+
+---
+
+*This release note focuses on user experience improvements. For technical details, see the `Changelog/` folder.*

--- a/spa/src/styles/__tests__/list-row-trailing.test.ts
+++ b/spa/src/styles/__tests__/list-row-trailing.test.ts
@@ -1,0 +1,77 @@
+/**
+ * A suggestion row's trailing controls: one pair, one weight, above the rows below it.
+ *
+ * Three defects with one shape — the overflow trigger sits inside `.proto-recall-row__more`,
+ * a wrapper that exists only to anchor the popover, so every `>` combinator aimed at the
+ * trailing span reached the ✕ and missed the ⋮ standing right beside it.
+ *
+ * Read as stylesheet text rather than rendered, because what must not regress is the shape of
+ * the selectors. The dangerous "fix" for all of this is a descendant selector, which looks
+ * identical in a screenshot and quietly dims every item of the open menu.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const components = readFileSync(
+  resolve(process.cwd(), 'spa/src/styles/prototype-components.css'),
+  'utf8',
+);
+const overrides = readFileSync(
+  resolve(process.cwd(), 'spa/src/styles/prototype-route-overrides.css'),
+  'utf8',
+);
+
+const WRAPPED = '.proto-list-panel__row-trailing > .proto-recall-row__more > button';
+
+describe('the kebab is weighted like the dismiss glyph next to it', () => {
+  it('dims the wrapped trigger at rest, hover, and focus', () => {
+    expect(components).toContain(`${WRAPPED} {`);
+    expect(components).toContain(`${WRAPPED}:hover`);
+    expect(components).toContain(`${WRAPPED}:focus-visible`);
+    expect(components).toContain(
+      '.proto-list-panel__row:hover .proto-list-panel__row-trailing > .proto-recall-row__more > button',
+    );
+  });
+
+  it('never dims by descendant, which would take the open menu with it', () => {
+    // `trailing button` (no `>`) reaches every `.proto-menu-item` inside the popover.
+    expect(components).not.toMatch(/\.proto-list-panel__row-trailing\s+button\s*[,{]/);
+    expect(overrides).not.toMatch(/\.proto-list-panel__row-trailing\s+button\s*[,{]/);
+  });
+
+  it('keeps the trigger lit while its own menu is open', () => {
+    expect(components).toContain(
+      '.proto-list-panel__row-trailing > .proto-recall-row__more:has(.proto-recall-row__menu) > button',
+    );
+  });
+
+  it('paints the wrapped trigger the same colour as the direct one', () => {
+    expect(overrides).toContain(`html.harvous-prototype-route ${WRAPPED}`);
+  });
+});
+
+describe('an open menu outranks the rows beneath it', () => {
+  it('lifts the row, since the menu cannot escape its row stacking context', () => {
+    // The row is `position: relative; z-index: 1`, so the menu's own 5000 only ever ranked it
+    // inside its own row. Raising the menu again would change nothing.
+    const sel = '.proto-list-panel__row:has(.proto-recall-row__menu)';
+    const i = components.indexOf(sel);
+    expect(i).toBeGreaterThan(-1);
+    const block = components.slice(components.indexOf('{', i), components.indexOf('}', i));
+    expect(block).toMatch(/z-index:\s*3/);
+  });
+});
+
+describe('the row text is not inset on one side only', () => {
+  it('gives the title column the width the asymmetric padding was holding', () => {
+    const i = components.indexOf('.proto-list-panel__row-main {');
+    expect(i).toBeGreaterThan(-1);
+    const block = components.slice(i, components.indexOf('}', i));
+    // Right padding is 0: the negative margin cancels top/bottom/left into hit area, and the
+    // right had no margin to cancel it, so it stacked with the row's padding and the flex gap.
+    expect(block).toMatch(/padding:\s*11px\s+0\s+11px\s+13px/);
+    // The margin must NOT gain a right value — the hit area would slide under the dismiss glyph.
+    expect(block).toMatch(/margin:\s*-11px\s+0\s+-11px\s+-13px/);
+  });
+});

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -12039,7 +12039,22 @@ html.harvous-prototype-route .pds-banner .pds-banner__action > button:disabled,
   display: flex;
   align-items: center;
   gap: 11px;
-  padding: 11px 13px;
+  /*
+   * No right padding, unlike the other three sides.
+   *
+   * The negative margin below cancels top, bottom and left, which turns that padding into extra
+   * hit area rather than inset — the button reaches the row's edges while the text still sits on
+   * the row's own 13px. The right had padding with no margin to cancel it, so it was the one side
+   * where the number inset the text for real, and it landed on top of the row's 13px padding and
+   * the 11px flex gap: 24px of dead space between the title and the dismiss glyph, on a 260px
+   * row where the meta line wants 382px and gets 113px.
+   *
+   * Zero is the symmetric answer, not a tightening. The text now ends 13px from the row's edge,
+   * the same 13px it starts from on the left. It is not given a negative margin to match the left
+   * either, because the trailing controls are 11px away and a button whose hit area slid under
+   * them would steal presses meant for the ✕.
+   */
+  padding: 11px 0 11px 13px;
   margin: -11px 0 -11px -13px;
   border-radius: 0;
 }
@@ -12065,6 +12080,24 @@ html.harvous-prototype-route .pds-banner .pds-banner__action > button:disabled,
   align-items: center;
 }
 
+/*
+ * A row holding an open menu outranks the rows under it.
+ *
+ * The menu already carries `z-index: 5000`, and that number was doing nothing here. Its row is
+ * `position: relative; z-index: 1`, which makes the row a stacking context — so 5000 only ever
+ * ranked the menu against its own row's contents, never against the next row. With every row at
+ * the same z-index, painting fell back to DOM order and the rows *below* drew on top: the
+ * "Not interested" card came up with the following row's dismiss glyph sitting on it.
+ *
+ * Lifting the row is the fix rather than raising the menu again, because no value on the menu can
+ * escape a stacking context its ancestor owns. `:has()` keeps it to the moment the menu exists —
+ * a row that is permanently lifted would re-order hover and focus rings against its neighbours
+ * for the 99% of the time nothing is open.
+ */
+.proto-list-panel__row:has(.proto-recall-row__menu) {
+  z-index: 3;
+}
+
 /* Wide enough for one item and no wider. The shared `--list-view` modifier drops the
    checkmark column but keeps a min-width sized for a translation list. */
 .proto-recall-row__menu {
@@ -12077,18 +12110,35 @@ html.harvous-prototype-route .pds-banner .pds-banner__action > button:disabled,
 
 /* At the chevron's weight, because they occupy the chevron's place. A row's trailing mark
    is punctuation until you reach for it: full-strength glyphs there made every dismissable
-   row look like it was asking to be dismissed. Rises to full on the pointer. */
-.proto-list-panel__row-trailing > button {
+   row look like it was asking to be dismissed. Rises to full on the pointer.
+   
+   The overflow trigger is named separately because it is a grandchild: it sits inside
+   `.proto-recall-row__more`, which exists to anchor the popover, and a `>` combinator does not
+   reach through it. So the ✕ dimmed and the ⋮ beside it stayed at full strength — same colour,
+   different weight, on two glyphs that are meant to read as one pair.
+   
+   Deliberately not a descendant selector. The popover lives inside `.proto-recall-row__more`
+   too, and `trailing button` would dim every item in the open menu along with the trigger. */
+.proto-list-panel__row-trailing > button,
+.proto-list-panel__row-trailing > .proto-recall-row__more > button {
   opacity: 0.4;
   transition: opacity var(--pds-duration-press) var(--pds-ease-standard);
 }
 
-.proto-list-panel__row:hover .proto-list-panel__row-trailing > button {
+.proto-list-panel__row:hover .proto-list-panel__row-trailing > button,
+.proto-list-panel__row:hover .proto-list-panel__row-trailing > .proto-recall-row__more > button {
   opacity: 0.62;
 }
 
 .proto-list-panel__row-trailing > button:hover,
-.proto-list-panel__row-trailing > button:focus-visible {
+.proto-list-panel__row-trailing > button:focus-visible,
+.proto-list-panel__row-trailing > .proto-recall-row__more > button:hover,
+.proto-list-panel__row-trailing > .proto-recall-row__more > button:focus-visible {
+  opacity: 1;
+}
+
+/* An open menu keeps its trigger lit, or the ⋮ fades out from under the panel it opened. */
+.proto-list-panel__row-trailing > .proto-recall-row__more:has(.proto-recall-row__menu) > button {
   opacity: 1;
 }
 

--- a/spa/src/styles/prototype-route-overrides.css
+++ b/spa/src/styles/prototype-route-overrides.css
@@ -226,7 +226,12 @@ html.harvous-prototype-route .pds-paper-stack button.pds-paper-stack__edge-dismi
 html.harvous-prototype-route .proto-list-panel__row-trailing > button,
 html.harvous-prototype-route .proto-list-panel__row-trailing > button svg,
 html.harvous-prototype-route .proto-list-panel__row-trailing > button path,
-html.harvous-prototype-route .proto-list-panel__row-trailing > button * {
+html.harvous-prototype-route .proto-list-panel__row-trailing > button *,
+/* The overflow trigger is a grandchild — see the opacity rules in prototype-components.css,
+   which had the same blind spot for the same reason. */
+html.harvous-prototype-route .proto-list-panel__row-trailing > .proto-recall-row__more > button,
+html.harvous-prototype-route .proto-list-panel__row-trailing > .proto-recall-row__more > button svg,
+html.harvous-prototype-route .proto-list-panel__row-trailing > .proto-recall-row__more > button path {
   color: var(--pds-text-primary) !important;
 }
 


### PR DESCRIPTION
All three trace to the same thing: the overflow trigger sits inside `.proto-recall-row__more`, a wrapper that exists only to anchor the popover, so every `>` combinator aimed at the trailing span reached the ✕ and missed the ⋮ standing right beside it.

## The menu drew under the rows below it

The popover already carried `z-index: 5000`, and that number was doing nothing. Its row is `position: relative; z-index: 1` — a stacking context — so 5000 only ever ranked the menu against its own row's contents. Every row shares that z-index, so painting fell back to DOM order and the rows *underneath* drew on top: "Not interested" came up with the next row's dismiss glyph sitting on the card.

Fixed by lifting the row, not by raising the menu again — no value on the menu can escape a stacking context its ancestor owns. Scoped with `:has()` to the moment the menu exists, since a permanently lifted row would re-order hover and focus rings against its neighbours the rest of the time.

## The ⋮ was heavier than the ✕

Same colour, different opacity — `1` against `0.4`. All three opacity rules used `trailing > button`, which the wrapper blocks.

Named the wrapped trigger explicitly rather than relaxing to a descendant selector: the popover lives inside `.proto-recall-row__more` too, so `trailing button` would dim every item of the open menu along with the trigger — **a regression that looks identical in a screenshot**, which is why the test pins the combinator rather than the appearance.

Added the state that was missing either way: an open menu keeps its trigger lit, or the ⋮ fades out from under the panel it just opened.

## The title column was inset on one side only

```css
padding: 11px 13px;
margin: -11px 0 -11px -13px;
```

The margin cancels top, bottom and left, turning that padding into hit area. The right had no margin to cancel it, so it was the one side where the number inset the text for real — stacking with the row's own 13px padding *and* the 11px flex gap. 24px of dead space beside the ✕, on a 260px row whose meta line wants 382px and gets 113px.

Zero is the symmetric answer rather than a tightening: the text now ends 13px from the row's edge, the same 13px it starts from on the left. It deliberately does **not** get a matching negative margin — the hit area would slide under the trailing controls and steal presses meant for them.

Measured before and after: title column 113px → 126px, gap 24px → 11px, hit area still clear of the trailing buttons. "Why I made Harvous" now fits where it was truncated.

## Verification

Full suite 4160 passing (404 files, +6). Typecheck at the 281 baseline. `design:check`, `check:color-tokens`, `perf:check` (1110.5 KB), and the marquee gallery suite all pass.

Also rewrites the auto-drafted release note, which ships with its own banner saying to rewrite it before sharing.