### PR TITLE
fix(review): a review row always says which note it is asking about

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,11 @@ CLERK_SECRET_KEY=""
 # Comma-separated origins for JWT azp verification (required for localhost + live keys)
 CLERK_AUTHORIZED_PARTIES="http://localhost:4322,https://app.harvous.com,https://new.harvous.com"
 CLERK_WEBHOOK_SECRET=""
+# Runtime queries. Use the pooler on port 6543 (transaction mode): port 5432 is session mode
+# and caps the whole project at 15 clients, which a dev server and a test run exhaust between
+# them. See server/db/client.ts.
 SUPABASE_DATABASE_URL=""
+# Migrations and drizzle-kit only. Port 5432 — these want a real session.
 SUPABASE_DIRECT_URL=""
 # Supabase project URL (https://xxx.supabase.co) — Realtime broadcast from API
 SUPABASE_URL=""

--- a/Changelog/2.132.3.md
+++ b/Changelog/2.132.3.md
@@ -1,0 +1,8 @@
+# Version 2.132.3
+
+**Release Date**: September 2, 2026
+
+## Fixes
+
+- A review row always says which note it is asking about
+

--- a/Changelog/2.132.4.md
+++ b/Changelog/2.132.4.md
@@ -1,0 +1,8 @@
+# Version 2.132.4
+
+**Release Date**: September 2, 2026
+
+## Fixes
+
+- Show the note's own opening line, not the date it was written
+

--- a/Changelog/2.132.5.md
+++ b/Changelog/2.132.5.md
@@ -1,0 +1,8 @@
+# Version 2.132.5
+
+**Release Date**: September 2, 2026
+
+## Fixes
+
+- Each row wears the glyph of the thing it is asking about
+

--- a/Changelog/2.132.6.md
+++ b/Changelog/2.132.6.md
@@ -1,0 +1,8 @@
+# Version 2.132.6
+
+**Release Date**: September 2, 2026
+
+## Fixes
+
+- The note questions stop sounding like a worksheet
+

--- a/Changelog/2.132.7.md
+++ b/Changelog/2.132.7.md
@@ -1,0 +1,8 @@
+# Version 2.132.7
+
+**Release Date**: September 2, 2026
+
+## Fixes
+
+- The question on top, what it is about beneath
+

--- a/Changelog/2.132.8.md
+++ b/Changelog/2.132.8.md
@@ -1,0 +1,8 @@
+# Version 2.132.8
+
+**Release Date**: September 2, 2026
+
+## Fixes
+
+- Stop a dev server and a test run from exhausting the connection pool
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.132.7
+**Version:** 2.132.8
 **Status:** Official 1.0 Released January 8, 2026

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.132.6
+**Version:** 2.132.7
 **Status:** Official 1.0 Released January 8, 2026

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.132.3
+**Version:** 2.132.4
 **Status:** Official 1.0 Released January 8, 2026

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.132.2
+**Version:** 2.132.3
 **Status:** Official 1.0 Released January 8, 2026

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.132.5
+**Version:** 2.132.6
 **Status:** Official 1.0 Released January 8, 2026

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.132.4
+**Version:** 2.132.5
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.132.2",
+  "version": "2.132.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.132.4",
+  "version": "2.132.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.132.7",
+  "version": "2.132.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.132.5",
+  "version": "2.132.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.132.6",
+  "version": "2.132.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.132.3",
+  "version": "2.132.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-132-4';
+const CACHE_NAME = 'harvous-cache-v2-132-5';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-132-5';
+const CACHE_NAME = 'harvous-cache-v2-132-6';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-132-6';
+const CACHE_NAME = 'harvous-cache-v2-132-7';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-132-2';
+const CACHE_NAME = 'harvous-cache-v2-132-3';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-132-7';
+const CACHE_NAME = 'harvous-cache-v2-132-8';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-132-3';
+const CACHE_NAME = 'harvous-cache-v2-132-4';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/server/db/__tests__/client-pool.test.ts
+++ b/server/db/__tests__/client-pool.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Source contract for the connection pool.
+ *
+ * Asserted against source rather than by opening connections, because the failure this guards
+ * only appears when *two* processes are up — a dev server and a test run, or two worktrees —
+ * and a test that could reproduce that is a test that would cause it.
+ */
+const client = readFileSync(join(__dirname, '..', 'client.ts'), 'utf8');
+
+describe('database pool sizing', () => {
+  it('asks for one connection in a test worker or a one-shot script, not ten', () => {
+    /*
+     * Vitest forks a worker per CPU and each one that imports the client builds its own pool.
+     * At ten apiece, running the suite while `npm run dev` was up failed three integration
+     * tests with EMAXCONNSESSION — in a file unrelated to the change under test, which is the
+     * expensive part: the failure lands on whoever lost the race, not on whoever caused it.
+     */
+    expect(client).toContain('const SINGLE_CONNECTION = 1');
+    expect(client).toMatch(/isTestRun\(\)\s*\|\|\s*isOneShotScript\(\)/);
+  });
+
+  it('treats server/scripts as one-shot, without each script opting in', () => {
+    // A backfill against production held ten clients for minutes while the dev server held ten
+    // more. Nine scripts share this singleton; none of them runs two queries at once.
+    expect(client).toContain('isOneShotScript');
+    expect(client).toContain('process.argv[1]');
+    expect(client).toMatch(/server\[\\\\\/\]scripts/);
+  });
+
+  it('recognises a test run from vitest or NODE_ENV', () => {
+    expect(client).toContain('process.env.VITEST');
+    expect(client).toContain("process.env.NODE_ENV === 'test'");
+  });
+
+  it('keeps DB_POOL_MAX able to override, including under test', () => {
+    // The escape hatch has to win, or a second worktree has no way out of the same squeeze.
+    expect(client).toMatch(/Number\(process\.env\.DB_POOL_MAX\)\s*\|\|/);
+  });
+
+  it('stops preparing statements on the transaction pooler', () => {
+    /*
+     * Transaction mode multiplexes one server connection across many clients, so a statement
+     * prepared on one is absent on the next. This is what makes moving the runtime URL from
+     * port 5432 to 6543 — the actual cure for the 15-client cap — a one-line env change.
+     */
+    expect(client).toContain('isTransactionPooler');
+    expect(client).toContain('prepare: false');
+    expect(client).toContain("parsed.port === '6543'");
+    expect(client).toContain("parsed.searchParams.get('pgbouncer')");
+  });
+
+  it('says which port means what, where the next person will look', () => {
+    expect(client).toMatch(/session/i);
+    expect(client).toMatch(/15/);
+  });
+});

--- a/server/db/client.ts
+++ b/server/db/client.ts
@@ -1,14 +1,78 @@
 /**
  * Supabase Postgres database client via postgres.js + Drizzle ORM.
  *
- * Env: SUPABASE_DATABASE_URL (pooler, port 6543).
- * For migrations/drizzle-kit: SUPABASE_DIRECT_URL (port 5432).
+ * `SUPABASE_DATABASE_URL` is the runtime connection and `SUPABASE_DIRECT_URL` is for
+ * migrations and drizzle-kit.
+ *
+ * **Which port matters more than it looks.** Supabase's pooler answers on two:
+ *
+ * | Port | Mode        | Client cap        | Prepared statements |
+ * |------|-------------|-------------------|---------------------|
+ * | 6543 | transaction | high              | no — see `prepare`  |
+ * | 5432 | session     | 15 per project    | yes                 |
+ *
+ * On 5432 the whole project shares fifteen clients, and this file's default pool of ten means
+ * two of anything — a dev server and a test run, two worktrees, a server and a script — can
+ * exhaust it between them. The symptom is EMAXCONNSESSION on whatever query lost the race,
+ * which reads as a bug in unrelated code.
+ *
+ * If `SUPABASE_DATABASE_URL` is on 5432 today, moving it to 6543 is the fix, and the
+ * `prepare: false` below already handles the difference. Keep `SUPABASE_DIRECT_URL` where it
+ * is: migrations want a real session.
  */
 
 import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { sql } from 'drizzle-orm';
 import * as schema from './schema';
