### PR TITLE
Turn Supabase Realtime on, plus status.harvous.com and the stage 3/4 record

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -52,10 +52,17 @@ jobs:
           # indistinguishable from today's, and a var Netlify leaves unset is a var this
           # build must leave unset too.
           #
-          # Notably ABSENT on purpose, though the code reads them:
-          #   VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY — unset in production, so
-          #     isSupabaseRealtimeConfigured() is false and the app runs on HTTP polling.
-          #     Setting them here would switch realtime ON only on Cloudflare.
+          # VITE_SUPABASE_* were deliberately absent during the cutover, to keep the bundle
+          # byte-identical to Netlify's. Added 2026-09-02, after the cutover, to TURN REALTIME
+          # ON — it has never run in production because these two were the only missing piece.
+          # Everything else was already in place: the RLS policies and
+          # harvous_realtime_topic_allowed() exist in the production database, and Fly has
+          # SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY, so the server could always broadcast —
+          # there were simply no subscribers. The anon key is public by design; it ships in
+          # the browser bundle and RLS on realtime.messages is what actually enforces access.
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          # Still ABSENT on purpose, though the code reads them:
           #   VITE_API_BASE_URL — unset, so the SPA calls its own origin. Correct, since the
           #     Worker proxies /api/* to Fly.
           #   VITE_PUBLIC_POSTHOG_KEY — the code reads it, production never sets it;

--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -91,6 +91,33 @@ jobs:
         # with "Invalid manifest: file size ... exceeds 5242880 limit [code: 10304]".
         run: cp cloudflare/_headers cloudflare/_redirects cloudflare/.assetsignore dist-spa/
 
+      # Staging authenticates against a Clerk DEVELOPMENT instance, which serves clerk.js
+      # from <slug>.clerk.accounts.dev. Production's CSP allows *.clerk.com and
+      # clerk.harvous.com only, so the dev script is blocked and the app never boots.
+      #
+      # That gap is latent on Netlify rather than absent: netlify.toml documents
+      # [context.staging] as "dev Clerk", but new.harvous.com actually ships pk_live_ today,
+      # so the dev path has never been exercised there. Verified 2026-09-01.
+      #
+      # Applied to STAGING ONLY, and derived from the production file rather than duplicated,
+      # so production's CSP stays byte-identical to netlify.toml and the two cannot drift.
+      - name: Widen CSP for the dev Clerk instance (staging only)
+        if: github.ref_name != 'main'
+        run: |
+          node -e '
+            const fs = require("fs");
+            const f = "dist-spa/_headers";
+            let h = fs.readFileSync(f, "utf8");
+            const before = h;
+            for (const d of ["script-src", "frame-src"]) {
+              h = h.replace(new RegExp("(" + d + " [^;]*)", "g"),
+                            "$1 https://*.clerk.accounts.dev");
+            }
+            if (h === before) { console.error("CSP not modified — directive names changed?"); process.exit(1); }
+            fs.writeFileSync(f, h);
+            console.log("staging CSP: added *.clerk.accounts.dev to script-src and frame-src");
+          '
+
       # Guards the one regression this migration is most likely to ship. See the ordering
       # note in cloudflare/_headers.
       - name: Assert the two deploy-breaking invariants

--- a/docs/CLOUDFLARE_MIGRATION.md
+++ b/docs/CLOUDFLARE_MIGRATION.md
@@ -1,6 +1,6 @@
 # Phase A: Netlify → Cloudflare (app.harvous.com)
 
-**Status: STAGE 2 COMPLETE — CI deploys a byte-identical artifact, 20/20 parity, no DNS touched. Next: staging auth test, then stage 3.** Drafted 2026-08-27. Part of [INFRA_ENDGAME.md](INFRA_ENDGAME.md).
+**Status: STAGE 3 COMPLETE — zone on Cloudflare, no app traffic moved. Next: attach custom domains (stage 4), staging first.** Drafted 2026-08-27. Part of [INFRA_ENDGAME.md](INFRA_ENDGAME.md).
 
 Moves everything Netlify still does for app.harvous.com onto Cloudflare Workers:
 static SPA hosting, the `/api/*` → Fly proxy, headers/CSP, the crawler OG rewrite,
@@ -629,6 +629,40 @@ section — the account has been on Pro since the Aug 2026 pause) as you go.
   - The live-key sign-in necessarily happens at **stage 4, immediately after attaching
     app.harvous.com**, with the DNS rollback standing by. Treat it as the first action after
     attach, not a later step.
