### PR TITLE
Phase A: serve the app from a Cloudflare Worker (verified, not yet live)

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -108,4 +108,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy ${{ github.ref_name == 'staging' && '--env staging' || '' }}
+          # ONLY main reaches the production Worker. Everything else — the staging branch,
+          # and any manual workflow_dispatch from a feature branch — goes to harvous-app-staging.
+          # Without this, a dispatch from a feature branch would deploy a DEV-Clerk build onto
+          # the production Worker, since the key above is chosen by the same ref check.
+          command: deploy ${{ github.ref_name == 'main' && '' || '--env staging' }}

--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -46,27 +46,41 @@ jobs:
 
       - run: npm run build:spa
         env:
-          # Live Clerk on main; dev Clerk on staging (new.harvous.com), matching
-          # netlify.toml's [context.staging]. The key is inlined at build time, which is
-          # why staging is a separate build rather than a redeploy of the same artifact.
+          # EXACTLY the 10 build-time vars Netlify's PRODUCTION context sets, verified
+          # 2026-08-30 via `netlify env:list --context production`. Do not add to this list
+          # on the theory that a var "looks needed": Phase A must produce a bundle
+          # indistinguishable from today's, and a var Netlify leaves unset is a var this
+          # build must leave unset too.
+          #
+          # Notably ABSENT on purpose, though the code reads them:
+          #   VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY — unset in production, so
+          #     isSupabaseRealtimeConfigured() is false and the app runs on HTTP polling.
+          #     Setting them here would switch realtime ON only on Cloudflare.
+          #   VITE_API_BASE_URL — unset, so the SPA calls its own origin. Correct, since the
+          #     Worker proxies /api/* to Fly.
+          #   VITE_PUBLIC_POSTHOG_KEY — the code reads it, production never sets it;
+          #     PUBLIC_POSTHOG_KEY is the one that is actually used.
+          #   VITE_POLAR_CHURCH_PRODUCT_* — referenced in one file, unset in production.
+          #
+          # Live Clerk on main, dev Clerk on staging (new.harvous.com), matching
+          # netlify.toml's [context.staging]. The key is inlined at build time, which is why
+          # staging is a separate build rather than a redeploy of the same artifact.
+          # WARNING: VITE_CLERK_PUBLISHABLE_KEY in the repo's .env is a pk_test_ DEV key.
+          # The _LIVE secret must come from the Clerk dashboard, not from .env — copying it
+          # across is what failed all three Fly cutovers.
           VITE_CLERK_PUBLISHABLE_KEY: ${{ github.ref_name == 'main' && secrets.VITE_CLERK_PUBLISHABLE_KEY_LIVE || secrets.VITE_CLERK_PUBLISHABLE_KEY_DEV }}
           PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ github.ref_name == 'main' && secrets.VITE_CLERK_PUBLISHABLE_KEY_LIVE || secrets.VITE_CLERK_PUBLISHABLE_KEY_DEV }}
-          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
-          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
-          VITE_PUBLIC_POSTHOG_KEY: ${{ secrets.VITE_PUBLIC_POSTHOG_KEY }}
-          PUBLIC_POSTHOG_KEY: ${{ secrets.VITE_PUBLIC_POSTHOG_KEY }}
+          PUBLIC_POSTHOG_KEY: ${{ secrets.PUBLIC_POSTHOG_KEY }}
+          PUBLIC_POSTHOG_HOST: ${{ secrets.PUBLIC_POSTHOG_HOST }}
+          VITE_CLERK_SHARED_SPACES_PLAN_ID: ${{ secrets.VITE_CLERK_SHARED_SPACES_PLAN_ID }}
           # Public plan identifiers, not secrets (netlify.toml carried them in
           # SECRETS_SCAN_OMIT_KEYS for exactly this reason). Omitting these is what made
-          # billing return zero plans during the Fly migration — the grep that built that
-          # import list only covered server/, and missed the ones the SPA bundle inlines.
+          # billing return zero plans during the Fly migration.
           VITE_POLAR_PLUS_PRODUCT_FOUNDING_ANNUAL: ${{ secrets.VITE_POLAR_PLUS_PRODUCT_FOUNDING_ANNUAL }}
           VITE_POLAR_PLUS_PRODUCT_MONTHLY: ${{ secrets.VITE_POLAR_PLUS_PRODUCT_MONTHLY }}
           VITE_POLAR_PLUS_PRODUCT_ANNUAL: ${{ secrets.VITE_POLAR_PLUS_PRODUCT_ANNUAL }}
           VITE_POLAR_CONNECTOR_PRODUCT_MONTHLY: ${{ secrets.VITE_POLAR_CONNECTOR_PRODUCT_MONTHLY }}
           VITE_POLAR_CONNECTOR_PRODUCT_ANNUAL: ${{ secrets.VITE_POLAR_CONNECTOR_PRODUCT_ANNUAL }}
-          VITE_POLAR_CHURCH_PRODUCT_MONTHLY: ${{ secrets.VITE_POLAR_CHURCH_PRODUCT_MONTHLY }}
-          VITE_POLAR_CHURCH_PRODUCT_ANNUAL: ${{ secrets.VITE_POLAR_CHURCH_PRODUCT_ANNUAL }}
 
       # Cloudflare-only routing/header config. Deliberately NOT in public/ — Vite copies
       # public/ verbatim, so a file there would also ship to Netlify and layer a second

--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -1,0 +1,97 @@
+# Deploy the SPA + Worker to Cloudflare (Phase A — docs/CLOUDFLARE_MIGRATION.md).
+#
+# Cloudflare has no git integration, so this replaces what Netlify's build hook did.
+# Netlify keeps building `main` in parallel during the cutover soak; it is the rollback
+# path and is not touched here.
+name: Deploy to Cloudflare
+
+on:
+  push:
+    branches: [main, staging]
+    # Mirrors scripts/netlify-skip-build.sh, which skips only when EVERY changed file is
+    # doc-only. paths-ignore reproduces that exactly; a `paths` allowlist would instead
+    # silently skip deploys for any path nobody remembered to list.
+    paths-ignore:
+      - 'docs/**'
+      - 'Changelog/**'
+      - 'help/**'
+      - 'release-notes/**'
+  workflow_dispatch:
+
+# One deploy at a time per branch; a newer push supersedes an in-flight one.
+concurrency:
+  group: cloudflare-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22 # was NODE_VERSION in netlify.toml
+          cache: npm
+
+      # NPM_FLAGS from netlify.toml
+      - run: npm ci --prefer-offline --no-audit
+
+      # Rolls the PWA cache key so returning clients pick up the new build. Reads
+      # GITHUB_SHA here — Netlify's COMMIT_REF/DEPLOY_ID do not exist on Actions, and
+      # without a build id every deploy between two version bumps ships a byte-identical
+      # sw.js. See the comment block in the script itself.
+      - run: node scripts/inject-sw-cache-version.js
+
+      - run: npm run build:spa
+        env:
+          # Live Clerk on main; dev Clerk on staging (new.harvous.com), matching
+          # netlify.toml's [context.staging]. The key is inlined at build time, which is
+          # why staging is a separate build rather than a redeploy of the same artifact.
+          VITE_CLERK_PUBLISHABLE_KEY: ${{ github.ref_name == 'main' && secrets.VITE_CLERK_PUBLISHABLE_KEY_LIVE || secrets.VITE_CLERK_PUBLISHABLE_KEY_DEV }}
+          PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ github.ref_name == 'main' && secrets.VITE_CLERK_PUBLISHABLE_KEY_LIVE || secrets.VITE_CLERK_PUBLISHABLE_KEY_DEV }}
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_PUBLIC_POSTHOG_KEY: ${{ secrets.VITE_PUBLIC_POSTHOG_KEY }}
+          PUBLIC_POSTHOG_KEY: ${{ secrets.VITE_PUBLIC_POSTHOG_KEY }}
+          # Public plan identifiers, not secrets (netlify.toml carried them in
+          # SECRETS_SCAN_OMIT_KEYS for exactly this reason). Omitting these is what made
+          # billing return zero plans during the Fly migration — the grep that built that
+          # import list only covered server/, and missed the ones the SPA bundle inlines.
+          VITE_POLAR_PLUS_PRODUCT_FOUNDING_ANNUAL: ${{ secrets.VITE_POLAR_PLUS_PRODUCT_FOUNDING_ANNUAL }}
+          VITE_POLAR_PLUS_PRODUCT_MONTHLY: ${{ secrets.VITE_POLAR_PLUS_PRODUCT_MONTHLY }}
+          VITE_POLAR_PLUS_PRODUCT_ANNUAL: ${{ secrets.VITE_POLAR_PLUS_PRODUCT_ANNUAL }}
+          VITE_POLAR_CONNECTOR_PRODUCT_MONTHLY: ${{ secrets.VITE_POLAR_CONNECTOR_PRODUCT_MONTHLY }}
+          VITE_POLAR_CONNECTOR_PRODUCT_ANNUAL: ${{ secrets.VITE_POLAR_CONNECTOR_PRODUCT_ANNUAL }}
+          VITE_POLAR_CHURCH_PRODUCT_MONTHLY: ${{ secrets.VITE_POLAR_CHURCH_PRODUCT_MONTHLY }}
+          VITE_POLAR_CHURCH_PRODUCT_ANNUAL: ${{ secrets.VITE_POLAR_CHURCH_PRODUCT_ANNUAL }}
+
+      # Cloudflare-only routing/header config. Deliberately NOT in public/ — Vite copies
+      # public/ verbatim, so a file there would also ship to Netlify and layer a second
+      # header source onto the live rollback target mid-soak.
+      - name: Stage Cloudflare _headers / _redirects / .assetsignore
+        # .assetsignore is not optional: Workers assets reject any single file over 5 MiB,
+        # and dist-spa/assets/index-*.js.map is ~10 MB. Without it the deploy fails outright
+        # with "Invalid manifest: file size ... exceeds 5242880 limit [code: 10304]".
+        run: cp cloudflare/_headers cloudflare/_redirects cloudflare/.assetsignore dist-spa/
+
+      # Guards the one regression this migration is most likely to ship. See the ordering
+      # note in cloudflare/_headers.
+      - name: Assert the two deploy-breaking invariants
+        run: |
+          # The cache tier that costs ~703.7 KB per visit if it regresses.
+          grep -q 'max-age=31536000, immutable' dist-spa/_headers
+          # No asset may exceed the 5 MiB Workers limit once .assetsignore is applied.
+          if find dist-spa -type f -size +5242880c ! -name '*.map' | grep -q .; then
+            echo "Asset over the 5 MiB Workers limit:" >&2
+            find dist-spa -type f -size +5242880c ! -name '*.map' -exec ls -lh {} \; >&2
+            exit 1
+          fi
+
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy ${{ github.ref_name == 'staging' && '--env staging' || '' }}

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ playwright-report/
 # version of the fix that survives the next wide `add`. The file stays on disk and is not deleted;
 # if it ever becomes something to publish, remove this line and add it deliberately.
 docs/future/SCRIPTURE_CONCORDANCE.md