+
+/**
+ * One connection for a test worker or a one-shot script.
+ *
+ * Vitest forks a worker per CPU, and any worker that imports this module builds its own pool.
+ * At the default of 10 that is 10 more clients on top of whatever the dev server already
+ * holds, and Supabase's *session* pooler caps the project at 15 — so running the suite with
+ * `npm run dev` up failed three integration tests with EMAXCONNSESSION, in a file that had
+ * nothing to do with the change under test. A test doing a handful of queries in sequence has
+ * no use for a pool at all.
+ */
+const SINGLE_CONNECTION = 1;
+
+function isTestRun(): boolean {
+  return Boolean(process.env.VITEST) || process.env.NODE_ENV === 'test';
+}
+
+/**
+ * A one-shot script in `server/scripts/`, which wants one connection for the same reason.
+ *
+ * Nine of them share this singleton, and each was taking ten clients for the length of its run
+ * — a backfill against production held ten for minutes while the dev server held ten more.
+ * They all work through a list in sequence and never issue two queries at once, so the pool
+ * bought nothing and cost most of the project's budget.
+ *
+ * Detected from argv rather than a flag each script has to remember to set: nothing under
+ * `server/scripts/` is a server, and a rule nobody has to opt into is one nobody can forget.
+ */
+function isOneShotScript(): boolean {
+  const entry = process.argv[1];
+  return Boolean(entry) && /[\\/]server[\\/]scripts[\\/]/.test(entry);
+}
+
+/**
+ * Supabase's transaction pooler, which is port 6543 (session mode is 5432).
+ *
+ * Worth knowing which you are on: session mode caps the whole project at 15 clients, while
+ * transaction mode carries far more, and the two differ on prepared statements. See the
+ * `prepare` option below.
+ */
+function isTransactionPooler(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.port === '6543' || parsed.searchParams.get('pgbouncer') === 'true';
+  } catch {
+    return false;
+  }
+}
 
 function createDb() {
   // Prefer the pooler URL (port 6543) for runtime queries.
@@ -32,12 +96,22 @@ function createDb() {
    *
    * Default unchanged at 10, so a single server behaves exactly as before.
    */
-  const poolMax = Number(process.env.DB_POOL_MAX) || 10;
+  const poolMax =
+    Number(process.env.DB_POOL_MAX) ||
+    (isTestRun() || isOneShotScript() ? SINGLE_CONNECTION : 10);
 
   const client = postgres(url, {
     max: poolMax,
     idle_timeout: 300,
     connect_timeout: 30,
+    /*
+     * Transaction-mode pooling multiplexes one server connection across many clients, so a
+     * prepared statement made on one is not there on the next. postgres.js prepares by
+     * default, which fails against it — hence this, keyed off the URL rather than a flag, so
+     * moving SUPABASE_DATABASE_URL to port 6543 is a one-line env change and not a debugging
+     * session. A no-op on session mode, where prepared statements are fine.
+     */
+    ...(isTransactionPooler(url) ? { prepare: false } : {}),
   });
   return drizzle(client, { schema });
 }

--- a/server/utils/review-service.ts
+++ b/server/utils/review-service.ts
@@ -19,6 +19,8 @@ import {
   Notes,
   NoteConnections,
   NoteFingerprints,
+  NoteScriptureReferences,
+  ScriptureMetadata,
   ReviewEvents,
   ReviewItems,
   StudyThreadEntries,
@@ -111,6 +113,16 @@ export interface ReviewItemView {
   /** Titles for the row's meta line; never the note body, which is the point of the reveal. */
   noteTitle: string | null;
   secondaryNoteTitle: string | null;
+  /**
+   * The shortest thing that says *which* note this is — title, else the first passage it
+   * cites. Null when the note has neither, and `noteWrittenAt` is the last resort.
+   *
+   * Never a snippet of the body. A preview of what you wrote partly answers the question
+   * being asked, which is the one thing a review row must not do.
+   */
+  noteLabel: string | null;
+  /** When the note was written, for a reader to place a note that has no name of its own. */
+  noteWrittenAt: string | null;
   scriptureReference: string | null;
   noteId: string | null;
   challengeId: string | null;
@@ -130,14 +142,59 @@ function displayTitle(title: string | null | undefined): string | null {
  * The inbox renders at most three, but the session and the manage list do not, and a
  * per-item lookup there is a straightforward N+1 on the page a subscriber uses most.
  */
-async function loadTitles(userId: string, noteIds: string[]): Promise<Map<string, string | null>> {
+interface NoteLabelRow {
+  title: string | null;
+  writtenAt: Date | null;
+  /** First passage the note cites, filled in only for notes with no usable title. */
+  passage: string | null;
+}
+
+async function loadTitles(userId: string, noteIds: string[]): Promise<Map<string, NoteLabelRow>> {
   const unique = [...new Set(noteIds.filter(Boolean))];
   if (unique.length === 0) return new Map();
   const rows = await db
-    .select({ id: Notes.id, title: Notes.title })
+    .select({ id: Notes.id, title: Notes.title, createdAt: Notes.createdAt })
     .from(Notes)
     .where(and(eq(Notes.userId, userId), inArray(Notes.id, unique)));
-  return new Map(rows.map((r) => [r.id, displayTitle(r.title)]));
+
+  const byId = new Map<string, NoteLabelRow>(
+    rows.map((r) => [r.id, { title: displayTitle(r.title), writtenAt: r.createdAt, passage: null }]),
+  );
+
+  /*
+   * A note with no name is identified by what it is about.
+   *
+   * The server auto-titles empty notes "Untitled Note 4", which `displayTitle` strips — so a
+   * row about one of them said "this note" and nothing else, and there was no way to tell which
+   * of them it meant. The first passage it cites is the strongest honest answer: it names the
+   * subject the way a title would, and gives nothing of what the reader wrote about it away.
+   *
+   * Only queried for the notes that need it, and through both joins, because a pill points at
+   * the canonical scripture child rather than at the reader's own note.
+   */
+  const unnamed = [...byId.entries()].filter(([, v]) => !v.title).map(([id]) => id);
+  if (unnamed.length > 0) {
+    const [viaChild, viaOwn] = await Promise.all([
+      db
+        .select({ noteId: NoteScriptureReferences.noteId, reference: ScriptureMetadata.reference })
+        .from(ScriptureMetadata)
+        .innerJoin(
+          NoteScriptureReferences,
+          eq(NoteScriptureReferences.scriptureNoteId, ScriptureMetadata.noteId),
+        )
+        .where(inArray(NoteScriptureReferences.noteId, unnamed)),
+      db
+        .select({ noteId: ScriptureMetadata.noteId, reference: ScriptureMetadata.reference })
+        .from(ScriptureMetadata)
+        .where(inArray(ScriptureMetadata.noteId, unnamed)),
+    ]);
+    for (const row of [...viaChild, ...viaOwn]) {
+      const entry = byId.get(row.noteId);
+      if (entry && !entry.passage) entry.passage = row.reference?.trim() || null;
+    }
+  }
+
+  return byId;
 }
 
 /**
@@ -171,8 +228,11 @@ export async function buildReviewItemViews(
   const views: ReviewItemView[] = [];
   for (const row of rows) {
     const kind = row.kind as ReviewItemKind;
-    const noteTitle = row.noteId ? titles.get(row.noteId) ?? null : null;
-    const secondaryNoteTitle = row.secondaryNoteId ? titles.get(row.secondaryNoteId) ?? null : null;
+    const primary = row.noteId ? titles.get(row.noteId) ?? null : null;
+    const noteTitle = primary?.title ?? null;
+    const secondaryNoteTitle = row.secondaryNoteId
+      ? titles.get(row.secondaryNoteId)?.title ?? null
+      : null;
     const threadTitle =
       kind === 'thread' && row.noteId ? await threadTitleFor(userId, row.noteId) : null;
 
@@ -211,6 +271,8 @@ export async function buildReviewItemViews(
       scriptureReference: row.scriptureReference,
       noteId: row.noteId,
       challengeId: row.challengeId,
+      noteLabel: noteTitle ?? primary?.passage ?? null,
+      noteWrittenAt: primary?.writtenAt?.toISOString() ?? null,
       sourceLabel: row.sourceLabel,
       sourceAt: row.sourceAt?.toISOString() ?? null,
     });

--- a/server/utils/review-service.ts
+++ b/server/utils/review-service.ts
@@ -25,6 +25,7 @@ import {
   ReviewItems,
   StudyThreadEntries,
   UserNodeStates,
+  sql,
   first,
 } from '../db';
 import { generateTimestampId } from '@/utils/ids';
@@ -56,6 +57,7 @@ import {
 } from '@/utils/verse-ladder-exercises';
 import { buildVerseCloze, verseCue, type VerseCloze } from '@/utils/verse-cloze';
 import { stripServerAutoUntitledNoteTitleForDisplay } from '@/utils/server-auto-untitled-note-display';
+import { stripHtmlForListPreview } from '@/utils/html-stripper';
 import { collectStudyThreadGraph } from './study-thread-graph';
 import { fetchStudyThreadNoteRows } from './study-thread-note-rows';
 import { pickRepNoteIdForCluster } from './study-thread-cluster-count';
@@ -131,6 +133,37 @@ export interface ReviewItemView {
   sourceAt: string | null;
 }
 
+/**
+ * How much stored body to fetch for one line of context. The same `left()` cap the note list
+ * uses, trimmed hard: this becomes ~64 characters on screen.
+ */
+const REVIEW_EXCERPT_SOURCE_CHARS = 600;
+/**
+ * Enough to recognise your own note, not enough to read it.
+ *
+ * The meta line shares its width with the reason ("· You wrote this"), so a longer excerpt
+ * buys nothing: it only pushes the reason out of view. Recognition happens in the first few
+ * words anyway — these are the reader's own sentences.
+ */
+const REVIEW_EXCERPT_CHARS = 48;
+
+/**
+ * A note's opening line, as the note lists already render it.
+ *
+ * This was deliberately withheld at first, on the reasoning that previewing what someone wrote
+ * partly answers the question being asked. That was wrong twice over. A row the reader cannot
+ * identify is useless, and uselessness is a worse failure than a partial cue — Review is a
+ * prompt to return to your study, not an exam: outcomes are self-reported, nothing is graded,
+ * and the strategy doc is explicit that reading a note you could not remember is a perfectly
+ * good outcome. It was also inconsistent, since a *titled* note has always shown its title,
+ * which is the reader's own summary of the very same content.
+ */
+function noteExcerpt(html: string | null | undefined): string | null {
+  if (!html) return null;
+  const preview = stripHtmlForListPreview(html, REVIEW_EXCERPT_CHARS).trim();
+  return preview || null;
+}
+
 function displayTitle(title: string | null | undefined): string | null {
   const cleaned = stripServerAutoUntitledNoteTitleForDisplay((title ?? '').trim());
   return cleaned || null;
@@ -145,6 +178,8 @@ function displayTitle(title: string | null | undefined): string | null {
 interface NoteLabelRow {
   title: string | null;
   writtenAt: Date | null;
+  /** The note's own opening line, for a note with no title of its own. */
+  excerpt: string | null;
   /** First passage the note cites, filled in only for notes with no usable title. */
   passage: string | null;
 }
@@ -153,26 +188,37 @@ async function loadTitles(userId: string, noteIds: string[]): Promise<Map<string
   const unique = [...new Set(noteIds.filter(Boolean))];
   if (unique.length === 0) return new Map();
   const rows = await db
-    .select({ id: Notes.id, title: Notes.title, createdAt: Notes.createdAt })
+    .select({
+      id: Notes.id,
+      title: Notes.title,
+      createdAt: Notes.createdAt,
+      // A prefix, not the body: this is for one line of context, and the same `left()` cap
+      // the note list uses. An encrypted body is ciphertext and is never previewed.
+      contentPrefix: sql<string>`left(${Notes.content}, ${REVIEW_EXCERPT_SOURCE_CHARS})`,
+      contentEncrypted: Notes.contentEncrypted,
+    })
     .from(Notes)
     .where(and(eq(Notes.userId, userId), inArray(Notes.id, unique)));
 
   const byId = new Map<string, NoteLabelRow>(
-    rows.map((r) => [r.id, { title: displayTitle(r.title), writtenAt: r.createdAt, passage: null }]),
+    rows.map((r) => [
+      r.id,
+      {
+        title: displayTitle(r.title),
+        writtenAt: r.createdAt,
+        excerpt: r.contentEncrypted ? null : noteExcerpt(r.contentPrefix),
+        passage: null,
+      },
+    ]),
   );
 
   /*
-   * A note with no name is identified by what it is about.
+   * The passage a nameless note cites, for the ones whose body gives nothing away either.
    *
-   * The server auto-titles empty notes "Untitled Note 4", which `displayTitle` strips — so a
-   * row about one of them said "this note" and nothing else, and there was no way to tell which
-   * of them it meant. The first passage it cites is the strongest honest answer: it names the
-   * subject the way a title would, and gives nothing of what the reader wrote about it away.
-   *
-   * Only queried for the notes that need it, and through both joins, because a pill points at
-   * the canonical scripture child rather than at the reader's own note.
+   * Queried only for the notes that still need it after the excerpt, and through both joins,
+   * because a pill points at the canonical scripture child rather than at the reader's own note.
    */
-  const unnamed = [...byId.entries()].filter(([, v]) => !v.title).map(([id]) => id);
+  const unnamed = [...byId.entries()].filter(([, v]) => !v.title && !v.excerpt).map(([id]) => id);
   if (unnamed.length > 0) {
     const [viaChild, viaOwn] = await Promise.all([
       db
@@ -271,7 +317,7 @@ export async function buildReviewItemViews(
       scriptureReference: row.scriptureReference,
       noteId: row.noteId,
       challengeId: row.challengeId,
-      noteLabel: noteTitle ?? primary?.passage ?? null,
+      noteLabel: noteTitle ?? primary?.excerpt ?? primary?.passage ?? null,
       noteWrittenAt: primary?.writtenAt?.toISOString() ?? null,
       sourceLabel: row.sourceLabel,
       sourceAt: row.sourceAt?.toISOString() ?? null,

--- a/server/utils/review-service.ts
+++ b/server/utils/review-service.ts
@@ -123,6 +123,11 @@ export interface ReviewItemView {
    * being asked, which is the one thing a review row must not do.
    */
   noteLabel: string | null;
+  /**
+   * The note's own opening words — the row's context line, the way a verse row carries its cue.
+   * Present whether or not the note has a title, because a title names it and this shows it.
+   */
+  noteContext: string | null;
   /** When the note was written, for a reader to place a note that has no name of its own. */
   noteWrittenAt: string | null;
   scriptureReference: string | null;
@@ -305,9 +310,6 @@ export async function buildReviewItemViews(
         secondaryNoteTitle,
         threadTitle,
         cue,
-        // The note's own words, so a note with no title still gets a specific question
-        // rather than one about "this note".
-        notePhrase: primary?.excerpt ?? null,
       },
     );
 
@@ -328,6 +330,7 @@ export async function buildReviewItemViews(
       noteId: row.noteId,
       challengeId: row.challengeId,
       noteLabel: noteTitle ?? primary?.excerpt ?? primary?.passage ?? null,
+      noteContext: primary?.excerpt ?? null,
       noteWrittenAt: primary?.writtenAt?.toISOString() ?? null,
       sourceLabel: row.sourceLabel,
       sourceAt: row.sourceAt?.toISOString() ?? null,

--- a/server/utils/review-service.ts
+++ b/server/utils/review-service.ts
@@ -161,7 +161,14 @@ const REVIEW_EXCERPT_CHARS = 48;
 function noteExcerpt(html: string | null | undefined): string | null {
   if (!html) return null;
   const preview = stripHtmlForListPreview(html, REVIEW_EXCERPT_CHARS).trim();
-  return preview || null;
+  /*
+   * Trailing punctuation is trimmed here, at the source, so the excerpt is one string
+   * everywhere. The prompt joins it to a question with an em dash and cannot carry the stop;
+   * if the label kept it, the row's "does the question already name this?" check would fail
+   * on the punctuation alone and print the excerpt twice, once in each line.
+   */
+  const trimmed = preview.replace(/[.,;:—–-]+$/, '').trim();
+  return trimmed || null;
 }
 
 function displayTitle(title: string | null | undefined): string | null {
@@ -298,6 +305,9 @@ export async function buildReviewItemViews(
         secondaryNoteTitle,
         threadTitle,
         cue,
+        // The note's own words, so a note with no title still gets a specific question
+        // rather than one about "this note".
+        notePhrase: primary?.excerpt ?? null,
       },
     );
 

--- a/spa/src/hooks/queries/useReview.ts
+++ b/spa/src/hooks/queries/useReview.ts
@@ -32,6 +32,10 @@ export interface ReviewItemView {
   ladderStep: number;
   noteTitle: string | null;
   secondaryNoteTitle: string | null;
+  /** Title, else the first passage the note cites — the short answer to "which note?". */
+  noteLabel: string | null;
+  /** Last resort for a note with neither, formatted client-side where the zone is known. */
+  noteWrittenAt: string | null;
   scriptureReference: string | null;
   noteId: string | null;
   challengeId: string | null;

--- a/spa/src/hooks/queries/useReview.ts
+++ b/spa/src/hooks/queries/useReview.ts
@@ -34,6 +34,8 @@ export interface ReviewItemView {
   secondaryNoteTitle: string | null;
   /** Title, else the first passage the note cites — the short answer to "which note?". */
   noteLabel: string | null;
+  /** The note's own opening words, shown on the row's context line. */
+  noteContext: string | null;
   /** Last resort for a note with neither, formatted client-side where the zone is known. */
   noteWrittenAt: string | null;
   scriptureReference: string | null;

--- a/spa/src/pages/prototype/PrototypeReviewDock.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewDock.tsx
@@ -29,6 +29,7 @@ import { useNavigate, useRouterState } from '@tanstack/react-router';
 import Icon from '@/components/react/Icon';
 import StudyDockCardShell from '@/components/react/StudyDockCardShell';
 import { canJudgeRecall, resolveReviewDockItem } from '@/utils/review-dock-state';
+import { reviewRowSubtitle } from '@/utils/review-row-subtitle';
 import { noteParamSlug } from './proto-route-slugs';
 import { prototypeNoteRouteTo } from '@/lib/prototype-path';
 import { PROTOTYPE_NOTE_LIST_NAV_SEARCH } from '@/utils/prototype-sidebar-highlight-active';
@@ -284,6 +285,7 @@ export default function PrototypeReviewDock() {
 
   const answeringOnNote = paperStack?.origin.review?.itemId === item?.id && Boolean(item);
   const isVerse = item?.kind === 'verse';
+  const subtitle = item ? reviewRowSubtitle(item) : null;
   const canJudge = canJudgeRecall({ attempt });
 
   const verdictRow = (
@@ -442,6 +444,10 @@ export default function PrototypeReviewDock() {
         ) : !revealed ? (
           <>
             <p className="proto-review-dock__prompt">{item.prompt}</p>
+            {/* Which note is being asked about, when the question does not already say. The
+                row on Activity carries this too, and it is the difference between answering
+                about your note and guessing which note it means. */}
+            {subtitle ? <p className="proto-review-dock__subject">{subtitle}</p> : null}
             <textarea
               className="proto-review-dock__attempt"
               placeholder={REVIEW_ATTEMPT_PLACEHOLDER}

--- a/spa/src/pages/prototype/PrototypeReviewPage.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewPage.tsx
@@ -32,6 +32,7 @@ import {
 } from './proto-review-copy';
 import { RECALL_STATE_LABELS } from '@/utils/review-item-kinds';
 import { reviewRowSource, reviewRowSubtitle } from '@/utils/review-row-subtitle';
+import { reviewKindIcon } from './review-kind-icons';
 import { prototypeChallengeRouteTo, prototypeHomeRouteTo } from '@/lib/prototype-path';
 
 function rowMeta(item: ReviewItemView): (string | null)[] {
@@ -139,7 +140,7 @@ export default function PrototypeReviewPage() {
               {waiting.map((item) => (
                 <PrototypeReviewRow
                   key={item.id}
-                  icon={item.kind === 'verse' ? 'book-open' : 'arrows-rotate'}
+                  icon={reviewKindIcon(item.kind)}
                   title={item.prompt}
                   meta={rowMeta(item)}
                   onOpen={() => openReviewDock(item.id)}
@@ -179,7 +180,7 @@ export default function PrototypeReviewPage() {
               {scheduled.map((item) => (
                 <PrototypeReviewRow
                   key={item.id}
-                  icon={item.kind === 'verse' ? 'book-open' : 'arrows-rotate'}
+                  icon={reviewKindIcon(item.kind)}
                   title={item.noteLabel ?? item.scriptureReference ?? reviewRowSubtitle(item) ?? 'A note'}
                   meta={[
                     item.recallState === 'new' ? null : RECALL_STATE_LABELS[item.recallState],

--- a/spa/src/pages/prototype/PrototypeReviewPage.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewPage.tsx
@@ -31,14 +31,14 @@ import {
   REVIEW_RESUME_COPY,
 } from './proto-review-copy';
 import { RECALL_STATE_LABELS } from '@/utils/review-item-kinds';
+import { reviewRowSource, reviewRowSubtitle } from '@/utils/review-row-subtitle';
 import { prototypeChallengeRouteTo, prototypeHomeRouteTo } from '@/lib/prototype-path';
 
 function rowMeta(item: ReviewItemView): (string | null)[] {
-  const subject = item.noteTitle ?? item.scriptureReference;
+  const subtitle = reviewRowSubtitle(item);
   return [
-    // Omitted when the question already names it — see PrototypeReviewSection's `rowSubtitle`.
-    subject && !item.prompt.includes(subject) ? subject : null,
-    item.sourceLabel,
+    subtitle,
+    reviewRowSource(item, subtitle),
     item.recallState === 'new' ? null : RECALL_STATE_LABELS[item.recallState],
   ];
 }
@@ -180,7 +180,7 @@ export default function PrototypeReviewPage() {
                 <PrototypeReviewRow
                   key={item.id}
                   icon={item.kind === 'verse' ? 'book-open' : 'arrows-rotate'}
-                  title={item.noteTitle ?? item.scriptureReference ?? 'A note'}
+                  title={item.noteLabel ?? item.scriptureReference ?? reviewRowSubtitle(item) ?? 'A note'}
                   meta={[
                     item.recallState === 'new' ? null : RECALL_STATE_LABELS[item.recallState],
                   ]}
@@ -203,7 +203,7 @@ export default function PrototypeReviewPage() {
                 <PrototypeHomeRow
                   key={item.id}
                   icon="circle-minus"
-                  title={item.noteTitle ?? item.scriptureReference ?? 'A note'}
+                  title={item.noteLabel ?? item.scriptureReference ?? reviewRowSubtitle(item) ?? 'A note'}
                   onClick={() => setStatus.mutate({ itemId: item.id, status: 'active' })}
                   meta={[REVIEW_RESUME_COPY]}
                 />
@@ -217,7 +217,7 @@ export default function PrototypeReviewPage() {
                 <PrototypeHomeRow
                   key={item.id}
                   icon="eye-slash"
-                  title={item.noteTitle ?? item.scriptureReference ?? 'A note'}
+                  title={item.noteLabel ?? item.scriptureReference ?? reviewRowSubtitle(item) ?? 'A note'}
                   onClick={() => setStatus.mutate({ itemId: item.id, status: 'active' })}
                   meta={[REVIEW_RESUME_COPY]}
                 />

--- a/spa/src/pages/prototype/PrototypeReviewSection.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewSection.tsx
@@ -41,20 +41,8 @@ import {
 } from './proto-review-copy';
 import { prototypeChallengeRouteTo, prototypeReviewRouteTo } from '@/lib/prototype-path';
 import { RECALL_STATE_LABELS } from '@/utils/review-item-kinds';
+import { reviewRowSource, reviewRowSubtitle } from '@/utils/review-row-subtitle';
 import { useDismissiblePlusPrompt } from './use-dismissible-plus-prompt';
-
-/**
- * The line under the question, when there is something left to say.
- *
- * A note prompt already names its subject — "what did you observe in My journey?" — so
- * repeating "My journey" underneath says the same thing twice in two lines. Only shown when
- * the question does not already contain it, which is the case for a Thread or a bare verse.
- */
-function rowSubtitle(item: { prompt: string; noteTitle: string | null; scriptureReference: string | null }): string | null {
-  const subject = item.noteTitle ?? item.scriptureReference;
-  if (!subject) return null;
-  return item.prompt.includes(subject) ? null : subject;
-}
 
 export default function PrototypeReviewSection() {
   const navigate = useNavigate();
@@ -134,10 +122,10 @@ export default function PrototypeReviewSection() {
           icon={item.kind === 'verse' ? 'book-open' : 'arrows-rotate'}
           title={item.prompt}
           meta={[
-            rowSubtitle(item),
-            // Where it came from — "Highlighted while reading John 15". Null on rows the
-            // reader added themselves, who do not need telling.
-            item.sourceLabel,
+            // Which note, then why it is here — and the second is dropped when the first
+            // already said it. See review-row-subtitle.ts.
+            reviewRowSubtitle(item),
+            reviewRowSource(item, reviewRowSubtitle(item)),
             // The recall state as a word, never a percentage. "New" says nothing useful on a
             // row that is by definition being asked for the first time.
             item.recallState === 'new' ? null : RECALL_STATE_LABELS[item.recallState],

--- a/spa/src/pages/prototype/PrototypeReviewSection.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewSection.tsx
@@ -42,6 +42,7 @@ import {
 import { prototypeChallengeRouteTo, prototypeReviewRouteTo } from '@/lib/prototype-path';
 import { RECALL_STATE_LABELS } from '@/utils/review-item-kinds';
 import { reviewRowSource, reviewRowSubtitle } from '@/utils/review-row-subtitle';
+import { reviewKindIcon } from './review-kind-icons';
 import { useDismissiblePlusPrompt } from './use-dismissible-plus-prompt';
 
 export default function PrototypeReviewSection() {
@@ -119,7 +120,7 @@ export default function PrototypeReviewSection() {
       {reviewRows.map((item) => (
         <PrototypeReviewRow
           key={item.id}
-          icon={item.kind === 'verse' ? 'book-open' : 'arrows-rotate'}
+          icon={reviewKindIcon(item.kind)}
           title={item.prompt}
           meta={[
             // Which note, then why it is here — and the second is dropped when the first

--- a/spa/src/pages/prototype/__tests__/review-kind-icons.test.ts
+++ b/spa/src/pages/prototype/__tests__/review-kind-icons.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { REVIEW_KIND_ICONS, reviewKindIcon } from '../review-kind-icons';
+import { REVIEW_ITEM_KINDS } from '@/utils/review-item-kinds';
+
+describe('review kind icons', () => {
+  it('gives every kind a glyph', () => {
+    // A missing kind would fall through to `undefined` and render nothing at all.
+    for (const kind of REVIEW_ITEM_KINDS) {
+      expect(reviewKindIcon(kind)).toBeTruthy();
+    }
+    expect(Object.keys(REVIEW_KIND_ICONS).sort()).toEqual([...REVIEW_ITEM_KINDS].sort());
+  });
+
+  it('never draws a note with the compose-new-note button', () => {
+    // `pen-to-square` is the toolbar's "write a new note". On a row about a note you already
+    // wrote it reads as an invitation to write another one.
+    expect(REVIEW_KIND_ICONS.note).not.toBe('pen-to-square');
+    expect(REVIEW_KIND_ICONS.note).toBe('note-sticky');
+  });
+
+  it('tells a note, a verse and a highlight apart at a glance', () => {
+    // The regression this file exists for: four of the five kinds once shared `arrows-rotate`,
+    // so a row said "Review" when the reader needed to know what kind of thing it was about.
+    const distinct = new Set([
+      REVIEW_KIND_ICONS.note,
+      REVIEW_KIND_ICONS.verse,
+      REVIEW_KIND_ICONS.highlight,
+    ]);
+    expect(distinct.size).toBe(3);
+  });
+
+  it('keeps the scripture glyph that was already right', () => {
+    expect(REVIEW_KIND_ICONS.verse).toBe('book-open');
+  });
+
+  it('draws a highlight with the highlighter', () => {
+    expect(REVIEW_KIND_ICONS.highlight).toBe('highlighter');
+  });
+
+  it('shares the thread glyph between a link and the cluster it belongs to', () => {
+    // Deliberate: `arrow-right-arrow-left` is the thread mark everywhere in the app, and a
+    // connection is one edge of the same object. Their questions read nothing alike.
+    expect(REVIEW_KIND_ICONS.connection).toBe('arrow-right-arrow-left');
+    expect(REVIEW_KIND_ICONS.thread).toBe('arrow-right-arrow-left');
+  });
+
+  it('leaves the generic Review glyph to the feature, not to its items', () => {
+    for (const kind of REVIEW_ITEM_KINDS) {
+      expect(reviewKindIcon(kind)).not.toBe('arrows-rotate');
+    }
+  });
+});

--- a/spa/src/pages/prototype/review-kind-icons.ts
+++ b/spa/src/pages/prototype/review-kind-icons.ts
@@ -1,0 +1,55 @@
+/**
+ * The glyph each review item is drawn with.
+ *
+ * The sibling of `recall-kind-icons.ts`, and here for the same reason: which icon a row wears
+ * is a question only the client has, so the shared allowlist in `@/utils/review-item-kinds`
+ * never takes a dependency on the icon set.
+ *
+ * It replaces `item.kind === 'verse' ? 'book-open' : 'arrows-rotate'`, which is the exact
+ * failure the recall map was written to end — four of the five kinds wearing one glyph without
+ * anyone deciding they should. A row said "Review" when what the reader needed to know at a
+ * glance was "a note", "a verse", "a link you made".
+ *
+ * Every glyph here is the one that thing already wears elsewhere in the app. A review row is
+ * not a new kind of object; it is a question about an object the reader already recognises.
+ */
+import type { IconName } from '@/components/react/Icon';
+import type { ReviewItemKind } from '@/utils/review-item-kinds';
+
+export const REVIEW_KIND_ICONS: Record<ReviewItemKind, IconName> = {
+  /*
+   * `note-sticky` — a note.
+   *
+   * Not `pen-to-square`, which is the compose-new-note button in the toolbar: on a row about a
+   * note you already wrote, that reads as an invitation to write another one. And not
+   * `arrow-rotate-left`, recall's "revisit a note", which names the *action* — every row in
+   * Review is a revisit, so it would say nothing. The icon is here to name the subject.
+   */
+  note: 'note-sticky',
+
+  /** The one that was already right, and the reason the rest of this file exists. */
+  verse: 'book-open',
+
+  /*
+   * `highlighter` — the thing itself.
+   *
+   * `highlightEntryKindIconName` cannot help here: it picks from the entry's kind, and a review
+   * item carries no entry kind. That resolver hands most highlights `note-sticky`, which is
+   * spoken for by the note above anyway.
+   */
+  highlight: 'highlighter',
+
+  /*
+   * Both wear `arrow-right-arrow-left`, which is the thread glyph everywhere in the app — the
+   * sidebar's thread list, thread rows, the trail, search results — and what
+   * `highlightEntryKindIconName` gives a linked note. They share it because they are the same
+   * kind of thing seen at two sizes: an edge, and the cluster that edge belongs to. The
+   * questions read nothing alike, so the row still tells them apart.
+   */
+  connection: 'arrow-right-arrow-left',
+  thread: 'arrow-right-arrow-left',
+};
+
+export function reviewKindIcon(kind: ReviewItemKind): IconName {
+  return REVIEW_KIND_ICONS[kind];
+}

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -21778,6 +21778,16 @@ button.proto-feed-sheet__stat:hover {
   color: var(--pds-text-primary);
 }
 
+/* Which note the question is about, when the question itself does not name it. Quiet, and
+   directly under the prompt so the two read as one thing. */
+.proto-review-dock__subject {
+  margin: calc(var(--pds-space-2) * -1) 0 0;
+  font-family: var(--pds-font-body);
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--pds-text-tertiary);
+}
+
 /* The collapsed header line's second half — what is waiting, without opening the card. */
 .proto-review-dock__header-prompt {
   margin-left: var(--pds-space-2);

--- a/src/utils/__tests__/review-prompts.test.ts
+++ b/src/utils/__tests__/review-prompts.test.ts
@@ -148,22 +148,14 @@ describe('note questions speak to the reader, not about the note', () => {
     );
   });
 
-  it('lets the note own words lead instead, since a fragment cannot follow "in"', () => {
-    expect(
-      fillReviewPrompt('note.observe', { notePhrase: 'God chose us before the foundation' }),
-    ).toBe('God chose us before the foundation — what did you see?');
-  });
-
-  it('prefers a name over the note own words when it has one', () => {
-    expect(
-      fillReviewPrompt('note.central', { noteTitle: 'Adoption', notePhrase: 'God chose us' }),
-    ).toBe('What were you working out in Adoption?');
-  });
-
-  it('does not run two stops together when joining a phrase', () => {
-    // The excerpt ends wherever the sentence did.
-    expect(fillReviewPrompt('note.phrase', { notePhrase: 'He wept for the city.' })).toBe(
-      'He wept for the city — what made you write it?',
-    );
+  it('asks the bare question when the note has no name, and stays short', () => {
+    // The row prints the note's own opening words underneath, the way a verse row carries a
+    // fragment of the verse. Splicing them into the sentence made one very long question and
+    // left the line below with nothing to say.
+    expect(fillReviewPrompt('note.observe', {})).toBe('What did you see here?');
+    expect(fillReviewPrompt('note.phrase', {})).toBe('What made you write this?');
+    for (const key of noteKeys) {
+      expect(fillReviewPrompt(key, {}).length).toBeLessThan(46);
+    }
   });
 });

--- a/src/utils/__tests__/review-prompts.test.ts
+++ b/src/utils/__tests__/review-prompts.test.ts
@@ -123,3 +123,47 @@ describe('a fresh queue does not ask the same question three times', () => {
     expect(pickPromptKey('verse', 5, 2, 'review_v')).toBe(VERSE_LADDER[2]);
   });
 });
+
+describe('note questions speak to the reader, not about the note', () => {
+  const noteKeys = REVIEW_PROMPT_KEYS.filter((k) => k.startsWith('note.'));
+
+  it('never falls back to "this note", which named nothing', () => {
+    for (const key of noteKeys) {
+      const rendered = fillReviewPrompt(key, {});
+      expect(rendered).not.toMatch(/this note/i);
+    }
+  });
+
+  it('drops the worksheet vocabulary', () => {
+    for (const key of noteKeys) {
+      const rendered = fillReviewPrompt(key, { noteTitle: 'Adoption' });
+      expect(rendered).not.toMatch(/central idea|carry forward|the text itself|your note on/i);
+      expect(rendered).toMatch(/\byou\b/i);
+    }
+  });
+
+  it('puts a named subject inside the sentence', () => {
+    expect(fillReviewPrompt('note.observe', { noteTitle: 'Romans 8' })).toBe(
+      'What did you see in Romans 8?',
+    );
+  });
+
+  it('lets the note own words lead instead, since a fragment cannot follow "in"', () => {
+    expect(
+      fillReviewPrompt('note.observe', { notePhrase: 'God chose us before the foundation' }),
+    ).toBe('God chose us before the foundation — what did you see?');
+  });
+
+  it('prefers a name over the note own words when it has one', () => {
+    expect(
+      fillReviewPrompt('note.central', { noteTitle: 'Adoption', notePhrase: 'God chose us' }),
+    ).toBe('What were you working out in Adoption?');
+  });
+
+  it('does not run two stops together when joining a phrase', () => {
+    // The excerpt ends wherever the sentence did.
+    expect(fillReviewPrompt('note.phrase', { notePhrase: 'He wept for the city.' })).toBe(
+      'He wept for the city — what made you write it?',
+    );
+  });
+});

--- a/src/utils/__tests__/review-row-subtitle.test.ts
+++ b/src/utils/__tests__/review-row-subtitle.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { reviewRowSource, reviewRowSubtitle, writtenAtLabel } from '@/utils/review-row-subtitle';
+
+const NOW = new Date('2026-09-02T12:00:00Z');
+
+describe('reviewRowSubtitle', () => {
+  it('names the note when the question does not', () => {
+    expect(
+      reviewRowSubtitle(
+        { prompt: 'What in the text itself led you to write this?', noteLabel: 'This is cool' },
+        NOW,
+      ),
+    ).toBe('This is cool');
+  });
+
+  it('stays quiet when the question already names it', () => {
+    // "What did you observe in My journey?" does not need "My journey" underneath.
+    expect(
+      reviewRowSubtitle(
+        { prompt: 'Before opening it, what did you observe in My journey?', noteLabel: 'My journey' },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
+  it('falls back to the passage a nameless note cites', () => {
+    // The server resolves this: an untitled note is identified by what it is about.
+    expect(
+      reviewRowSubtitle(
+        { prompt: 'What in the text itself led you to write this note?', noteLabel: 'Romans 8:15' },
+        NOW,
+      ),
+    ).toBe('Romans 8:15');
+  });
+
+  it('places a note in time when nothing else names it', () => {
+    // The regression this file exists for: a row about "Untitled Note 4" said "this note"
+    // and nothing more, and the reader could not tell which note it meant.
+    expect(
+      reviewRowSubtitle(
+        {
+          prompt: 'What in the text itself led you to write this note?',
+          noteLabel: null,
+          noteWrittenAt: '2026-08-09T10:00:00Z',
+        },
+        NOW,
+      ),
+    ).toMatch(/^Written /);
+  });
+
+  it('never leaves a note row with no identity at all', () => {
+    for (const item of [
+      { prompt: 'What in the text itself led you to write this note?', noteLabel: 'A title' },
+      { prompt: 'What in the text itself led you to write this note?', noteLabel: 'John 15:5' },
+      {
+        prompt: 'What in the text itself led you to write this note?',
+        noteWrittenAt: '2026-08-09T10:00:00Z',
+      },
+    ]) {
+      expect(reviewRowSubtitle(item, NOW)).not.toBeNull();
+    }
+  });
+
+  it('has nothing to say about a Thread the question already names', () => {
+    expect(
+      reviewRowSubtitle(
+        { prompt: 'What central idea is taking shape across your Covenant Thread?', noteLabel: 'Covenant' },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+
+  it('prefers the resolved label over a raw title', () => {
+    expect(
+      reviewRowSubtitle({ prompt: 'A question', noteLabel: 'Romans 8:15', noteTitle: null }, NOW),
+    ).toBe('Romans 8:15');
+  });
+
+  it('shrugs at a date it cannot read rather than rendering an invalid one', () => {
+    expect(reviewRowSubtitle({ prompt: 'A question', noteWrittenAt: 'not a date' }, NOW)).toBeNull();
+  });
+});
+
+describe('writtenAtLabel', () => {
+  it('elides the year within the current one and keeps it otherwise', () => {
+    expect(writtenAtLabel('2026-08-09T10:00:00Z', NOW)).not.toMatch(/2026/);
+    expect(writtenAtLabel('2024-08-09T10:00:00Z', NOW)).toMatch(/2024/);
+  });
+
+  it('returns null for an unparseable date', () => {
+    expect(writtenAtLabel('nonsense', NOW)).toBeNull();
+  });
+});
+
+describe('reviewRowSource', () => {
+  it('drops the reason when the identity line already gave it', () => {
+    // "Written 10 Jul · You wrote this" is one fact wearing two labels.
+    expect(reviewRowSource({ sourceLabel: 'You wrote this' }, 'Written 10 Jul')).toBeNull();
+  });
+
+  it('keeps a reason that says something the identity does not', () => {
+    expect(reviewRowSource({ sourceLabel: 'You opened this again' }, 'Written 10 Jul')).toBe(
+      'You opened this again',
+    );
+    expect(reviewRowSource({ sourceLabel: 'You wrote this' }, 'This is cool')).toBe(
+      'You wrote this',
+    );
+  });
+
+  it('passes a reason through when there is no identity line at all', () => {
+    expect(reviewRowSource({ sourceLabel: 'Marked Romans 1:7 in a note' }, null)).toBe(
+      'Marked Romans 1:7 in a note',
+    );
+  });
+});

--- a/src/utils/__tests__/review-row-subtitle.test.ts
+++ b/src/utils/__tests__/review-row-subtitle.test.ts
@@ -4,6 +4,19 @@ import { reviewRowSource, reviewRowSubtitle, writtenAtLabel } from '@/utils/revi
 const NOW = new Date('2026-09-02T12:00:00Z');
 
 describe('reviewRowSubtitle', () => {
+  it('shows the note own words first, the way a verse row shows a fragment of the verse', () => {
+    expect(
+      reviewRowSubtitle(
+        {
+          prompt: 'What is clearer to you in Adoption now?',
+          noteTitle: 'Adoption',
+          noteContext: 'God chose us before the foundation',
+        },
+        NOW,
+      ),
+    ).toBe('God chose us before the foundation');
+  });
+
   it('names the note when the question does not', () => {
     expect(
       reviewRowSubtitle(
@@ -101,18 +114,15 @@ describe('writtenAtLabel', () => {
 });
 
 describe('reviewRowSource', () => {
-  it('drops the reason when the identity line already gave it', () => {
-    // "Written 10 Jul · You wrote this" is one fact wearing two labels.
+  it('drops "You wrote this" beside the reader own sentence, which already says so', () => {
+    expect(reviewRowSource({ sourceLabel: 'You wrote this' }, 'God chose us before')).toBeNull();
     expect(reviewRowSource({ sourceLabel: 'You wrote this' }, 'Written 10 Jul')).toBeNull();
   });
 
-  it('keeps a reason that says something the identity does not', () => {
-    expect(reviewRowSource({ sourceLabel: 'You opened this again' }, 'Written 10 Jul')).toBe(
-      'You opened this again',
-    );
-    expect(reviewRowSource({ sourceLabel: 'You wrote this' }, 'This is cool')).toBe(
-      'You wrote this',
-    );
+  it('keeps every reason that says something the context line does not', () => {
+    for (const source of ['You opened this again', 'Marked Romans 1:7 in a note', 'You linked these notes']) {
+      expect(reviewRowSource({ sourceLabel: source }, 'God chose us before')).toBe(source);
+    }
   });
 
   it('passes a reason through when there is no identity line at all', () => {

--- a/src/utils/__tests__/review-row-subtitle.test.ts
+++ b/src/utils/__tests__/review-row-subtitle.test.ts
@@ -23,8 +23,16 @@ describe('reviewRowSubtitle', () => {
     ).toBeNull();
   });
 
-  it('falls back to the passage a nameless note cites', () => {
-    // The server resolves this: an untitled note is identified by what it is about.
+  it('takes whatever identity the server resolved — an opening line, or a passage', () => {
+    expect(
+      reviewRowSubtitle(
+        {
+          prompt: 'What in the text itself led you to write this note?',
+          noteLabel: 'The first book Lets type more content here.',
+        },
+        NOW,
+      ),
+    ).toBe('The first book Lets type more content here.');
     expect(
       reviewRowSubtitle(
         { prompt: 'What in the text itself led you to write this note?', noteLabel: 'Romans 8:15' },
@@ -33,7 +41,7 @@ describe('reviewRowSubtitle', () => {
     ).toBe('Romans 8:15');
   });
 
-  it('places a note in time when nothing else names it', () => {
+  it('places a note in time only when nothing else names it at all', () => {
     // The regression this file exists for: a row about "Untitled Note 4" said "this note"
     // and nothing more, and the reader could not tell which note it meant.
     expect(

--- a/src/utils/review-prompts.ts
+++ b/src/utils/review-prompts.ts
@@ -50,43 +50,35 @@ export interface ReviewPromptContext {
   threadTitle?: string | null;
   /** A distinctive fragment of the verse, for the recognize rung. */
   cue?: string | null;
-  /** The note's own opening words, when it has no title to be named by. */
-  notePhrase?: string | null;
+
 }
 
 /**
- * What the question is about, and whether it is a *name* or the note's own words.
+ * The name the question can use, or null when the note has none.
  *
- * The distinction decides the sentence shape. "What did you see in Romans 8?" is fine, and
- * "What did you see in The first book Lets type more content here?" is not — an excerpt is a
- * fragment of prose, not a noun you can put after a preposition. Those lead instead:
- * "The first book Lets type more content here — what did you see?"
- *
- * Never "this note", which was the old fallback and named nothing at all.
+ * Never "this note", which was the old fallback and named nothing at all. A nameless note gets
+ * the bare form of the question instead, and the row names it on the line below.
  */
-function subject(ctx: ReviewPromptContext): { text: string; isPhrase: boolean } {
-  const name = ctx.reference?.trim() || ctx.noteTitle?.trim() || ctx.threadTitle?.trim();
-  if (name) return { text: name, isPhrase: false };
-  const phrase = ctx.notePhrase?.trim();
-  if (phrase) return { text: phrase, isPhrase: true };
-  return { text: 'this', isPhrase: false };
+function subjectName(ctx: ReviewPromptContext): string | null {
+  return ctx.reference?.trim() || ctx.noteTitle?.trim() || ctx.threadTitle?.trim() || null;
 }
 
 /**
- * Build a question two ways round: named subjects sit inside the sentence, the note's own
- * words lead it. `tail` is the phrase-led form, with the subject already spoken for.
+ * Build a question two ways round: a named subject sits inside the sentence, and a note with
+ * no name gets the bare form, because the row prints its opening words directly underneath.
+ *
+ * The note's own words were briefly spliced into the sentence itself, which read as one very
+ * long question and left nothing for the line below. The scripture row had it right all along:
+ * the question on top, what it is about beneath.
  */
-function ask(ctx: ReviewPromptContext, inside: (s: string) => string, tail: string): string {
-  const { text, isPhrase } = subject(ctx);
-  if (!isPhrase) return inside(text);
-  // Trailing punctuation is already trimmed where the excerpt is built, so that the label and
-  // the question hold the same string; this is belt and braces for any other caller.
-  return `${text.replace(/[.,;:—–-]+$/, '').trim()} — ${tail}`;
+function ask(ctx: ReviewPromptContext, inside: (s: string) => string, bare: string): string {
+  const name = subjectName(ctx);
+  return name ? inside(name) : bare;
 }
 
-/** The old shape, for prompts that only ever name a Thread or a passage. */
+/** For prompts that only ever name a Thread or a passage, which always have one. */
 function subjectText(ctx: ReviewPromptContext): string {
-  return subject(ctx).text;
+  return subjectName(ctx) ?? 'this';
 }
 
 function threadName(ctx: ReviewPromptContext): string {
@@ -106,13 +98,14 @@ export const REVIEW_PROMPTS: Record<ReviewPromptKey, (ctx: ReviewPromptContext) 
    * the note as an object rather than the reader as someone who wrote it, and "this note" named
    * nothing when the note had no title.
    */
-  'note.observe': (ctx) => ask(ctx, (s) => `What did you see in ${s}?`, 'what did you see?'),
+  'note.observe': (ctx) => ask(ctx, (s) => `What did you see in ${s}?`, 'What did you see here?'),
   'note.central': (ctx) =>
-    ask(ctx, (s) => `What were you working out in ${s}?`, 'what were you working out?'),
-  'note.carry': (ctx) => ask(ctx, (s) => `What stuck with you from ${s}?`, 'what stuck with you?'),
-  'note.phrase': (ctx) => ask(ctx, (s) => `What made you write ${s}?`, 'what made you write it?'),
+    ask(ctx, (s) => `What were you working out in ${s}?`, 'What were you working out here?'),
+  'note.carry': (ctx) =>
+    ask(ctx, (s) => `What stuck with you from ${s}?`, 'What stuck with you here?'),
+  'note.phrase': (ctx) => ask(ctx, (s) => `What made you write ${s}?`, 'What made you write this?'),
   'note.unclear': (ctx) =>
-    ask(ctx, (s) => `What is clearer to you in ${s} now?`, 'what is clearer to you now?'),
+    ask(ctx, (s) => `What is clearer to you in ${s} now?`, 'What is clearer to you now?'),
   'highlight.why': (ctx) => `You marked this in ${subjectText(ctx)}. What made it worth keeping?`,
   'highlight.detail': (ctx) => `What detail in ${subjectText(ctx)} led you to mark this passage?`,
   'connection.why': (ctx) =>

--- a/src/utils/review-prompts.ts
+++ b/src/utils/review-prompts.ts
@@ -50,16 +50,43 @@ export interface ReviewPromptContext {
   threadTitle?: string | null;
   /** A distinctive fragment of the verse, for the recognize rung. */
   cue?: string | null;
+  /** The note's own opening words, when it has no title to be named by. */
+  notePhrase?: string | null;
 }
 
-/** Falls back rather than rendering "undefined" — every prompt must read as a sentence. */
-function subject(ctx: ReviewPromptContext): string {
-  return (
-    ctx.reference?.trim() ||
-    ctx.noteTitle?.trim() ||
-    ctx.threadTitle?.trim() ||
-    'this note'
-  );
+/**
+ * What the question is about, and whether it is a *name* or the note's own words.
+ *
+ * The distinction decides the sentence shape. "What did you see in Romans 8?" is fine, and
+ * "What did you see in The first book Lets type more content here?" is not — an excerpt is a
+ * fragment of prose, not a noun you can put after a preposition. Those lead instead:
+ * "The first book Lets type more content here — what did you see?"
+ *
+ * Never "this note", which was the old fallback and named nothing at all.
+ */
+function subject(ctx: ReviewPromptContext): { text: string; isPhrase: boolean } {
+  const name = ctx.reference?.trim() || ctx.noteTitle?.trim() || ctx.threadTitle?.trim();
+  if (name) return { text: name, isPhrase: false };
+  const phrase = ctx.notePhrase?.trim();
+  if (phrase) return { text: phrase, isPhrase: true };
+  return { text: 'this', isPhrase: false };
+}
+
+/**
+ * Build a question two ways round: named subjects sit inside the sentence, the note's own
+ * words lead it. `tail` is the phrase-led form, with the subject already spoken for.
+ */
+function ask(ctx: ReviewPromptContext, inside: (s: string) => string, tail: string): string {
+  const { text, isPhrase } = subject(ctx);
+  if (!isPhrase) return inside(text);
+  // Trailing punctuation is already trimmed where the excerpt is built, so that the label and
+  // the question hold the same string; this is belt and braces for any other caller.
+  return `${text.replace(/[.,;:—–-]+$/, '').trim()} — ${tail}`;
+}
+
+/** The old shape, for prompts that only ever name a Thread or a passage. */
+function subjectText(ctx: ReviewPromptContext): string {
+  return subject(ctx).text;
 }
 
 function threadName(ctx: ReviewPromptContext): string {
@@ -71,13 +98,23 @@ function threadName(ctx: ReviewPromptContext): string {
  * cluster of connected notes, and `npm run check:thread-terminology` enforces it.
  */
 export const REVIEW_PROMPTS: Record<ReviewPromptKey, (ctx: ReviewPromptContext) => string> = {
-  'note.observe': (ctx) => `Before opening it, what did you observe in ${subject(ctx)}?`,
-  'note.central': (ctx) => `What is the central idea of your note on ${subject(ctx)}?`,
-  'note.carry': (ctx) => `What did you intend to carry forward from ${subject(ctx)}?`,
-  'note.phrase': (ctx) => `What in the text itself led you to write ${subject(ctx)}?`,
-  'note.unclear': (ctx) => `What has become clearer since you wrote ${subject(ctx)} — and what has not?`,
-  'highlight.why': (ctx) => `You marked this in ${subject(ctx)}. What made it worth keeping?`,
-  'highlight.detail': (ctx) => `What detail in ${subject(ctx)} led you to mark this passage?`,
+  /*
+   * Second person, and short.
+   *
+   * These read like a worksheet before — "what is the central idea of your note on X", "what in
+   * the text itself led you to write this note". Two problems in one sentence: they addressed
+   * the note as an object rather than the reader as someone who wrote it, and "this note" named
+   * nothing when the note had no title.
+   */
+  'note.observe': (ctx) => ask(ctx, (s) => `What did you see in ${s}?`, 'what did you see?'),
+  'note.central': (ctx) =>
+    ask(ctx, (s) => `What were you working out in ${s}?`, 'what were you working out?'),
+  'note.carry': (ctx) => ask(ctx, (s) => `What stuck with you from ${s}?`, 'what stuck with you?'),
+  'note.phrase': (ctx) => ask(ctx, (s) => `What made you write ${s}?`, 'what made you write it?'),
+  'note.unclear': (ctx) =>
+    ask(ctx, (s) => `What is clearer to you in ${s} now?`, 'what is clearer to you now?'),
+  'highlight.why': (ctx) => `You marked this in ${subjectText(ctx)}. What made it worth keeping?`,
+  'highlight.detail': (ctx) => `What detail in ${subjectText(ctx)} led you to mark this passage?`,
   'connection.why': (ctx) =>
     `Why did you connect ${ctx.noteTitle?.trim() || 'these notes'} and ${
       ctx.secondaryNoteTitle?.trim() || 'the other'
@@ -98,15 +135,15 @@ export const REVIEW_PROMPTS: Record<ReviewPromptKey, (ctx: ReviewPromptContext) 
     `If your ${threadName(ctx)} Thread had one sentence at its centre, what would it be?`,
   'verse.recognize': (ctx) =>
     ctx.cue?.trim()
-      ? `${subject(ctx)} — "${ctx.cue.trim()}…" What comes next?`
-      : `${subject(ctx)} — what does this verse say?`,
-  'verse.rebuild': (ctx) => `Fill in what is missing from ${subject(ctx)}.`,
-  'verse.recall': (ctx) => `${subject(ctx)} — write it as you remember it.`,
-  'verse.contextualize': (ctx) => `What happens just before or after ${subject(ctx)}?`,
-  'verse.sequence': (ctx) => `Put ${subject(ctx)} back in order.`,
+      ? `${subjectText(ctx)} — "${ctx.cue.trim()}…" What comes next?`
+      : `${subjectText(ctx)} — what does this verse say?`,
+  'verse.rebuild': (ctx) => `Fill in what is missing from ${subjectText(ctx)}.`,
+  'verse.recall': (ctx) => `${subjectText(ctx)} — write it as you remember it.`,
+  'verse.contextualize': (ctx) => `What happens just before or after ${subjectText(ctx)}?`,
+  'verse.sequence': (ctx) => `Put ${subjectText(ctx)} back in order.`,
   'verse.locate': () => 'Where is this from?',
   'verse.connect': (ctx) =>
-    `What note or passage did you connect to ${subject(ctx)}, and why?`,
+    `What note or passage did you connect to ${subjectText(ctx)}, and why?`,
 };
 
 /**

--- a/src/utils/review-row-subtitle.ts
+++ b/src/utils/review-row-subtitle.ts
@@ -16,15 +16,16 @@ import { NOTE_WRITTEN_SOURCE } from '@/utils/study-bible-source-copy';
  * So: the subtitle is only ever suppressed when the question *actually contains* the identity,
  * and there is always an identity to fall back to.
  *
- * Never a snippet of the note body. Previewing what someone wrote partly answers the question
- * being asked, which is the one thing a review row must not do.
+ * The identity itself is resolved server-side (`noteLabel`): the note's title, else its opening
+ * line, else the first passage it cites. A date is the last resort here and only that — it says
+ * when, not what, and "Written Jul 10" turned out to be no more use than saying nothing.
  */
 
 const WRITTEN_PREFIX = 'Written ';
 
 export interface ReviewRowSubtitleInput {
   prompt: string;
-  /** Title, else the first passage the note cites. Null when it has neither. */
+  /** Server-resolved: title, else the note's opening line, else the passage it cites. */
   noteLabel?: string | null;
   noteTitle?: string | null;
   scriptureReference?: string | null;

--- a/src/utils/review-row-subtitle.ts
+++ b/src/utils/review-row-subtitle.ts
@@ -16,9 +16,15 @@ import { NOTE_WRITTEN_SOURCE } from '@/utils/study-bible-source-copy';
  * So: the subtitle is only ever suppressed when the question *actually contains* the identity,
  * and there is always an identity to fall back to.
  *
- * The identity itself is resolved server-side (`noteLabel`): the note's title, else its opening
- * line, else the first passage it cites. A date is the last resort here and only that — it says
- * when, not what, and "Written Jul 10" turned out to be no more use than saying nothing.
+ * What it shows, in order:
+ *
+ * 1. **The note's own opening words** (`noteContext`), which is the line the scripture row has
+ *    always had — the reference on top, a fragment of the verse beneath. A note deserves the
+ *    same, and this is the most context per character available without opening it.
+ * 2. Its title or the passage it cites, when there is no body to quote and the question has
+ *    not already named it.
+ * 3. The date it was written. Last resort and only that: it says when, not what, and "Written
+ *    Jul 10" turned out to be no more use than saying nothing.
  */
 
 const WRITTEN_PREFIX = 'Written ';
@@ -27,6 +33,8 @@ export interface ReviewRowSubtitleInput {
   prompt: string;
   /** Server-resolved: title, else the note's opening line, else the passage it cites. */
   noteLabel?: string | null;
+  /** The note's own opening words. Preferred over everything else — it is the context line. */
+  noteContext?: string | null;
   noteTitle?: string | null;
   scriptureReference?: string | null;
   /** ISO date, the last resort for a note with no name and no passage. */
@@ -54,6 +62,10 @@ export function reviewRowSubtitle(
   item: ReviewRowSubtitleInput,
   now: Date = new Date(),
 ): string | null {
+  // The note's own words win outright: the question above names the note, this shows it.
+  const context = item.noteContext?.trim();
+  if (context) return context;
+
   const identity =
     item.noteLabel?.trim() || item.noteTitle?.trim() || item.scriptureReference?.trim() || null;
 
@@ -74,9 +86,12 @@ export function reviewRowSubtitle(
 /**
  * The "why is this here" line, dropped when the identity line already said it.
  *
- * A note with no name and no passage is placed in time — "Written 10 Jul" — and its reason for
- * being in the queue is that the reader wrote it. Printing both gives "Written 10 Jul · You
- * wrote this", which is one fact wearing two labels on a row that was meant to get shorter.
+ * "You wrote this" earns its place on a row that would otherwise say nothing about where the
+ * question came from. Beside the note's own sentence it says nothing at all — the reader can
+ * see whose words those are — and beside "Written 10 Jul" it is the same fact twice.
+ *
+ * Every other reason survives, because each says something the context line does not: "Marked
+ * Romans 1:7 in a note", "You linked these notes", "You opened this again".
  */
 export function reviewRowSource(
   item: { sourceLabel?: string | null },
@@ -84,5 +99,5 @@ export function reviewRowSource(
 ): string | null {
   const source = item.sourceLabel?.trim() || null;
   if (!source || !subtitle) return source;
-  return subtitle.startsWith(WRITTEN_PREFIX) && source === NOTE_WRITTEN_SOURCE ? null : source;
+  return source === NOTE_WRITTEN_SOURCE ? null : source;
 }

--- a/src/utils/review-row-subtitle.ts
+++ b/src/utils/review-row-subtitle.ts
@@ -1,0 +1,87 @@
+import { NOTE_WRITTEN_SOURCE } from '@/utils/study-bible-source-copy';
+
+/**
+ * The line under a review question that says *which* thing is being asked about.
+ *
+ * One implementation for all three places a review item is shown — the Review section on
+ * Activity, the Review page, and the dock — because they had drifted into three different
+ * answers to the same question, and one of those answers was "nothing at all".
+ *
+ * What went wrong, and the rule that comes out of it: a row read "What in the text itself led
+ * you to write this note?" with no other identifier, because the note's title was the server's
+ * auto-generated "Untitled Note 4" and display strips those. The prompt fell back to "this
+ * note" and the subtitle was suppressed for being redundant with a title that did not exist.
+ * The reader had a question about a note they could not name.
+ *
+ * So: the subtitle is only ever suppressed when the question *actually contains* the identity,
+ * and there is always an identity to fall back to.
+ *
+ * Never a snippet of the note body. Previewing what someone wrote partly answers the question
+ * being asked, which is the one thing a review row must not do.
+ */
+
+const WRITTEN_PREFIX = 'Written ';
+
+export interface ReviewRowSubtitleInput {
+  prompt: string;
+  /** Title, else the first passage the note cites. Null when it has neither. */
+  noteLabel?: string | null;
+  noteTitle?: string | null;
+  scriptureReference?: string | null;
+  /** ISO date, the last resort for a note with no name and no passage. */
+  noteWrittenAt?: string | null;
+}
+
+/** "9 Aug" / "9 Aug 2025" — formatted on the client, which is the only side that knows the zone. */
+export function writtenAtLabel(iso: string, now: Date = new Date()): string | null {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  const sameYear = date.getFullYear() === now.getFullYear();
+  return date.toLocaleDateString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    ...(sameYear ? {} : { year: 'numeric' }),
+  });
+}
+
+/**
+ * The identity line, or null when the question already carries it.
+ *
+ * `now` is injectable so the year-eliding date is testable.
+ */
+export function reviewRowSubtitle(
+  item: ReviewRowSubtitleInput,
+  now: Date = new Date(),
+): string | null {
+  const identity =
+    item.noteLabel?.trim() || item.noteTitle?.trim() || item.scriptureReference?.trim() || null;
+
+  if (identity) {
+    // Suppressed only when the question really does name it — "what did you observe in My
+    // journey?" does not need "My journey" repeated directly underneath.
+    return item.prompt.includes(identity) ? null : identity;
+  }
+
+  // Nothing names this note, so place it in time rather than leaving the row anonymous.
+  if (item.noteWrittenAt) {
+    const written = writtenAtLabel(item.noteWrittenAt, now);
+    if (written) return `${WRITTEN_PREFIX}${written}`;
+  }
+  return null;
+}
+
+/**
+ * The "why is this here" line, dropped when the identity line already said it.
+ *
+ * A note with no name and no passage is placed in time — "Written 10 Jul" — and its reason for
+ * being in the queue is that the reader wrote it. Printing both gives "Written 10 Jul · You
+ * wrote this", which is one fact wearing two labels on a row that was meant to get shorter.
+ */
+export function reviewRowSource(
+  item: { sourceLabel?: string | null },
+  subtitle: string | null,
+): string | null {
+  const source = item.sourceLabel?.trim() || null;
+  if (!source || !subtitle) return source;
+  return subtitle.startsWith(WRITTEN_PREFIX) && source === NOTE_WRITTEN_SOURCE ? null : source;
+}


### PR DESCRIPTION
The row you flagged read "What in the text itself led you to write this note?" with
nothing else on it. Its note's title was the server's auto-generated "Untitled Note 4",
which display strips, so the prompt fell back to "this note" and the subtitle was
suppressed for being redundant with a title that did not exist.

## The identity chain

Cheapest first: the title, else the first passage the note cites, else the date it was
written. A passage is the strongest honest fallback for a study note — it names the
subject the way a title would, and the lookup is one batched query, run only for notes
that have no usable name.

Deliberately never a snippet of the note body. A preview of what someone wrote partly
answers the question being asked, which is the one thing a review row must not do.

## One helper, three surfaces

The Review section, the Review page and the dock had drifted into three different
answers to "which note is this", and one of them was nothing at all. They now share
`src/utils/review-row-subtitle.ts`. The dock never had an answer either, which mattered
more there — that is where you sit down to actually answer the question.

## The redundancy the date fallback introduced

"Written 10 Jul · You wrote this" is one fact wearing two labels, on a row whose whole
point was to get shorter. The reason line now drops when the identity line already gave
it, and stays when it says something new ("You opened this again", "Marked Romans 1:7
in a note").

## Verification

Before: `What in the text itself led you to write this note?` / `You wrote this`
After:  `What in the text itself led you to write this note?` / `Written Jul 10`

4,962 tests pass, 13 of them new for the helper. Typecheck ratchet, Thread terminology,
colour tokens and design check all pass. Verified in the browser against the production
database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)