+
+- 2026-09-02 (**stage 3 complete — zone is on Cloudflare**) — Nameservers moved from
+  `ns1/ns2.hover.com` to `lennox.ns.cloudflare.com` / `sara.ns.cloudflare.com`. Delegation
+  propagated within minutes; Google, Cloudflare and Quad9 resolvers all see the new pair.
+  Every record verified through 1.1.1.1 afterwards, and the live surfaces are unchanged:
+  `app.harvous.com` 200 (still Netlify), `/api/health` 200 (still proxying to Fly),
+  `clerk.harvous.com` 200, `www` 301. **No app traffic moved.**
+
+  **Cloudflare's zone scan missed SEVEN records.** Switching on its import alone would have
+  broken authentication and email:
+
+  - `clerk`, `accounts` — auth. `clerk.harvous.com` failing to resolve takes down sign-in
+    for every user, on Netlify, instantly.
+  - `clkmail`, `clk._domainkey`, `clk2._domainkey` — Clerk transactional mail + DKIM.
+  - `heymail._domainkey` — **HEY's DKIM.** Outbound mail from @harvous.com would have failed
+    DKIM; with DMARC at `p=none` nothing bounces, deliverability just quietly degrades.
+  - `subdomain-owner-verification` TXT — purpose unidentified, preserved anyway.
+
+  It also defaulted **six** records to Proxied that had to be forced back to DNS-only: the
+  apex A, `www`, `app`, `new`, `status`, and `mail` — the last of which would have put
+  Hover's IMAP/SMTP behind an HTTP proxy.
+
+  **The method lesson, worth more than the record list.** The `dig` snapshot committed the
+  day before asserted "no hey1/hey2 DKIM selectors exist — HEY signs via the SPF include."
+  That was wrong: the selector is `heymail`, and the conclusion came from probing *guessed*
+  names and treating their absence as evidence. The first verification pass then reported
+  "16 of 16 match, zero differences" — true, but comparing Cloudflare against the same
+  incomplete list, so both sides agreed while both were missing the same records. **The
+  registrar's own panel caught it.** A zone diff is only as good as its more complete side;
+  compare against the registrar, never against your own capture.
+
+  Final gate before the switch: 18 records diffed against **both** Cloudflare nameservers,
+  0 failing.
+
 
 
 

--- a/docs/CLOUDFLARE_MIGRATION.md
+++ b/docs/CLOUDFLARE_MIGRATION.md
@@ -1,6 +1,6 @@
 # Phase A: Netlify → Cloudflare (app.harvous.com)
 
-**Status: STAGE 4 COMPLETE — app.harvous.com and new.harvous.com serve the Worker; authenticated smoke test passed. Next: freeze Netlify auto-publish, soak one week, then cleanup (CSRF first).** Drafted 2026-08-27. Part of [INFRA_ENDGAME.md](INFRA_ENDGAME.md).
+**Status: STAGE 4 COMPLETE — all three hosts (app, new, status) serve the Worker; authenticated smoke test passed; Netlify serves nothing. Next: freeze Netlify auto-publish, soak one week, then cleanup (CSRF first).** Drafted 2026-08-27. Part of [INFRA_ENDGAME.md](INFRA_ENDGAME.md).
 
 Moves everything Netlify still does for app.harvous.com onto Cloudflare Workers:
 static SPA hosting, the `/api/*` → Fly proxy, headers/CSP, the crawler OG rewrite,
@@ -722,3 +722,25 @@ section — the account has been on Pro since the Aug 2026 pause) as you go.
 
 
 
+
+- 2026-09-02 (**status.harvous.com attached — Netlify now serves nothing**) — All three hosts
+  are on the Worker. `/api/status/public` proxies to Fly correctly, so the status page's data
+  path is intact.
+
+  **The host gate is now proven live, on the host that motivated it:**
+
+  | path | `app.harvous.com` (dedicated) | `status.harvous.com` (not) |
+  |---|---|---|
+  | `/prototype/dashboard` | **302** → `/dashboard` | **200** — correctly not stripped |
+  | `/thread_abc123` | **301** → `/thread/abc123` | **301** → `/thread/abc123` |
+
+  Without the gate, `/prototype` — a live route on the status host — would have been stripped
+  and broken it the moment the domain attached.
+
+  **A false alarm worth recording, because this file already warned about it.** Right after
+  the attach, a plain `curl https://app.harvous.com/thread_abc123` returned 200 instead of 301
+  and looked like a regression. The response carried `server: Netlify`: this machine's
+  resolver still held the pre-cutover CNAME, and the checks that had passed minutes earlier
+  used `--resolve` while these did not. The stale-DNS caveat in the stage-4 entry above was
+  written and then walked into within the hour. **Never verify a cutover with a plain curl
+  from the machine that has been hitting the old host all day** — pin the IP, every time.