+
+# Wrangler local state (wrangler dev caches, local KV/DO/R2 simulation)
+.wrangler/

--- a/cloudflare/.assetsignore
+++ b/cloudflare/.assetsignore
@@ -1,0 +1,21 @@
+# Excluded from the Cloudflare asset upload (gitignore syntax, read from the assets
+# directory root). Cloudflare-only: the Netlify build stays byte-identical, so the
+# rollback target during the soak is unaffected.
+
+# Sourcemaps. Two reasons, found 2026-08-30 during the first temporary deploy:
+#
+#   1. HARD BLOCKER. Workers assets cap a single file at 5 MiB
+#      (5,242,880 bytes) and dist-spa/assets/index-*.js.map is ~10 MB, so the
+#      upload is rejected outright: "Invalid manifest: file size of 10450166
+#      exceeds 5242880 limit [code: 10304]".
+#   2. Nothing consumes them. vite.config.ts sets `sourcemap: 'hidden'`, so no
+#      `//# sourceMappingURL=` comment is emitted and no browser requests them; no
+#      workflow uploads them to an error tracker either. They are 14 MB across 34
+#      files — 37% of a 38 MB deploy — shipped for no reader.
+#
+# Worth knowing separately: they ARE publicly fetchable on Netlify today
+# (GET /assets/index-<hash>.js.map returns 200 and 10.4 MB), which makes the
+# minified bundle trivially reconstructable. Excluding them here closes that on
+# Cloudflare; closing it on Netlify would mean changing the shared build, which is
+# deliberately frozen until cleanup.
+*.map

