### PR TITLE
chore(git): never let a .env backup be staged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ pnpm-debug.log*
 
 # environment variables
 .env
+# Local backups of .env hold live credentials; never let one be staged.
+.env.bak*
+.env.*.bak
 .env.local
 .env.production
 


### PR DESCRIPTION
A local backup taken before editing `.env` holds live production credentials. It was
untracked but not ignored, which puts it one `git add -A` away from being committed.

`.env.bak*` and `.env.*.bak` are now ignored alongside `.env` itself.

One line of ignore rules, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)