--- a/docs/CLOUDFLARE_MIGRATION.md
+++ b/docs/CLOUDFLARE_MIGRATION.md
@@ -1,6 +1,6 @@
 # Phase A: Netlify → Cloudflare (app.harvous.com)
 
-**Status: STAGE 3 COMPLETE — zone on Cloudflare, no app traffic moved. Next: attach custom domains (stage 4), staging first.** Drafted 2026-08-27. Part of [INFRA_ENDGAME.md](INFRA_ENDGAME.md).
+**Status: STAGE 4 IN PROGRESS — new.harvous.com is on Cloudflare and verified. app.harvous.com has NOT moved.** Drafted 2026-08-27. Part of [INFRA_ENDGAME.md](INFRA_ENDGAME.md).
 
 Moves everything Netlify still does for app.harvous.com onto Cloudflare Workers:
 static SPA hosting, the `/api/*` → Fly proxy, headers/CSP, the crawler OG rewrite,
@@ -591,6 +591,29 @@ section — the account has been on Pro since the Aug 2026 pause) as you go.
 
   So **three** custom domains attach at stage 4, not one: `app.harvous.com` and
   `status.harvous.com` on production, `new.harvous.com` on `--env staging`.
+
+- 2026-09-02 (**stage 4, staging half — new.harvous.com is on Cloudflare**) — Attached to
+  `harvous-app-staging`. Verified on the real domain: `server: cloudflare`, HSTS, the
+  `_headers` cache tiers, staging bundle `index-OS4t3bEc.js` carrying **pk_test_**, the
+  `clerk.accounts.dev` CSP widening, `/api/health` 200 through the proxy, stale asset 404,
+  and `/prototype/dashboard` → **302** `/dashboard`. That last one confirms the host-gated
+  redirect works in both directions — no strip on `*.workers.dev`, strip on a dedicated host.
+
+  **The rehearsal paid for itself: the attach failed the first time.**
+  `Hostname 'new.harvous.com' already has externally managed DNS records ... Delete them
+  first [code: 100117]` — Cloudflare will not overwrite a DNS record you manage. The existing
+  `new → harvous-new.netlify.app` CNAME had to be deleted first.
+
+  **This will happen again on `app.harvous.com`, and there it matters.** The sequence is
+  *delete the CNAME, then attach*, and between those two steps the hostname does not resolve.
+  On `new` that is nothing; on `app` it is a live outage window measured in however long the
+  deploy takes. Do them back-to-back, with the rollback CNAME value in hand
+  (`app → harvouscom.netlify.app`), and do not start unless able to finish.
+
+  Also worth expecting: local resolvers cache the old CNAME for its TTL (15 min here), so the
+  domain can appear to still serve Netlify well after the cutover succeeded. Verify with
+  `curl --resolve` against the Cloudflare IP rather than trusting a stale local answer.
+
 
 - 2026-09-01 (stage 2 complete, one gate re-ordered) — **CI now builds and deploys the real
   artifact, and it is byte-identical to Netlify's.** `harvous-app.harvous.workers.dev` serves

--- a/docs/CLOUDFLARE_MIGRATION.md
+++ b/docs/CLOUDFLARE_MIGRATION.md
@@ -1,6 +1,6 @@
 # Phase A: Netlify → Cloudflare (app.harvous.com)
 
-**Status: STAGE 4 IN PROGRESS — new.harvous.com is on Cloudflare and verified. app.harvous.com has NOT moved.** Drafted 2026-08-27. Part of [INFRA_ENDGAME.md](INFRA_ENDGAME.md).
+**Status: STAGE 4 COMPLETE — app.harvous.com and new.harvous.com serve the Worker; authenticated smoke test passed. Next: freeze Netlify auto-publish, soak one week, then cleanup (CSRF first).** Drafted 2026-08-27. Part of [INFRA_ENDGAME.md](INFRA_ENDGAME.md).
 
 Moves everything Netlify still does for app.harvous.com onto Cloudflare Workers:
 static SPA hosting, the `/api/*` → Fly proxy, headers/CSP, the crawler OG rewrite,