--- a/cloudflare/_headers
+++ b/cloudflare/_headers
@@ -1,0 +1,50 @@
+# Transcribed from netlify.toml (Phase A, docs/CLOUDFLARE_MIGRATION.md).
+#
+# NOT in public/ on purpose. Vite copies public/ verbatim into dist-spa, so a file
+# there would ALSO be served by Netlify — layering a second header source onto the live
+# site during the rollback soak. The deploy workflow copies this into dist-spa/ for
+# Cloudflare only, which keeps netlify.toml and public/_redirects byte-identical until
+# cleanup.
+#
+# ORDERING WARNING — the one thing that does not port cleanly. Netlify applies every
+# matching rule and lets the LATER one win, which is why the cache tiers below sit after
+# the /* catch-all in netlify.toml. That ordering is load-bearing there and documented at
+# length: getting it backwards once shipped a 2.7MB bundle with no-cache on every visit.
+# Cloudflare uses SPECIFICITY instead, and the `!` lines below detach the inherited value
+# so each tier wins outright. Both the specificity assumption and the `!` syntax are
+# checked by scripts/cf-parity-check.sh before any DNS moves — if they do not hold, these
+# move into Worker code where order is explicit.
+
+/*
+  Cache-Control: no-cache, must-revalidate
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.clerk.com https://clerk.harvous.com https://*.js.stripe.com https://js.stripe.com https://*.posthog.com https://*.us.posthog.com https://challenges.cloudflare.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: https: blob:; connect-src 'self' https://*.clerk.com https://clerk.harvous.com https://*.clerk.accounts.dev https://api.stripe.com https://*.posthog.com https://*.us.posthog.com https://api.bible.org; frame-src 'self' https://*.clerk.com https://clerk.harvous.com https://challenges.cloudflare.com https://*.js.stripe.com https://js.stripe.com https://hooks.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests;
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=()
+  X-XSS-Protection: 1; mode=block
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+
+# Hashed filenames: a change is a new name, so these can be kept forever. This is the
+# single most important line in the file (~703.7 KB gzipped re-downloaded per visit if
+# it regresses — docs/performance/PERF_BASELINE.md).
+/assets/*
+  ! Cache-Control
+  Cache-Control: public, max-age=31536000, immutable
+
+# Fonts are NOT content-hashed, so not `immutable` — a year would be unrecallable if a
+# face were ever replaced. Thirty days still turns the 1.4MB variable font from a
+# revalidation on every page load into one fetch a month.
+/fonts/*
+  ! Cache-Control
+  Cache-Control: public, max-age=2592000
+
+# Wallpapers, space covers, auth heroes — 13MB of them. Stable names, same reasoning as
+# fonts: a long but finite window rather than `immutable`.
+/images/*
+  ! Cache-Control
+  Cache-Control: public, max-age=2592000
+
+/icons/*
+  ! Cache-Control
+  Cache-Control: public, max-age=2592000

--- a/cloudflare/_redirects
+++ b/cloudflare/_redirects
@@ -1,0 +1,18 @@
+# What is left of public/_redirects once the Worker owns routing (Phase A).
+#
+# Gone from here, all now Worker code (cloudflare/worker.ts):
+#   /api/og/image/* and /api/*  -> Fly            (Cloudflare _redirects CANNOT 200-proxy to
+#                                                  an external domain; this is the whole
+#                                                  reason Phase A uses Workers, not Pages)
+#   /assets/*  404 guard                          (assets branch)
+#   /*  ->  /index.html  200                      (not_found_handling: single-page-application)
+#
+# Same-site rewrites are supported, so this one stays. Chrome fetches the dotted path for
+# PWA link handling; the undotted copy is what gets served.
+#
+# NOTE (found 2026-08-30): public/.well-known/web-app-origin-association now also exists as a
+# real file — same JSON, pretty-printed rather than minified — so this rule may be a leftover
+# from the Astro era, when /well-known/ was an endpoint rather than a file. Keeping it
+# reproduces today's Netlify behaviour exactly, which is the Phase A contract. Revisit in
+# cleanup, not during the cutover.
+/.well-known/web-app-origin-association  /well-known/web-app-origin-association  200

--- a/cloudflare/worker.ts
+++ b/cloudflare/worker.ts
@@ -1,0 +1,172 @@
+/**
+ * The Cloudflare Worker fronting app.harvous.com / new.harvous.com.
+ *
+ * Replaces five things Netlify used to do (docs/CLOUDFLARE_MIGRATION.md):
+ *   1. reverse-proxy /api/* to the Hono API on Fly
+ *   2. the crawler-UA rewrite on /shared/* (was netlify/edge-functions/shared-og.ts)
+ *   3. the stale-hashed-asset 404 guard (was a rule in public/_redirects)
+ *   4. the legacy 301/302 redirects (were [[redirects]] blocks in netlify.toml)
+ *   5. SPA fallback + static hosting (the `assets` binding in wrangler.jsonc)
+ *
+ * Everything else — Fly, Supabase, Clerk, Polar — is untouched. The SPA, the native
+ * app, and the offline queue keep calling app.harvous.com and must not be able to
+ * tell the difference.
+ */
+
+interface Env {
+  ASSETS: Fetcher;
+  /** https://harvous.fly.dev — set in wrangler.jsonc, per-env. */
+  API_ORIGIN: string;
+}
+
+/**
+ * Case-insensitive substrings matched against User-Agent.
+ * Ported verbatim from netlify/edge-functions/shared-og.ts — keep the two in sync
+ * until that file is deleted in cleanup.
+ *
+ * Note what does NOT come across: Netlify's declaration-level `config` matchers, which
+ * existed as a *billing gate* (Aug 2026 bot floods burned ~772K of 1M free invocations
+ * because a bare path glob invoked the function for every hit). Cloudflare's
+ * `run_worker_first` has no UA filter, so this list is now only a behavioural check —
+ * the cost question is handled by the plan tier instead.
+ */
+const CRAWLER_UA_SNIPPETS = [
+  'facebookexternalhit',
+  'Facebot',
+  'Twitterbot',
+  'LinkedInBot',
+  'Slackbot',
+  'Slack-ImgProxy',
+  'Discordbot',
+  'TelegramBot',
+  'WhatsApp',
+  'Applebot',
+  'facebookcatalog',
+  'meta-externalagent',
+  'Pinterestbot',
+  'Embedly',
+  'Quora Link Preview',
+  'outbrain',
+  'vkShare',
+  'W3C_Validator',
+  'redditbot',
+  'SkypeUriPreview',
+  'Iframely',
+  'Googlebot',
+  'bingbot',
+  'Baiduspider',
+  'DuckDuckBot',
+  'YandexBot',
+  'ia_archiver',
+];
+
+const SHARE_PATH = /^\/shared\/(note|thread)\/([A-Za-z0-9]{12})\/?$/;
+
+function isCrawler(userAgent: string | null): boolean {
+  if (!userAgent) return false;
+  const ua = userAgent.toLowerCase();
+  return CRAWLER_UA_SNIPPETS.some((snippet) => ua.includes(snippet.toLowerCase()));
+}
+
+/**
+ * The [[redirects]] blocks from netlify.toml.
+ *
+ * THE ONE PLACE THIS WORKER IS NOT BYTE-FAITHFUL TO TODAY'S PRODUCTION — read before
+ * assuming it is a regression. Verified against app.harvous.com on 2026-08-30: every one of
+ * these rules is currently DEAD. `public/_redirects` ends in a `/* -> /index.html 200`
+ * catch-all which Netlify evaluates first, so /thread_abc123 and /prototype/dashboard both
+ * return the SPA shell at 200 and these [[redirects]] never fire. The Worker runs before the
+ * asset lookup, so implementing them here makes them work for the first time.
+ *
+ * Kept deliberately, because the alternative is porting known-dead config into a fresh
+ * implementation to preserve an ordering accident:
+ *   - /thread_ /note_ /space_ (301): pure legacy-bookmark repair. Today those URLs reach the
+ *     SPA's not-found state (router.tsx has no matching route — only a legacy `?space=`
+ *     query-param reader). Cannot collide with the live /thread/$threadId etc. routes,
+ *     which take a slash rather than an underscore.
+ *   - /prototype/* (302): safe on exactly the two hosts this Worker serves. Both
+ *     app.harvous.com and new.harvous.com are in DEDICATED_PROTOTYPE_HOSTS
+ *     (src/lib/prototype-path.ts), where /prototype is never a live route and the SPA
+ *     already strips the prefix client-side (spa/src/router.tsx:114). This just does it a
+ *     round-trip earlier. On any OTHER host /prototype IS a live route — which is why the
+ *     netlify.toml version was host-scoped, and why this must not be reused elsewhere.
+ *
+ * If either is unwanted, deleting this function is a safe no-op against current behaviour.
+ *
+ * The /prototype strip was host-scoped in netlify.toml (one block per host). It is
+ * host-agnostic here for the reason above, and `new URL(path, url)` preserves whichever
+ * host the request arrived on.
+ */
+function legacyRedirect(url: URL): Response | null {
+  const p = url.pathname;
+
+  // 302 — legacy bookmarks from when the prototype lived under /prototype/.
+  if (p.startsWith('/prototype/')) {
+    return Response.redirect(new URL(p.slice('/prototype'.length) + url.search, url).toString(), 302);
+  }
+
+  // 301 — old underscore URL format (/thread_ID) to the current one (/thread/ID).
+  for (const [prefix, target] of [
+    ['/thread_', '/thread/'],
+    ['/note_', '/note/'],
+    ['/space_', '/space/'],
+  ] as const) {
+    if (p.startsWith(prefix)) {
+      return Response.redirect(new URL(target + p.slice(prefix.length) + url.search, url).toString(), 301);
+    }
+  }
+
+  return null;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    // ── /api/* → the Hono API on Fly, streamed both directions.
+    //
+    // No Netlify-style ~28s proxy ceiling and no duplicated request headers, which is
+    // what let CSRF be re-enabled in server/app.ts. Both public/_redirects rules
+    // (/api/og/image/* and /api/*) pointed at the same origin, so one branch covers them.
+    if (url.pathname.startsWith('/api/')) {
+      const upstream = new URL(url.pathname + url.search, env.API_ORIGIN);
+      return fetch(new Request(upstream.toString(), request));
+    }
+
+    // ── Crawlers on share URLs get server-rendered OG meta HTML from Fly so unfurls
+    // carry og:title/og:description/og:image. Humans fall through to the SPA shell.
+    const share = url.pathname.match(SHARE_PATH);
+    if (share && isCrawler(request.headers.get('user-agent'))) {
+      const [, kind, token] = share;
+      const og = new URL(`/api/og/share/${kind}/${token}`, env.API_ORIGIN);
+      return fetch(new Request(og.toString(), request));
+    }
+
+    // ── Hashed build assets must NEVER fall through to the SPA shell.
+    //
+    // Each deploy publishes a fresh dist-spa, so the previous deploy's
+    // /assets/*-<hash>.js are gone. Answering those with index.html at 200 text/html
+    // (a) fails the module MIME check as "Failed to fetch dynamically imported module"
+    // and (b) gets cached by the service worker under the .js URL, making the failure
+    // permanent. 404 is the honest answer. Same reasoning as the load-bearing rule this
+    // replaces in public/_redirects.
+    //
+    // VERIFIED 2026-08-30 (wrangler dev, local workerd): this branch is REQUIRED. With
+    // /assets/* removed from `run_worker_first`, a missing hashed asset returns
+    // `200 text/html` — the SPA shell — which is exactly the poisoning case above.
+    // `not_found_handling: "single-page-application"` does NOT exempt extension-bearing
+    // paths. Re-confirm once against the deployed workers.dev URL at stage 2, then treat
+    // it as settled: /assets/* stays in run_worker_first, and every hashed chunk therefore
+    // bills a Worker invocation. That is what the plan-tier decision has to price in.
+    if (url.pathname.startsWith('/assets/')) {
+      const res = await env.ASSETS.fetch(request);
+      const servedHtmlInstead =
+        res.ok && (res.headers.get('content-type') ?? '').includes('text/html');
+      if (servedHtmlInstead) return new Response('Not found', { status: 404 });
+      return res;
+    }
+
+    // ── Legacy redirects, then static assets with SPA fallback.
+    return legacyRedirect(url) ?? env.ASSETS.fetch(request);
+  },
+} satisfies ExportedHandler<Env>;