@@ -609,6 +609,38 @@ section — the account has been on Pro since the Aug 2026 pause) as you go.
   On `new` that is nothing; on `app` it is a live outage window measured in however long the
   deploy takes. Do them back-to-back, with the rollback CNAME value in hand
   (`app → harvouscom.netlify.app`), and do not start unless able to finish.
+
+- 2026-09-02 (**STAGE 4 COMPLETE — app.harvous.com is on Cloudflare**) — Traffic moved.
+  Cloudflare serves `index-BzUzz5zc.js`, byte-identical to what Netlify was serving at the
+  moment of the switch, with the live Clerk key. Verified on the real domain: HSTS,
+  `/assets/*` immutable, `/api/health` 200 through the proxy to Fly,
+  `/prototype/dashboard` → 302, stale asset → 404, and the site-inspired sign-in rendering
+  with zero console errors. **The authenticated gate passed: signed in and created a note.**
+  That is the check that failed all three Fly cutovers, and it passed first attempt here —
+  because the artifact was already proven byte-identical to production before it was routed.
+
+  **The dashboard could not do this, and that is worth recording.** Workers → Domains →
+  "Connect domain" reported *"No zones match app.harvous.com"* while the zone was demonstrably
+  live and serving; "Find similar" then opened a domain **purchase** screen offering
+  `appharvous.com` and `app-harvous.com`. The attach succeeded from the CLI:
+
+      npx wrangler triggers deploy
+
+  which applies route/domain changes **without rebuilding**. That property was not a
+  convenience — it was the safety requirement. A local `wrangler deploy` from this worktree
+  would have rebuilt with no `.env`, inlined no Clerk key, and pushed a bundle that cannot
+  boot straight to production at the exact moment traffic was moving.
+
+  **The outage window is real and was measured.** Between deleting the `app` CNAME and the
+  attach, public resolvers returned NO RECORD on both 1.1.1.1 and 8.8.8.8 while a stale local
+  cache still answered 200 — which is exactly how this looks fine from the operator's machine
+  and broken for everyone else. Verify a cutover with `dig @1.1.1.1` and `--resolve`, never
+  with a plain `curl` from the machine that has been hitting the old host all day. Recovery
+  is asymmetric too: the NXDOMAIN negative cache outlived the record's own 300s TTL.
+
+  Remaining: `status.harvous.com` is still on Netlify (separate attach, and the last thing
+  pinning the Netlify site).
+
 
   Also worth expecting: local resolvers cache the old CNAME for its TTL (15 min here), so the
   domain can appear to still serve Netlify well after the cutover succeeded. Verify with

--- a/docs/CLOUDFLARE_MIGRATION.md
+++ b/docs/CLOUDFLARE_MIGRATION.md
@@ -1,6 +1,6 @@
 # Phase A: Netlify → Cloudflare (app.harvous.com)
 
-**Status: STAGE 2 CLEAR — deployed to the real Cloudflare account, 20/20 parity, no DNS touched.** Drafted 2026-08-27. Part of [INFRA_ENDGAME.md](INFRA_ENDGAME.md).
+**Status: STAGE 2 COMPLETE — CI deploys a byte-identical artifact, 20/20 parity, no DNS touched. Next: staging auth test, then stage 3.** Drafted 2026-08-27. Part of [INFRA_ENDGAME.md](INFRA_ENDGAME.md).
 
 Moves everything Netlify still does for app.harvous.com onto Cloudflare Workers:
 static SPA hosting, the `/api/*` → Fly proxy, headers/CSP, the crawler OG rewrite,
@@ -591,6 +591,45 @@ section — the account has been on Pro since the Aug 2026 pause) as you go.
 
   So **three** custom domains attach at stage 4, not one: `app.harvous.com` and
   `status.harvous.com` on production, `new.harvous.com` on `--env staging`.
+
+- 2026-09-01 (stage 2 complete, one gate re-ordered) — **CI now builds and deploys the real
+  artifact, and it is byte-identical to Netlify's.** `harvous-app.harvous.workers.dev` serves
+  `/assets/index-DTnuXr7O.js` at 2,718,358 bytes — the *same content hash and same bytes* as
+  app.harvous.com. That is the strongest available proof the env reconciliation is right: had
+  any of `VITE_SUPABASE_*`, `VITE_API_BASE_URL` or the rest been set, the hash would differ.
+  Live Clerk key inlined (6 occurrences), zero Supabase project URLs, `sw.js` cache name now
+  carries its commit sha (`harvous-cache-v2-87-2-5c3aeaec`), parity 20/20.
+
+  **Two CI bugs found by checking rather than trusting the green tick:**
+
+  1. The first run went green and deployed **nothing to production**. `deploy --env staging`
+     executed on `main`, putting a live-Clerk build on the staging Worker while production
+     kept serving a manual upload. Cause: GitHub's `A && B || C` is short-circuiting, not a
+     ternary — an empty-string true-branch is falsy and falls through, so
+     `ref_name == 'main' && '' || '--env staging'` sends *every* ref to staging. The
+     non-empty value must sit in the TRUE position. Fixed by negating the condition.
+  2. `wrangler.jsonc` cannot carry the custom-domain routes before the zone exists (already
+     recorded above) — worth restating because it is the same class: config that reads
+     correctly and behaves otherwise.
+
+  **GATE RE-ORDERED — the authenticated smoke test cannot run on `*.workers.dev`.** Clerk
+  production instances are domain-locked: loading the deployed app there fails with
+  *"Production Keys are only allowed for domain harvous.com"*, and the page stays blank. The
+  plan's ordering (smoke-test on workers.dev, then move DNS) is therefore impossible as
+  written. Revised:
+
+  - The **wrong-key failure mode that killed all three Fly cutovers is structurally ruled
+    out here**, in a way it never was on Fly: the bundle is byte-identical to the one
+    production serves today, so the key inside it is definitionally the working one. What
+    remains untested is not the credential but whether Clerk works *through the Worker* —
+    an Origin/proxy question, not a secrets question.
+  - Exercise that on **staging with the dev Clerk key**: development instances are not
+    domain-locked, so `harvous-app-staging.harvous.workers.dev` can be signed into and will
+    exercise Clerk → Worker proxy → Fly → DB end to end. Do this before stage 3.
+  - The live-key sign-in necessarily happens at **stage 4, immediately after attaching
+    app.harvous.com**, with the DNS rollback standing by. Treat it as the first action after
+    attach, not a later step.
+
 
 
 