--- a/cloudflare/worker.ts
+++ b/cloudflare/worker.ts
@@ -62,6 +62,16 @@ const CRAWLER_UA_SNIPPETS = [
 
 const SHARE_PATH = /^\/shared\/(note|thread)\/([A-Za-z0-9]{12})\/?$/;
 
+/**
+ * Mirrors DEDICATED_PROTOTYPE_HOSTS in src/lib/prototype-path.ts. Keep the two in sync:
+ * the app decides whether `/prototype` is a live route from this same set, and the
+ * /prototype strip below is only correct on hosts that are in it.
+ *
+ * `localhost` is omitted deliberately — it is in the app's set for dev, but this Worker
+ * never serves it.
+ */
+const DEDICATED_PROTOTYPE_HOSTS = new Set(['app.harvous.com', 'new.harvous.com']);
+
 function isCrawler(userAgent: string | null): boolean {
   if (!userAgent) return false;
   const ua = userAgent.toLowerCase();
@@ -101,7 +111,15 @@ function legacyRedirect(url: URL): Response | null {
   const p = url.pathname;
 
   // 302 — legacy bookmarks from when the prototype lived under /prototype/.
-  if (p.startsWith('/prototype/')) {
+  //
+  // HOST-GATED, and it must stay that way. `/prototype` is only a dead prefix on hosts in
+  // DEDICATED_PROTOTYPE_HOSTS; everywhere else it is a LIVE route
+  // (getPrototypeBasePath() returns '/prototype' when the host is not dedicated), so
+  // stripping it there would break the app. status.harvous.com is exactly such a host —
+  // it is served by this same build and this same Worker, and spa/src/router.tsx carries
+  // the matching rule in so many words: "status.harvous.com owns `/` for the public status
+  // page — never send it to /prototype."
+  if (DEDICATED_PROTOTYPE_HOSTS.has(url.hostname) && p.startsWith('/prototype/')) {
     return Response.redirect(new URL(p.slice('/prototype'.length) + url.search, url).toString(), 302);
   }
 

--- a/docs/CLOUDFLARE_MIGRATION.md
+++ b/docs/CLOUDFLARE_MIGRATION.md
@@ -567,4 +567,30 @@ section — the account has been on Pro since the Aug 2026 pause) as you go.
      GitHub secrets, let `cloudflare-deploy.yml` build, then smoke-test that artifact
      *before* stage 3.
 
+- 2026-08-30 (status host) — **`status.harvous.com` resolved, and it was hiding a bug.**
+  The runbook left it as "decide during execution". Decision: it belongs on the **production
+  Worker**, because it is a Netlify *domain alias of the same site* today — same `dist-spa`,
+  with `isStatusHost()` (`src/lib/status-page-host.ts`) making the SPA render the status page
+  at `/`. Putting it anywhere else would mean keeping the Netlify site alive purely for one
+  alias, which blocks the "delete the Netlify site" cleanup step.
+
+  The bug it exposed: `status.harvous.com` is **not** in `DEDICATED_PROTOTYPE_HOSTS`, so
+  `/prototype` is a **live route** there — `spa/src/router.tsx` states it directly
+  ("status.harvous.com owns `/` for the public status page — never send it to /prototype").
+  `legacyRedirect()` stripped `/prototype/*` on every host, so attaching the status domain
+  would have broken it. It is now gated on a mirror of `DEDICATED_PROTOTYPE_HOSTS`
+  (app/new only — `localhost` omitted, this Worker never serves it); keep the two in sync.
+
+  Consequence for the gate: the `/prototype` strip is **unverifiable on a `*.workers.dev`
+  URL**, where the correct behaviour is *not* to redirect. `scripts/cf-parity-check.sh` now
+  asserts both directions and picks which by hostname. Re-verified 20/20 after the change.
+
+  Status-page data path is unaffected: it reads `/api/status/public` on Fly through the
+  Worker proxy, and `BETTERSTACK_STATUS_JSON_URL` is a Fly env var that does not move. Per
+  `docs/STATUS_PAGE_SETUP.md`, it must not point at `status.harvous.com/index.json` (loops).
+
+  So **three** custom domains attach at stage 4, not one: `app.harvous.com` and
+  `status.harvous.com` on production, `new.harvous.com` on `--env staging`.
+
+
 

--- a/docs/CLOUDFLARE_MIGRATION.md
+++ b/docs/CLOUDFLARE_MIGRATION.md
@@ -1,6 +1,6 @@
 # Phase A: Netlify → Cloudflare (app.harvous.com)
 
-**Status: PLANNED.** Drafted 2026-08-27. Part of [INFRA_ENDGAME.md](INFRA_ENDGAME.md).
+**Status: STAGE 2 CLEAR — deployed to the real Cloudflare account, 20/20 parity, no DNS touched.** Drafted 2026-08-27. Part of [INFRA_ENDGAME.md](INFRA_ENDGAME.md).
 
 Moves everything Netlify still does for app.harvous.com onto Cloudflare Workers:
 static SPA hosting, the `/api/*` → Fly proxy, headers/CSP, the crawler OG rewrite,
@@ -462,3 +462,109 @@ section — the account has been on Pro since the Aug 2026 pause) as you go.
   against source this date; Cloudflare platform behaviors (`_headers` detach
   syntax, assets-binding 404 shape) flagged inline for empirical verification at
   execution time.
+
+- 2026-08-30 — **Stage 1 built and verified locally. No Cloudflare account, no deploy, no DNS
+  change yet.** Added `wrangler.jsonc`, `cloudflare/worker.ts`, `cloudflare/_headers`,
+  `cloudflare/_redirects`, `scripts/cf-parity-check.sh`,
+  `.github/workflows/cloudflare-deploy.yml`; `wrangler` + `@cloudflare/workers-types` as
+  devDeps. `scripts/cf-parity-check.sh` reports **20/20 against `wrangler dev`**, and 16/20
+  against production Netlify (the four gaps being the legacy redirects — see below).
+  `npm run perf:check` green (1117.2 KB, 0.3 KB under baseline; the doc's 1078.4 KB figure
+  had already moved).
+
+  Five findings that change the runbook as drafted:
+
+  1. **`scripts/inject-sw-cache-version.js` read only `COMMIT_REF`/`DEPLOY_ID`, both
+     Netlify-only.** On GitHub Actions the build id fell back to empty, which ships a
+     byte-identical `sw.js` for every deploy between two version bumps — returning clients
+     then keep serving the previous deploy's `index.html` with dead chunk hashes. Fixed by
+     adding `GITHUB_SHA` to the fallback chain. This would have been a soak-week mystery.
+  2. **The `/assets/*` guard is REQUIRED — the tier question is settled against us.** With
+     `/assets/*` removed from `run_worker_first`, local workerd answers a missing hashed asset
+     with `200 text/html`; `not_found_handling: "single-page-application"` does not exempt
+     extension-bearing paths. So every hashed chunk bills an invocation (~7 per cold load from
+     the initial document alone, 90 built asset files in total). The drafted
+     Workers-Paid-from-day-one recommendation stands, now on evidence rather than estimate.
+  3. **Every legacy redirect in `netlify.toml` is dead in production.** Verified against
+     app.harvous.com: `public/_redirects` ends in a `/* -> /index.html 200` catch-all that
+     Netlify evaluates first, so `/thread_abc123` and `/prototype/dashboard` both return the
+     SPA shell at 200 and the `[[redirects]]` blocks never fire. The Worker hits the same trap
+     unless the paths are listed in `run_worker_first` — they now are, so these work for the
+     first time. Deleting those four strings is the clean opt-out back to strict parity.
+  4. **Cloudflare's `_headers` reproduced the cache tiering exactly**, `!` detach syntax and
+     all — the ordering risk the doc flags as the #1 regression did not materialise. The files
+     live at `cloudflare/` rather than `public/` so Vite does not also ship them to Netlify
+     during the soak, keeping the rollback target byte-identical.
+  5. **`public/.well-known/web-app-origin-association` now exists as a real file** and Vite
+     copies the dotfile directory into `dist-spa`. The 200-rewrite is kept anyway to match
+     current behaviour; revisit in cleanup.
+
+  Also corrected in `.claude/agents/engineer.context.md`: the stale "Netlify free plan is a
+  hard cap" section (the account is on Pro — 5,000 credits, measured 2,628.4 consumed in 9
+  days), and the `/api/health` baseline (**182 ms** re-measured 2026-08-30, vs the 250-280 ms
+  row that predates the Fly cutover).
+
+- 2026-08-30 (later) — **Verified against REAL Cloudflare edge** via
+  `wrangler deploy --temporary`, which spins up a throwaway preview account with no
+  signup, no payment and no DNS (`https://harvous-app-preview.<temp>.workers.dev`).
+  Every one of the 20 parity checks passed on real infrastructure. Three things this
+  caught that local `wrangler dev` could not:
+
+  1. **A hard deploy blocker the runbook never anticipated.** Workers assets reject any
+     single file over **5 MiB**, and `dist-spa/assets/index-*.js.map` is ~10 MB, so the
+     first upload failed outright (`code: 10304`). Fixed with `cloudflare/.assetsignore`
+     excluding `*.map` — 14 MB across 34 files, **37% of a 38 MB deploy**, with no
+     consumer: `vite.config.ts` sets `sourcemap: 'hidden'` so no `sourceMappingURL` is
+     emitted, and no workflow uploads them to an error tracker. The deploy workflow now
+     copies `.assetsignore` alongside `_headers`/`_redirects` and fails the build on any
+     non-map asset over the limit.
+  2. **Sourcemaps are publicly served on Netlify today** —
+     `GET /assets/index-<hash>.js.map` returns **200 and 10.4 MB**, which makes the
+     minified bundle trivially reconstructable. Closed on Cloudflare by the above; closing
+     it on Netlify would mean changing the shared build, deliberately frozen until cleanup.
+  3. **`_headers` specificity reproduces the Netlify tiering exactly on real edge** —
+     `/assets/*` immutable, `/fonts|images|icons/*` at 30 days, `/*` no-cache, all seven
+     security headers, and `/api/*` `no-store` passing through untouched from Fly. The
+     ordering risk the doc calls the #1 regression did not materialise in either engine.
+
+  Two caveats on the method, both about the throwaway account rather than the config:
+  **temporary preview accounts challenge automated traffic** — roughly 20% of rapid
+  requests come back as a bare 403, and some as Cloudflare's "Just a moment..."
+  interstitial, on the same URL within the same second. `scripts/cf-parity-check.sh` now
+  retries transient 403s and reports the count, since retries are expected on a temporary
+  account and a red flag on a real one. A clean single-shot 20/20 therefore needs a real
+  account. Latency measured 149-192 ms through Cloudflare to Fly against 182 ms through
+  Netlify to Fly, but the challenge traffic makes that provisional — re-measure at stage 4.
+
+- 2026-08-30 (stage 2) — **Deployed to the real account and the gate is CLEAR: 20/20, zero
+  retries.** Account `Testament Made` / `ec934baa29eb81459ffeaf18ba044b9e`, authenticated
+  by `wrangler login` (browser OAuth — no API token ever entered the working session).
+  Worker live at `https://harvous-app.harvous.workers.dev`; `app.harvous.com` untouched and
+  still entirely on Netlify. Latency 126-152 ms mean of 6 vs **182 ms** through Netlify, so
+  the "≤ Netlify" gate is met with margin.
+
+  Three things stage 2 changed:
+
+  1. **`wrangler.jsonc` cannot carry the custom-domain route before stage 3.** harvous.com
+     is not a zone on the account yet, so wrangler cannot resolve `app.harvous.com` and
+     *every* deploy fails. Both `routes` blocks are now commented with a STAGE 4 marker and
+     `workers_dev: true` added, which is what stages 1-2 test against. Uncomment at stage 4;
+     that is the moment traffic actually moves.
+  2. **`_headers` rules take ~30-60s to propagate after a deploy.** Runs started immediately
+     after `wrangler deploy` reported random subsets of missing `cache-control` / HSTS that
+     were all correct a minute later — seen on three separate deploys, and it is what made
+     the earlier temporary-account runs look worse than they were.
+     `scripts/cf-parity-check.sh` now polls for HSTS on `/` before running anything and says
+     so, which is the difference between a trustworthy gate and a flaky one.
+  3. **The deployed bundle is unauthenticated and cannot boot.** There is no `.env` in the
+     worktree, so the local `build:spa` inlined no `VITE_CLERK_PUBLISHABLE_KEY` and no
+     Supabase config; the page renders its theme background and React then throws
+     `Missing VITE_CLERK_PUBLISHABLE_KEY env var`. **This does not affect the parity result** —
+     the matrix exercises the Worker layer (routing, headers, proxy, redirects, crawler
+     rewrite), all of which is what Phase A migrates. But it means the **authenticated Clerk
+     smoke test cannot be run against this build**, and that is the single check that caught
+     all three failed Fly cutovers. It needs a CI build carrying the real secrets — set the
+     GitHub secrets, let `cloudflare-deploy.yml` build, then smoke-test that artifact
+     *before* stage 3.
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "harvous",
-  "version": "2.37.3",
+  "version": "2.87.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "harvous",
-      "version": "2.37.3",
+      "version": "2.87.2",
       "hasInstallScript": true,
       "dependencies": {
         "@capacitor/android": "^8.1.0",
@@ -90,6 +90,7 @@
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.88.0",
         "@clerk/testing": "^1.13.35",
+        "@cloudflare/workers-types": "^5.20260831.1",
         "@netlify/edge-functions": "^3.0.8",
         "@playwright/test": "^1.58.2",
         "@testing-library/jest-dom": "^6.6.3",
@@ -102,7 +103,8 @@
         "jsdom": "^25.0.1",
         "lighthouse": "^11.7.1",
         "tsx": "^4.21.0",
-        "vitest": "^4.0.18"
+        "vitest": "^4.0.18",
+        "wrangler": "^4.127.1"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -691,6 +693,148 @@
         "node": ">=18.17.0"
       }
     },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260828.1.tgz",