--- a/docs/DNS_SNAPSHOT_harvous.com.md
+++ b/docs/DNS_SNAPSHOT_harvous.com.md
@@ -1,0 +1,64 @@
+# DNS snapshot — harvous.com (pre-Cloudflare)
+
+**Captured 2026-09-02 UTC**, before Phase A stage 3 (moving the zone to Cloudflare).
+This is the recovery record. Diff Cloudflare's imported zone against it **before** touching
+nameservers at Hover.
+
+Current nameservers: `ns1.hover.com`, `ns2.hover.com`
+SOA serial at capture: `1788064358`
+CAA: **none** — nothing restricts which CA may issue, so Cloudflare certs are unblocked.
+
+## Records
+
+| Name | Type | Value | Cloudflare proxy | Notes |
+|---|---|---|---|---|
+| `@` | A | `75.2.60.5` | **grey** | Netlify load balancer — marketing site |
+| `www` | CNAME | `harvousdotcom.netlify.app` | **grey** | Marketing site, separate repo, **stays on Netlify** |
+| `app` | CNAME | `harvouscom.netlify.app` | **grey**, then replaced | Becomes a Worker custom domain at stage 4 |
+| `new` | CNAME | `harvous-new.netlify.app` | **grey**, then replaced | Worker `--env staging` at stage 4 |
+| `status` | CNAME | `harvouscom.netlify.app` | **grey**, then replaced | Worker (production) at stage 4 |
+| `clerk` | CNAME | `frontend-api.clerk.services` | **GREY — MANDATORY** | See below |
+| `accounts` | CNAME | `accounts.clerk.services` | **GREY — MANDATORY** | See below |
+| `clkmail` | CNAME | `mail.afn1kb8xgpgh.clerk.services` | **grey** | Clerk transactional mail (SendGrid) |
+| `clk._domainkey` | CNAME | `dkim1.afn1kb8xgpgh.clerk.services` | **grey** | Clerk DKIM |
+| `clk2._domainkey` | CNAME | `dkim2.afn1kb8xgpgh.clerk.services` | **grey** | Clerk DKIM |
+| `mail` | CNAME | `mail.hover.com.cust.hostedemail.com` | **grey** | Hover hosted email — verify still in use |
+
+## Email — the part that breaks silently
+
+| Name | Type | Value |
+|---|---|---|
+| `@` | MX 10 | `work-mx.app.hey.com` |
+| `@` | TXT | `v=spf1 include:_spf.hey.com ~all` |
+| `@` | TXT | `hey-verification:RyipH6toMcmCKjBzte1wkdd8` |
+| `_dmarc` | TXT | `v=DMARC1; p=none;` |
+
+Mail is **HEY for Work**. No `hey1`/`hey2` DKIM selectors exist — HEY signs via the SPF
+include. If MX or that SPF record fails to import, inbound mail dies with no error anywhere.
+
+## Other TXT at apex (domain verifications — losing one silently un-verifies a service)
+
+```
+openai-domain-verification=dv-Xiz7N5xXlXJ3ZWzUA0t3yYxl
+pinterest-site-verification=e517285f57887cd775f96418798ceee1
+google-site-verification=wJ9hRieP1eXaDNXIHySuOne8OED7GZS46pcFHHkpoLc
+```
+
+## Why `clerk` and `accounts` must stay grey-cloud
+
+`clerk.harvous.com` already answers with `server: cloudflare` and a `cf-ray` header — it is
+proxied by **Clerk's own** Cloudflare (`worker.clerkprod-cloudflare.net`), not ours. Orange-
+clouding it would proxy an already-proxied host through a second Cloudflare zone. Auth is the
+blast radius. Leave both DNS-only.
+
+## Confirmed absent
+
+`smtp`, `ftp`, `help`, `docs`, `blog`, `api`, `cdn`, `hey1._domainkey`, `hey2._domainkey`,
+and any CAA record.
+
+## Limitation — read this before trusting the table
+
+`dig` can only find record names that were **guessed**. There is no zone transfer, so this is
+a safety net, not a complete dump. **The authoritative list is Hover's DNS panel.** Compare
+Cloudflare's import against Hover's own record list; use this file to catch anything both of
+them drop.

--- a/docs/DNS_SNAPSHOT_harvous.com.md
+++ b/docs/DNS_SNAPSHOT_harvous.com.md
@@ -33,8 +33,18 @@ CAA: **none** — nothing restricts which CA may issue, so Cloudflare certs are 
 | `@` | TXT | `hey-verification:RyipH6toMcmCKjBzte1wkdd8` |
 | `_dmarc` | TXT | `v=DMARC1; p=none;` |
 
-Mail is **HEY for Work**. No `hey1`/`hey2` DKIM selectors exist — HEY signs via the SPF
-include. If MX or that SPF record fails to import, inbound mail dies with no error anywhere.
+| `heymail._domainkey` | CNAME | `heymail._domainkey.hey.com` | **CORRECTED 2026-09-02** |
+
+Mail is **HEY for Work**. If MX or the SPF record fails to import, inbound mail dies with no
+error anywhere; if the DKIM CNAME is missed, outbound mail fails DKIM and quietly loses
+deliverability (DMARC is `p=none`, so nothing bounces — it just degrades).
+
+> **Correction.** This file originally claimed "No `hey1`/`hey2` DKIM selectors exist — HEY
+> signs via the SPF include." That was wrong, and wrong in an instructive way: `dig` was
+> probed for the selector names I *guessed*, and a conclusion was drawn from their absence.
+> HEY's selector is **`heymail`**. The record was found only by reading Hover's own panel —
+> the exact fallback this file's Limitation section names. Absence of a guessed record is
+> not evidence that no record exists.
 
 ## Other TXT at apex (domain verifications — losing one silently un-verifies a service)
 
@@ -53,8 +63,14 @@ blast radius. Leave both DNS-only.
 
 ## Confirmed absent
 
-`smtp`, `ftp`, `help`, `docs`, `blog`, `api`, `cdn`, `hey1._domainkey`, `hey2._domainkey`,
-and any CAA record.
+`smtp`, `ftp`, `help`, `docs`, `blog`, `api`, `cdn`, and any CAA record.
+
+`hey1._domainkey` / `hey2._domainkey` are also absent — but see the correction above: their
+absence meant the selector was named something else, not that DKIM was unused.
+
+**Also present on Hover and missed by this capture:** a TXT record whose name Hover's UI
+truncates to `subdomain-…`, value `1a6b81fc06c1398b663610a095caaa80`. Purpose unidentified;
+resolve the full name from Hover's edit view before relying on this list.
 
 ## Limitation — read this before trusting the table
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -78,9 +78,11 @@
       "name": "harvous-app-staging",
       "observability": { "enabled": true },
       "vars": { "API_ORIGIN": "https://harvous.fly.dev" },