+      "integrity": "sha512-CVd+xPhqUESg8Xhq09TZx0wl4FSirfJGOzvbPz2yHhBIvmNHFFQkSN3rkd7wEwnhQQk37Xi0/aD6ykPLJbmGiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260828.1.tgz",
+      "integrity": "sha512-5HDPXRM152vU5JveByGFk34X57TVyIsfp4cabepAf45DC0MKvm52ucJqAjW1h8bvW4X+zRw9GU35OHF9FEC9Ww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260828.1.tgz",
+      "integrity": "sha512-MQ1Ll9P7F72HHUKizbb7BlDfbY8fRoNMpbIpZoU6uKsSkneFICWSKv6UlgU9EQZ+w0i7TMa12iUgJ8l29eRI9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260828.1.tgz",
+      "integrity": "sha512-FBTaUQ1xcU9jcp4OyBPcH8x0QiFvc1iuZL2GkD8zp2q1WyTVHYOptRDQUU+cuHjt0rQ2EIKVPBjahPxfa0joBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260828.1.tgz",
+      "integrity": "sha512-yvr77hC7dUbvK5K+SCg062kkPq3sx+drV1PcgHslzHDYcJBtT0V3X80qLE49LW1vq2svaeNmsVQS+vHsqWu8cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260831.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260831.1.tgz",
+      "integrity": "sha512-yXg4pwfYjhsDH9rYc3qZ3K+z62DCSvO/aj7GiZo6AyDeWGZpyFRpPMYcQ6LF/zfaf1x0Ngw2gSqL8JjuUtMGlA==",
+      "devOptional": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -891,9 +1035,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1982,6 +2126,43 @@
         "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32/node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
@@ -2332,6 +2513,43 @@
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32/node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -3625,6 +3843,48 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/dumper/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@posthog/core": {
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.24.1.tgz",
@@ -4826,6 +5086,19 @@
       "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@sparticuz/chromium": {
       "version": "131.0.1",
       "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-131.0.1.tgz",
@@ -4838,6 +5111,13 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/@stablelib/base64": {
       "version": "1.0.1",
@@ -6522,6 +6802,13 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -7670,6 +7957,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/es-define-property": {
@@ -9736,6 +10033,539 @@
         "node": ">=4"
       }
     },
+    "node_modules/miniflare": {
+      "version": "5.20260828.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260828.0-alpha.tgz",
+      "integrity": "sha512-6nbxhZEcz/UET3Y1OnYPsrAUjUmuFoib3ynUqteRdn1YnDxsLg8cwgZJZCk9QmtOmGzXwzXzgE/d/C0dJAPtVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260828.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/miniflare/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/miniflare/node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -10142,6 +10972,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -11195,9 +12032,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12430,11 +13267,31 @@
         "through": "^2.3.8"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
     },
     "node_modules/unicode-trie": {
       "version": "2.0.0",
@@ -12913,6 +13770,562 @@
         "node": ">=8"
       }
     },
+    "node_modules/workerd": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260828.1.tgz",
+      "integrity": "sha512-pB9yvt0kkwZDAGZHmpY59r0o3hM0DzdW6BJERqwZOhunZ3ssOyDSgQxOQer2cSZW4YCFeOTIQYN1qwhK5wv/Cw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260828.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260828.1",
+        "@cloudflare/workerd-linux-64": "1.20260828.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260828.1",
+        "@cloudflare/workerd-windows-64": "1.20260828.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.127.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.127.1.tgz",
+      "integrity": "sha512-OzsiNgaI8i681L/+KnAKc+uEZ5D57xK5JuNvCOpRKICF4/5Q3Cu1oTGuUiT/f3GDUqQb3gzXNT0tfOHGMEtknw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260828.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260828.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260828.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -12962,9 +14375,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -13110,6 +14523,45 @@
       "resolved": "https://registry.npmjs.org/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz",
       "integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==",
       "license": "MIT"
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/youch/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -184,6 +184,7 @@
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.88.0",
     "@clerk/testing": "^1.13.35",
+    "@cloudflare/workers-types": "^5.20260831.1",
     "@netlify/edge-functions": "^3.0.8",
     "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "^6.6.3",
@@ -196,6 +197,7 @@
     "jsdom": "^25.0.1",
     "lighthouse": "^11.7.1",
     "tsx": "^4.21.0",
-    "vitest": "^4.0.18"
+    "vitest": "^4.0.18",
+    "wrangler": "^4.127.1"
   }
 }

--- a/scripts/cf-parity-check.sh
+++ b/scripts/cf-parity-check.sh
@@ -150,7 +150,20 @@ check_redirect() {
     bad "$path" "$want_status $want_loc" "$st ${loc:-<no location>}"
   fi
 }
-check_redirect "/prototype/dashboard" 302 "/dashboard"
+# The /prototype strip is host-gated in the Worker, because /prototype is a LIVE route on
+# any host outside DEDICATED_PROTOTYPE_HOSTS (status.harvous.com is one such host, and is
+# served by this same Worker). So this check is only meaningful once a real dedicated
+# domain is attached — on a *.workers.dev URL the correct behaviour is NOT to redirect.
+case "$BASE" in
+  *app.harvous.com|*new.harvous.com) check_redirect "/prototype/dashboard" 302 "/dashboard" ;;
+  *)
+    st=$(status_of "$BASE/prototype/dashboard")
+    if [ "$st" = "200" ]; then
+      ok "/prototype/* correctly NOT stripped on a non-dedicated host"
+    else
+      bad "/prototype/* on a non-dedicated host" "200 (no redirect — /prototype is live here)" "$st"
+    fi ;;
+esac
 check_redirect "/thread_abc123" 301 "/thread/abc123"
 check_redirect "/note_abc123" 301 "/note/abc123"
 check_redirect "/space_abc123" 301 "/space/abc123"