-      "workers_dev": true
-      // STAGE 4 ONLY — same reasoning as the production route above.
-      // "routes": [{ "pattern": "new.harvous.com", "custom_domain": true }]
+      "workers_dev": true,
+      // ATTACHED 2026-09-02 (stage 4, staging half). new.harvous.com now serves this Worker
+      // instead of Netlify's branch deploy. Rollback is re-pointing the DNS record.
+      // app.harvous.com is still commented out below — production has not moved.
+      "routes": [{ "pattern": "new.harvous.com", "custom_domain": true }]
     }
   }
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -64,10 +64,7 @@
   // on hostname (src/lib/status-page-host.ts, spa/src/router.tsx buildStatusHostRoutes).
   // Same build, same Worker. It is also the reason legacyRedirect() is host-gated — see
   // cloudflare/worker.ts; /prototype is a LIVE route on the status host.
-  // "routes": [
-  //   { "pattern": "app.harvous.com", "custom_domain": true },
-  //   { "pattern": "status.harvous.com", "custom_domain": true }
-  // ],
+  "routes": [{ "pattern": "app.harvous.com", "custom_domain": true }],
 
   "env": {
     // Mirrors netlify.toml's [context.staging]: dev Clerk key, production DB.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -64,7 +64,14 @@
   // on hostname (src/lib/status-page-host.ts, spa/src/router.tsx buildStatusHostRoutes).
   // Same build, same Worker. It is also the reason legacyRedirect() is host-gated — see
   // cloudflare/worker.ts; /prototype is a LIVE route on the status host.
-  "routes": [{ "pattern": "app.harvous.com", "custom_domain": true }],
+  "routes": [
+    { "pattern": "app.harvous.com", "custom_domain": true },
+    // status.harvous.com is the same build and the same Worker — a Netlify domain alias
+    // historically, with isStatusHost() (src/lib/status-page-host.ts) making the SPA render
+    // the status page at /. It is NOT in DEDICATED_PROTOTYPE_HOSTS, which is why
+    // legacyRedirect() in cloudflare/worker.ts is host-gated: /prototype is a live route here.
+    { "pattern": "status.harvous.com", "custom_domain": true }
+  ],
 
   "env": {
     // Mirrors netlify.toml's [context.staging]: dev Clerk key, production DB.


### PR DESCRIPTION
Everything since #51. The substantive change is the last commit: **Supabase Realtime has never run in production, and this turns it on.**

## Realtime

`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` were the only missing piece. They were held back during the cutover to keep the Cloudflare bundle byte-identical to Netlify's; that constraint expired when Netlify stopped serving.

Verified already in place, which is why this is one config line rather than a project:

- `harvous_realtime_topic_allowed()` and the `harvous_realtime_select` / `harvous_realtime_insert` policies on `realtime.messages` **exist in the production database**
- Fly already carries `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` — the server has been able to broadcast all along, with nobody subscribed
- `@supabase/supabase-js` already ships (71 references in the live bundle), so there is **no bundle cost** — it simply never initialized

What switches on, all currently inert: cross-device cache patching, shared-space presence (today hardcoded to an empty roster), and the pass-the-pen edit lease (today fully gated off). The latter two are Shared Spaces features — the paid add-on.

**Still manual after merge, in order:** confirm Clerk's native Supabase integration is active so session JWTs carry `"role": "authenticated"` (without it every private subscribe fails silently), verify private joins succeed, then turn OFF "Allow public access" in Supabase → Realtime → Settings.

## Also in here

- **`status.harvous.com` attached** — all three hosts now serve the Worker; Netlify serves nothing.
- **The host gate proven live:** `/prototype/dashboard` returns 302 on `app.harvous.com` and 200 on `status.harvous.com`. Without it, `/prototype` — a live route on the status host — would have broken on attach.
- **Stage 3/4 status log**, including what Cloudflare's zone scan missed (7 records, incl. both Clerk auth CNAMEs and HEY's DKIM) and the DNS snapshot as a recovery record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)