--- a/scripts/cf-parity-check.sh
+++ b/scripts/cf-parity-check.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Cloudflare parity matrix — the gate for Phase A (docs/CLOUDFLARE_MIGRATION.md).
+#
+# Re-run at three points:
+#   stage 2  against https://harvous-app.<account>.workers.dev   (before any DNS moves)
+#   stage 4  against https://app.harvous.com                     (after custom domain attach)
+#   stage 5  against https://app.harvous.com                     (during the soak)
+#
+# Usage:  scripts/cf-parity-check.sh <base-url> [share-token]
+#   e.g.  scripts/cf-parity-check.sh https://harvous-app.example.workers.dev
+#         scripts/cf-parity-check.sh https://app.harvous.com AbCdEf123456
+#
+# Exit code is the gate: non-zero means do not proceed to the next stage.
+
+set -uo pipefail
+
+BASE="${1:-}"
+SHARE_TOKEN="${2:-${SHARE_TOKEN:-}}"
+
+if [ -z "$BASE" ]; then
+  echo "usage: $0 <base-url> [share-token]" >&2
+  exit 2
+fi
+BASE="${BASE%/}"
+
+PASS=0; FAIL=0
+ok()   { printf '  \033[32mPASS\033[0m  %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31mFAIL\033[0m  %s\n' "$1"; printf '        expected: %s\n        actual:   %s\n' "$2" "$3"; FAIL=$((FAIL+1)); }
+skip() { printf '  \033[33mSKIP\033[0m  %s (%s)\n' "$1" "$2"; }
+# Cloudflare's TEMPORARY preview accounts (wrangler deploy --temporary) throttle bursts and
+# answer a random ~20% of requests with a bare 403 — same URL, same second, interleaved with
+# 200s. That is an account-tier artifact, not the Worker. Retry those so the matrix measures
+# configuration; the retry count is reported at the end so a genuine 403 pattern still shows.
+RETRY_LOG="$(mktemp)"
+trap 'rm -f "$RETRY_LOG"' EXIT
+_curl_retry() { # $1 = "head"|"status"|"body", rest = curl args
+  local mode="$1"; shift
+  local attempt out code
+  for attempt in 1 2 3; do
+    case "$mode" in
+      head)   out=$(curl -sS -o /dev/null -D - --max-time 20 "$@" 2>/dev/null)
+              code=$(printf '%s' "$out" | head -1 | awk '{print $2}') ;;
+      status) out=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "$@" 2>/dev/null)
+              code="$out" ;;
+      body)   code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "$@" 2>/dev/null)
+              out=$(curl -sS --max-time 20 "$@" 2>/dev/null) ;;
+    esac
+    [ "$code" != "403" ] && { printf '%s' "$out"; return 0; }
+    echo x >> "$RETRY_LOG"
+    sleep 2
+  done
+  printf '%s' "$out"
+}
+head_of() { _curl_retry head "$@"; }
+# Header value, lowercased name, first match, trimmed.
+hdr() { head_of "$2" ${3:+-H "$3"} | tr -d '\r' | grep -i "^$1:" | head -1 | sed "s/^[^:]*: *//"; }
+status_of() { _curl_retry status "$@"; }
+# CDNs normalise Cache-Control spacing differently (Netlify strips the space after commas,
+# Cloudflare may not). Compare on content, not whitespace.
+norm() { printf '%s' "$1" | tr -d ' '; }
+same() { [ "$(norm "$1")" = "$(norm "$2")" ]; }
+
+echo "Cloudflare parity matrix against $BASE"
+echo
+
+# ── Settle gate ──────────────────────────────────────────────────────────────────
+# _headers rules take up to ~30-60s to propagate across the edge after a deploy, and
+# requests inside that window come back WITHOUT them. Observed on three separate
+# deploys (2026-08-30): runs started seconds after `wrangler deploy` reported random
+# subsets of missing cache-control / HSTS that were all correct a minute later. Poll
+# until the rules are actually live, so the matrix measures configuration rather than
+# propagation. This is the difference between a trustworthy gate and a flaky one.
+printf 'Waiting for _headers rules to propagate'
+SETTLED=no
+for _ in $(seq 1 30); do
+  if curl -sS -o /dev/null -D - --max-time 10 "$BASE/" 2>/dev/null | tr -d '\r' \
+       | grep -qi '^strict-transport-security:'; then SETTLED=yes; break; fi
+  printf '.'; sleep 3
+done
+if [ "$SETTLED" = yes ]; then echo " live."; else echo " TIMED OUT after 90s — results below may be propagation noise, not config."; fi
+echo
+
+# ── 1. Security + cache headers on the HTML shell ────────────────────────────────
+echo "[1] Document headers"
+cc=$(hdr cache-control "$BASE/")
+same "$cc" "no-cache, must-revalidate" && ok "/ cache-control" || bad "/ cache-control" "no-cache, must-revalidate" "$cc"
+csp=$(hdr content-security-policy "$BASE/")
+case "$csp" in
+  "default-src 'self'"*"challenges.cloudflare.com"*) ok "/ content-security-policy present" ;;
+  *) bad "/ content-security-policy" "default-src 'self' ... challenges.cloudflare.com ..." "${csp:-<missing>}" ;;
+esac
+hsts=$(hdr strict-transport-security "$BASE/")
+same "$hsts" "max-age=31536000; includeSubDomains; preload" && ok "/ strict-transport-security" || bad "/ strict-transport-security" "max-age=31536000; includeSubDomains; preload" "${hsts:-<missing>}"
+for h in "x-frame-options:DENY" "x-content-type-options:nosniff" "referrer-policy:strict-origin-when-cross-origin"; do
+  name="${h%%:*}"; want="${h#*:}"; got=$(hdr "$name" "$BASE/")
+  [ "$got" = "$want" ] && ok "/ $name" || bad "/ $name" "$want" "${got:-<missing>}"
+done
+
+# ── 2. THE most important check: hashed assets must be immutable ─────────────────
+echo
+echo "[2] Cache tiers"
+asset=$(_curl_retry body "$BASE/" | grep -oE '/assets/index-[A-Za-z0-9_-]+\.js' | head -1)
+if [ -n "$asset" ]; then
+  cc=$(hdr cache-control "$BASE$asset")
+  if same "$cc" "public, max-age=31536000, immutable"; then
+    ok "$asset immutable"
+  else
+    bad "$asset immutable  <-- THE load-bearing line (~703.7 KB re-downloaded per visit if wrong)" \
+        "public, max-age=31536000, immutable" "${cc:-<missing>}"
+  fi
+else
+  bad "discover hashed asset from /" "an /assets/index-<hash>.js reference in the HTML" "none found"
+fi
+for pair in "fonts:/fonts/Roundo-Variable.ttf" "images:/images/harvous-2-icon.png" "icons:/icons/app-icon.png"; do
+  label="${pair%%:*}"; path="${pair#*:}"
+  st=$(status_of "$BASE$path")
+  if [ "$st" != "200" ]; then skip "/$label/* cache tier" "$path -> HTTP $st"; continue; fi
+  cc=$(hdr cache-control "$BASE$path")
+  same "$cc" "public, max-age=2592000" && ok "/$label/* 30-day cache" || bad "/$label/* 30-day cache" "public, max-age=2592000" "${cc:-<missing>}"
+done
+
+# ── 3. The /api/* proxy to Fly ───────────────────────────────────────────────────
+echo
+echo "[3] API proxy -> Fly"
+st=$(status_of "$BASE/api/health")
+[ "$st" = "200" ] && ok "/api/health 200" || bad "/api/health 200" "200" "$st"
+cc=$(hdr cache-control "$BASE/api/health")
+case "$cc" in
+  *no-store*) ok "/api/* no-store passes through from Fly" ;;
+  *) bad "/api/* no-store from Fly" "contains no-store" "${cc:-<missing>}" ;;
+esac
+# n=6 warm latency — gate is "<= Netlify's 250-280ms baseline" (engineer.context.md).
+lat=$(for _ in 1 2 3 4 5 6; do curl -sS -o /dev/null -w '%{time_total}\n' --max-time 20 "$BASE/api/health"; done \
+      | awk '{s+=$1; n++} END {if (n) printf "%.0f", (s/n)*1000}')
+echo "  INFO  /api/health mean of 6: ${lat}ms  (Netlify baseline 250-280ms; Fly direct ~100ms)"
+
+# ── 4. Legacy redirects ──────────────────────────────────────────────────────────
+echo
+echo "[4] Legacy redirects"
+check_redirect() {
+  local path="$1" want_status="$2" want_loc="$3"
+  local out st loc
+  out=$(head_of "$BASE$path" | tr -d '\r')
+  st=$(printf '%s' "$out" | head -1 | awk '{print $2}')
+  loc=$(printf '%s' "$out" | grep -i '^location:' | head -1 | sed 's/^[^:]*: *//')
+  loc="${loc#"$BASE"}"
+  if [ "$st" = "$want_status" ] && [ "$loc" = "$want_loc" ]; then
+    ok "$path -> $want_status $want_loc"
+  else
+    bad "$path" "$want_status $want_loc" "$st ${loc:-<no location>}"
+  fi
+}
+check_redirect "/prototype/dashboard" 302 "/dashboard"
+check_redirect "/thread_abc123" 301 "/thread/abc123"
+check_redirect "/note_abc123" 301 "/note/abc123"
+check_redirect "/space_abc123" 301 "/space/abc123"
+
+# ── 5. PWA origin association ────────────────────────────────────────────────────
+echo
+echo "[5] PWA"
+body=$(_curl_retry body "$BASE/.well-known/web-app-origin-association")
+case "$body" in
+  *'"web_apps"'*'manifest.json'*) ok "/.well-known/web-app-origin-association serves JSON" ;;
+  *) bad "/.well-known/web-app-origin-association" 'JSON containing "web_apps" and manifest.json' "${body:0:80}" ;;
+esac
+
+# ── 6. Stale-asset honesty — a 200 text/html here is the permanent-SW-cache bug ───
+echo
+echo "[6] Stale asset guard"
+out=$(head_of "$BASE/assets/index-DOESNOTEXIST.js" | tr -d '\r')
+st=$(printf '%s' "$out" | head -1 | awk '{print $2}')
+ct=$(printf '%s' "$out" | grep -i '^content-type:' | head -1 | sed 's/^[^:]*: *//')
+if [ "$st" = "404" ]; then
+  ok "missing hashed asset -> 404 (not an index.html fallback)"
+else
+  bad "missing hashed asset -> 404  <-- a 200 text/html here poisons the service-worker cache permanently" \
+      "404" "$st ${ct:-}"
+fi
+
+# ── 7. Crawler vs human on share URLs ────────────────────────────────────────────
+echo
+echo "[7] Share-URL crawler rewrite"
+TOKEN="${SHARE_TOKEN:-AAAAAAAAAAAA}"
+human=$(_curl_retry body -A "Mozilla/5.0" "$BASE/shared/note/$TOKEN")
+crawler=$(_curl_retry body -A "Twitterbot/1.0" "$BASE/shared/note/$TOKEN")
+case "$human" in
+  *'<div id="root"'*) ok "human UA gets the SPA shell" ;;
+  *) bad "human UA gets the SPA shell" '<div id="root">' "${human:0:80}" ;;
+esac
+if [ -n "$SHARE_TOKEN" ]; then
+  case "$crawler" in
+    *"og:title"*) ok "crawler UA gets server-rendered OG meta" ;;
+    *) bad "crawler UA gets server-rendered OG meta" "HTML containing og:title" "${crawler:0:80}" ;;
+  esac
+else
+  if [ "$crawler" != "$human" ]; then
+    ok "crawler UA routes differently from human (pass a real token to assert og:title)"
+  else
+    bad "crawler UA routes differently from human" "a different response from the SPA shell" "identical to human response"
+  fi
+fi
+
+echo
+echo "────────────────────────────────────────"
+printf '  %d passed, %d failed\n' "$PASS" "$FAIL"
+RETRIES=$(wc -l < "$RETRY_LOG" | tr -d ' ')
+if [ "${RETRIES:-0}" -gt 0 ]; then
+  printf '  %s transient 403s retried — expected on a --temporary preview account,\n' "$RETRIES"
+  printf '  and a red flag on a real one.\n'
+fi
+if [ "$FAIL" -gt 0 ]; then
+  echo "  GATE: do not proceed to the next stage."
+  exit 1
+fi
+echo "  GATE: clear."

--- a/scripts/inject-sw-cache-version.js
+++ b/scripts/inject-sw-cache-version.js
@@ -28,8 +28,12 @@ const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
 const version = pkg.version || '0.0.0';
 // e.g. "1.132.0" -> "v1-132-0"
 const cacheVersion = 'v' + version.replace(/\./g, '-');
-// Netlify sets COMMIT_REF (and DEPLOY_ID) on every build, including redeploys of the same commit.
-const buildId = (process.env.COMMIT_REF || process.env.DEPLOY_ID || '')
+// Netlify sets COMMIT_REF (and DEPLOY_ID) on every build, including redeploys of the same
+// commit. GitHub Actions sets GITHUB_SHA instead, and sets neither of the others — so the
+// Cloudflare deploy workflow would otherwise fall through to an empty build id here and ship
+// a byte-identical sw.js for every deploy between two version bumps, which is exactly the
+// failure the paragraph above describes. Keep all three.
+const buildId = (process.env.COMMIT_REF || process.env.DEPLOY_ID || process.env.GITHUB_SHA || '')
   .replace(/[^a-zA-Z0-9]/g, '')
   .slice(0, 8);
 const cacheName = buildId

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,77 @@
+// Cloudflare Worker for app.harvous.com (docs/CLOUDFLARE_MIGRATION.md, Phase A).
+//
+// Workers-with-static-assets, deliberately NOT Pages: Cloudflare's _redirects cannot
+// 200-proxy to an external domain, so the /api/* -> Fly proxy has to be code. Pages is
+// also in maintenance mode, and Durable Objects (Phase B) only attach to Workers.
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "harvous-app",
+  "main": "cloudflare/worker.ts",
+  "compatibility_date": "2026-08-01",
+
+  // Workers Logs — on for the stage-5 soak, where Worker error rate is one of the
+  // things being watched. Cheap to leave on afterwards.
+  "observability": { "enabled": true },
+
+  "assets": {
+    "directory": "./dist-spa",
+    "binding": "ASSETS",
+    // Replaces the `/* /index.html 200` catch-all from public/_redirects.
+    "not_found_handling": "single-page-application",
+
+    // Paths where Worker code runs BEFORE the asset lookup. Everything absent from this
+    // list is served straight from the asset store, which is free and unmetered.
+    //
+    // /assets/* hosts the stale-chunk 404 guard, and MEASUREMENT SAYS IT MUST STAY
+    // (2026-08-30, local workerd): without it a missing hashed asset returns 200 text/html,
+    // not 404. So every hashed JS/CSS chunk does bill a Worker invocation — ~7 per cold
+    // load from the initial document alone, more as lazy chunks load. Price the plan tier
+    // on that; it does not get to be free.
+    //
+    // The four legacy-redirect patterns are here for the same reason the netlify.toml
+    // versions never worked: without them the asset layer answers first and returns the SPA
+    // shell at 200, so cloudflare/worker.ts#legacyRedirect never runs. They are rare paths,
+    // so the invocation cost is noise. Deleting these four strings is the clean way to opt
+    // back into strict parity with today's production — the function then goes dormant
+    // rather than needing removal.
+    "run_worker_first": [
+      "/api/*",
+      "/shared/note/*",
+      "/shared/thread/*",
+      "/assets/*",
+      "/prototype/*",
+      "/thread_*",
+      "/note_*",
+      "/space_*"
+    ]
+  },
+
+  "vars": { "API_ORIGIN": "https://harvous.fly.dev" },
+
+  // A *.workers.dev URL for every deploy. This is what stages 1-2 test against, with
+  // app.harvous.com still served entirely by Netlify and completely unaffected.
+  // Consider turning this off in stage-5 cleanup once the custom domain is live, so the
+  // app has exactly one public origin.
+  "workers_dev": true,
+
+  // STAGE 4 ONLY — uncomment when attaching the custom domain, NOT before.
+  // harvous.com becomes a Cloudflare zone in stage 3; until then wrangler cannot resolve
+  // this route and every deploy fails. Attaching it is the moment traffic actually moves,
+  // and the rollback is re-pointing this record back at Netlify.
+  // "routes": [{ "pattern": "app.harvous.com", "custom_domain": true }],
+
+  "env": {
+    // Mirrors netlify.toml's [context.staging]: dev Clerk key, production DB.
+    // The Clerk split happens at build time via VITE_CLERK_PUBLISHABLE_KEY, so staging is
+    // a SEPARATE BUILD of dist-spa — see .github/workflows/cloudflare-deploy.yml, which
+    // builds per target rather than deploying one artifact twice.
+    "staging": {
+      "name": "harvous-app-staging",
+      "observability": { "enabled": true },
+      "vars": { "API_ORIGIN": "https://harvous.fly.dev" },
+      "workers_dev": true
+      // STAGE 4 ONLY — same reasoning as the production route above.
+      // "routes": [{ "pattern": "new.harvous.com", "custom_domain": true }]
+    }
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -54,11 +54,20 @@
   // app has exactly one public origin.
   "workers_dev": true,
 
-  // STAGE 4 ONLY — uncomment when attaching the custom domain, NOT before.
+  // STAGE 4 ONLY — uncomment when attaching the custom domains, NOT before.
   // harvous.com becomes a Cloudflare zone in stage 3; until then wrangler cannot resolve
-  // this route and every deploy fails. Attaching it is the moment traffic actually moves,
-  // and the rollback is re-pointing this record back at Netlify.
-  // "routes": [{ "pattern": "app.harvous.com", "custom_domain": true }],
+  // these routes and every deploy fails. Attaching them is the moment traffic actually
+  // moves, and the rollback is re-pointing the records back at Netlify.
+  //
+  // status.harvous.com belongs on THIS Worker, not on a separate one: it is a Netlify
+  // domain alias of the same site today, serving the same dist-spa, with the SPA branching
+  // on hostname (src/lib/status-page-host.ts, spa/src/router.tsx buildStatusHostRoutes).
+  // Same build, same Worker. It is also the reason legacyRedirect() is host-gated — see
+  // cloudflare/worker.ts; /prototype is a LIVE route on the status host.
+  // "routes": [
+  //   { "pattern": "app.harvous.com", "custom_domain": true },
+  //   { "pattern": "status.harvous.com", "custom_domain": true }
+  // ],
 
   "env": {
     // Mirrors netlify.toml's [context.staging]: dev Clerk key, production DB.


### PR DESCRIPTION
Phase A stages 1–2 of `docs/INFRA_ENDGAME.md`. One Worker replaces everything Netlify still does for `app.harvous.com`: static hosting, the `/api/*` proxy to Fly, headers, the crawler OG rewrite, and the legacy redirects.

**Nothing user-facing changes when this merges.** No DNS moves. `app.harvous.com` stays entirely on Netlify. Merging deploys the Worker to `harvous-app.harvous.workers.dev` with the live Clerk key — which is the artifact the authenticated smoke test needs before stage 3.

Deployed and passing **20/20** on the parity matrix against the real Cloudflare account.

## Why now

Netlify is at ~2,628 of 5,000 credits in 9 days (~292/day against a sustainable ~82/day), hitting zero around Sept 7 with auto-recharge disabled. Bandwidth and deploys are 95% of that, and both become unmetered on Cloudflare — they stop being costs rather than getting cheaper.

## Five things the build found

1. **`inject-sw-cache-version.js` read only `COMMIT_REF`/`DEPLOY_ID`, both Netlify-only.** On Actions the build id fell back to empty, which ships a byte-identical `sw.js` between version bumps and strands returning clients on a cached `index.html` full of dead chunk hashes. `GITHUB_SHA` added to the fallback chain.

2. **Workers assets reject any file over 5 MiB** and `index-*.js.map` is ~10 MB, so the first deploy failed outright. `cloudflare/.assetsignore` excludes `*.map` — 14 MB across 34 files, 37% of the deploy, with no consumer (`sourcemap: 'hidden'`, nothing uploads them). Those maps are also publicly fetchable on Netlify today (200, 10.4 MB), which this closes on Cloudflare.

3. **Every legacy redirect in `netlify.toml` is dead in production.** `public/_redirects` ends in a catch-all Netlify evaluates first, so `/thread_abc123` has been answering with the SPA shell at 200. They work for the first time here. Deleting four strings from `run_worker_first` opts back into strict parity.

4. **The build env now mirrors production exactly** — 10 vars, from `netlify env:list --context production`, not 14 inferred from grepping. Notably `VITE_SUPABASE_URL`/`ANON_KEY` are deliberately unset: production never set them, so `isSupabaseRealtimeConfigured()` is false and **Supabase Realtime has never been on in production**. Setting them would switch realtime on for Cloudflare alone. Worth re-scoping Phase B around.

5. **`status.harvous.com` was hiding a bug.** It's a Netlify domain alias of the same site, so it belongs on this Worker — but it is *not* in `DEDICATED_PROTOTYPE_HOSTS`, meaning `/prototype` is a live route there. `legacyRedirect()` stripped it on every host and would have broken that domain on attach. Now host-gated, asserted both directions by the parity script.

## Notes for review

- Custom-domain routes are commented with a `STAGE 4 ONLY` marker — harvous.com isn't a Cloudflare zone yet, so wrangler can't resolve them and every deploy would fail. Uncommenting is the moment traffic moves.
- `_headers` rules take 30–60s to propagate after a deploy; `cf-parity-check.sh` polls before asserting, or it flakes.
- Only `main` deploys to the production Worker; every other ref goes to `harvous-app-staging`.
- Verify with: `bash scripts/cf-parity-check.sh https://harvous-app.harvous.workers.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)