### PR TITLE
Connect suggestions in two queries and four at a time, not 120 in series

### DIFF
--- a/Changelog/2.87.3.md
+++ b/Changelog/2.87.3.md
@@ -1,0 +1,14 @@
+# 2.87.3
+
+## Performance
+
+- **Connect suggestions no longer hold the dashboard open.** `/api/notes/connect-suggestions`
+  ran up to 120 database round trips in series — twenty candidate notes, each awaiting two
+  passage lookups plus a ranking pass that repeated the same per-user scan every time. It now
+  batches the passage lookups into two queries, hoists the scan out to run once per request,
+  and ranks four candidates at a time while still stopping early. 4189ms to roughly 800ms,
+  with byte-identical results.
+
+  This was also why the Home dashboard's loading dots lasted two and a half seconds on every
+  cold load: the readiness gate waits on the slowest query it renders from, so Home was
+  settling on its 2500ms backstop deadline rather than on the gate. It now settles on the gate.

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.87.2
+**Version:** 2.87.3
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.87.2",
+  "version": "2.87.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-87-2';
+const CACHE_NAME = 'harvous-cache-v2-87-3';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/server/utils/__tests__/connect-suggestions-batching.test.ts
+++ b/server/utils/__tests__/connect-suggestions-batching.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The shape of the work, not the answer it produces.
+ *
+ * `getConnectSuggestions` used to walk its candidates one at a time, awaiting two passage
+ * queries and a full ranking pass for each before starting the next. Every one of those
+ * ranking passes re-ran the same per-user candidate scan, so twenty candidates meant twenty
+ * identical scans and roughly a hundred and twenty round trips in series — measured at 4.2
+ * seconds against a real database, which was long enough to hold the entire Home dashboard
+ * on its loading dots until the presentation deadline gave up waiting.
+ *
+ * Nothing about the result changed, so a test on the returned suggestions would not have
+ * caught the regression and would not catch it coming back. These assertions are about
+ * per-candidate work: the scan happens once, the passages are fetched in one pass, and the
+ * ranking runs concurrently. Sibling file `connect-suggestions.test.ts` covers the ranking
+ * itself.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const selectCalls: unknown[][] = [];
+let selectBatches: unknown[][] = [];
+
+/** One chainable stub standing in for `select().from().where()`, resolving the next batch. */
+function makeChain() {
+  const rows = selectBatches.shift() ?? [];
+  const chain: Record<string, unknown> = {};
+  for (const method of ['from', 'where', 'innerJoin', 'orderBy', 'limit']) {
+    chain[method] = () => chain;
+  }
+  chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(rows).then(resolve);
+  return chain;
+}
+
+vi.mock('../../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db')>();
+  return {
+    ...actual,
+    db: {
+      ...actual.db,
+      select: (...args: unknown[]) => {
+        selectCalls.push(args);
+        return makeChain();
+      },
+    },
+  };
+});
+
+const mockGetRelatedNoteCandidates = vi.fn();
+const mockGetRelatedNotesForPassages = vi.fn();
+
+vi.mock('../scripture-knowledge', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../scripture-knowledge')>();
+  return {
+    ...actual,
+    getRelatedNoteCandidates: (...a: unknown[]) => mockGetRelatedNoteCandidates(...a),
+    getRelatedNotesForPassages: (...a: unknown[]) => mockGetRelatedNotesForPassages(...a),
+  };
+});
+
+const { getConnectSuggestions } = await import('../connect-suggestions');
+
+/** Five notes, each tagged with a distinct verse, none of them connected to each other. */
+function seedFiveUnconnectedNotes() {
+  const noteIds = ['n1', 'n2', 'n3', 'n4', 'n5'];
+  selectBatches = [
+    // userNotes
+    noteIds.map((id) => ({ id, title: `Note ${id}` })),
+    // NoteConnections edges — none
+    [],
+    // getNotePassagesBatch: NoteScriptureReferences links — none
+    [],
+    // getNotePassagesBatch: ScriptureMetadata rows, one verse per note
+    noteIds.map((id, i) => ({ noteId: id, book: 'Romans', chapter: 8, verse: i + 1 })),
+  ];
+  return noteIds;
+}
+
+beforeEach(() => {
+  selectCalls.length = 0;
+  selectBatches = [];
+  mockGetRelatedNoteCandidates.mockReset();
+  mockGetRelatedNotesForPassages.mockReset();
+  mockGetRelatedNoteCandidates.mockResolvedValue([
+    { noteId: 'n9', book: 'Romans', chapter: 8, verse: 1 },
+  ]);
+  mockGetRelatedNotesForPassages.mockResolvedValue([]);
+});
+
+describe('getConnectSuggestions does its lookups in bulk', () => {
+  it('scans for candidates once for the whole run, not once per candidate', async () => {
+    seedFiveUnconnectedNotes();
+    await getConnectSuggestions('user_1');
+
+    expect(mockGetRelatedNoteCandidates).toHaveBeenCalledTimes(1);
+    // Five candidates were ranked, so the old code would have scanned five times.
+    expect(mockGetRelatedNotesForPassages.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('hands every ranking pass the same candidate rows it already fetched', async () => {
+    seedFiveUnconnectedNotes();
+    await getConnectSuggestions('user_1');
+
+    const scanned = await mockGetRelatedNoteCandidates.mock.results[0]!.value;
+    for (const call of mockGetRelatedNotesForPassages.mock.calls) {
+      expect(call[2]).toMatchObject({ candidates: scanned });
+    }
+  });
+
+  it('fetches every candidate note’s passages in one pass', async () => {
+    const noteIds = seedFiveUnconnectedNotes();
+    await getConnectSuggestions('user_1');
+
+    // userNotes, existing edges, then the two that make up the batched passage lookup.
+    // Per-candidate passage queries would put this at 2 + 2 x candidates.
+    expect(selectCalls.length).toBeLessThanOrEqual(2 + 2);
+    expect(selectCalls.length).toBeLessThan(2 + 2 * noteIds.length);
+  });
+
+  it('ranks candidates concurrently rather than one after another', async () => {
+    seedFiveUnconnectedNotes();
+    let inFlight = 0;
+    let peak = 0;
+    mockGetRelatedNotesForPassages.mockImplementation(async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 1));
+      inFlight -= 1;
+      return [];
+    });
+
+    await getConnectSuggestions('user_1');
+    // Serial ranking never exceeds one in flight; the chunk size is 4.
+    expect(peak).toBeGreaterThan(1);
+    expect(peak).toBeLessThanOrEqual(4);
+  });
+
+  it('stops early once it has enough suggestions instead of ranking every candidate', async () => {
+    seedFiveUnconnectedNotes();
+    mockGetRelatedNotesForPassages.mockResolvedValue([
+      { noteId: 'n9', score: 9, sharedPassages: ['Romans|8|1'], sharedCrossRefs: [], sharedThemes: [], sameSection: false },
+    ]);
+
+    await getConnectSuggestions('user_1', { limit: 3 });
+    // The first chunk of four already yields three pairs, so the fifth is never ranked.
+    expect(mockGetRelatedNotesForPassages.mock.calls.length).toBeLessThanOrEqual(4);
+  });
+});

--- a/server/utils/connect-suggestions.ts
+++ b/server/utils/connect-suggestions.ts
@@ -13,13 +13,15 @@ import {
   inArray,
   Notes,
   NoteConnections,
+  NoteScriptureReferences,
   ScriptureMetadata,
   ScriptureTopics,
 } from '../db';
 import {
+  getRelatedNoteCandidates,
   getRelatedNotesForPassages,
-  getNotePassages,
   type RelatedNote,
+  type VerseKey,
 } from './scripture-knowledge';
 import { isNoteConnectionsTableMissing } from './pg-undefined-relation';
 
@@ -139,6 +141,79 @@ async function resolveSharedThemeLabels(pairs: RankedPair[]): Promise<ConnectSug
 }
 
 /**
+ * Every candidate's passages in two queries instead of two per candidate.
+ *
+ * `getNotePassages` is the single-note version and stays the right call for a single note.
+ * Here it was being awaited once per candidate inside a serial loop, so twenty candidates
+ * cost forty round trips before the ranking had even started — and the ranking then paid for
+ * more of its own. Same rows, same dedupe, one pass.
+ */
+async function getNotePassagesBatch(noteIds: string[]): Promise<Map<string, VerseKey[]>> {
+  const out = new Map<string, VerseKey[]>();
+  if (!noteIds.length) return out;
+
+  // A note's passages are its own scripture metadata plus that of every scripture note it
+  // links to, so the linked ids have to be resolved before the metadata can be asked for.
+  const links = await db
+    .select({ noteId: NoteScriptureReferences.noteId, sid: NoteScriptureReferences.scriptureNoteId })
+    .from(NoteScriptureReferences)
+    .where(inArray(NoteScriptureReferences.noteId, noteIds));
+
+  const linkedByNote = new Map<string, string[]>();
+  for (const l of links) {
+    const list = linkedByNote.get(l.noteId);
+    if (list) list.push(l.sid);
+    else linkedByNote.set(l.noteId, [l.sid]);
+  }
+
+  const metadataIds = [...new Set([...noteIds, ...links.map((l) => l.sid)])];
+  const rows = await db
+    .select({
+      noteId: ScriptureMetadata.noteId,
+      book: ScriptureMetadata.book,
+      chapter: ScriptureMetadata.chapter,
+      verse: ScriptureMetadata.verse,
+    })
+    .from(ScriptureMetadata)
+    .where(inArray(ScriptureMetadata.noteId, metadataIds));
+
+  const rowsByNote = new Map<string, VerseKey[]>();
+  for (const r of rows) {
+    const list = rowsByNote.get(r.noteId);
+    const key = { book: r.book, chapter: r.chapter, verse: r.verse };
+    if (list) list.push(key);
+    else rowsByNote.set(r.noteId, [key]);
+  }
+
+  for (const noteId of noteIds) {
+    const seen = new Set<string>();
+    const passages: VerseKey[] = [];
+    for (const sourceId of [noteId, ...(linkedByNote.get(noteId) ?? [])]) {
+      for (const v of rowsByNote.get(sourceId) ?? []) {
+        const k = `${v.book}|${v.chapter}|${v.verse}`;
+        if (seen.has(k)) continue;
+        seen.add(k);
+        passages.push(v);
+      }
+    }
+    out.set(noteId, passages);
+  }
+
+  return out;
+}
+
+/**
+ * How many candidates are ranked at once.
+ *
+ * Each ranking pass is four dependent queries, so running them one candidate at a time made
+ * the endpoint as slow as twenty of those chains end to end. Four at a time is the useful
+ * part of that win without turning one dashboard request into twenty concurrent connections:
+ * the Supabase session pooler caps clients per process, and exhausting it surfaces as
+ * unrelated requests failing rather than as this one being slow.
+ */
+const RANKING_CONCURRENCY = 4;
+
+/**
  * Find the strongest pair of the user's notes that are related (by passage/cross-ref/theme) but
  * not yet connected via NoteConnections. Checks the top N notes by meaning weight (from fingerprints)
  * to keep the query bounded. Returns at most `limit` suggestions.
@@ -189,31 +264,53 @@ export async function getConnectSuggestions(
   const usedPairs = new Set<string>();
   const candidates = noteIds.slice(0, candidateLimit);
 
-  for (const noteId of candidates) {
-    if (out.length >= limit) break;
-    const passages = await getNotePassages(noteId);
-    if (!passages.length) continue;
+  // Fetched once for the whole run. Every ranking pass below scans the same set — the user's
+  // scripture-tagged notes — and differs only by which single note it excludes, so leaving the
+  // scan inside the pass meant running it twenty times for twenty one-row differences.
+  const [passagesByNote, relatedCandidates] = await Promise.all([
+    getNotePassagesBatch(candidates),
+    getRelatedNoteCandidates(userId),
+  ]);
+  // A candidate with no passages has nothing to match on, so it never reaches the ranker.
+  // Dropping those here rather than inside the loop means the concurrency below is spent
+  // entirely on candidates that can actually produce a pair.
+  const rankable = candidates.filter((noteId) => (passagesByNote.get(noteId) ?? []).length > 0);
 
-    const related = await getRelatedNotesForPassages(userId, passages, {
-      excludeNoteId: noteId,
-      limit: 10,
-    });
-
-    const linkedIds = linkedByNote.get(noteId) ?? new Set();
-    const best = pickBestUnlinkedPair(
-      noteId,
-      titleById.get(noteId) ?? 'Untitled note',
-      related,
-      linkedIds,
-      titleById,
+  /*
+   * Ranked a few at a time, still stopping as soon as there are enough suggestions.
+   *
+   * The early exit is what makes the chunking worth keeping over a plain `Promise.all`: a user
+   * whose first four notes yield three pairs pays for one wave, not twenty candidates' worth of
+   * queries. The order candidates are considered in is unchanged, and so is the result — the
+   * chunk's outcomes are folded back in list order, not completion order, so two runs over the
+   * same data still produce the same suggestions in the same sequence.
+   */
+  for (let i = 0; i < rankable.length && out.length < limit; i += RANKING_CONCURRENCY) {
+    const chunk = rankable.slice(i, i + RANKING_CONCURRENCY);
+    const ranked = await Promise.all(
+      chunk.map(async (noteId) => {
+        const related = await getRelatedNotesForPassages(userId, passagesByNote.get(noteId)!, {
+          excludeNoteId: noteId,
+          limit: 10,
+          candidates: relatedCandidates,
+        });
+        return pickBestUnlinkedPair(
+          noteId,
+          titleById.get(noteId) ?? 'Untitled note',
+          related,
+          linkedByNote.get(noteId) ?? new Set(),
+          titleById,
+        );
+      }),
     );
 
-    if (best) {
+    for (const best of ranked) {
+      if (out.length >= limit) break;
+      if (!best) continue;
       const pairKey = [best.noteAId, best.noteBId].sort().join('|');
-      if (!usedPairs.has(pairKey)) {
-        usedPairs.add(pairKey);
-        out.push(best);
-      }
+      if (usedPairs.has(pairKey)) continue;
+      usedPairs.add(pairKey);
+      out.push(best);
     }
   }
 

--- a/server/utils/scripture-knowledge.ts
+++ b/server/utils/scripture-knowledge.ts
@@ -332,9 +332,35 @@ export interface RelatedNotesOptions {
   maxCrossRefs?: number;
 }
 
+/** One of the user's scripture-tagged notes, as the candidate scan returns it. */
+export interface RelatedNoteCandidate extends VerseKey {
+  noteId: string;
+}
+
 export interface RelatedNotesForPassagesOptions extends RelatedNotesOptions {
   /** When set, exclude this note from candidate matches (e.g. the source note). */
   excludeNoteId?: string;
+  /**
+   * The user's candidate rows, already fetched.
+   *
+   * The scan is per-user, not per-passage: it returns every scripture-tagged note the user
+   * has, and the only thing the source note changes about it is which single note gets
+   * filtered out. A caller ranking one note should leave this alone. A caller ranking many
+   * in a row — connect-suggestions walks up to twenty — would otherwise run the same scan
+   * once per note and throw away all but one row's difference each time, which was most of
+   * what made that endpoint slow. Pass {@link getRelatedNoteCandidates} once and the
+   * exclusion still happens here, in memory.
+   */
+  candidates?: RelatedNoteCandidate[];
+}
+
+/** The candidate scan on its own, for callers that rank several notes against one user. */
+export async function getRelatedNoteCandidates(userId: string): Promise<RelatedNoteCandidate[]> {
+  return db
+    .select({ noteId: ScriptureMetadata.noteId, book: ScriptureMetadata.book, chapter: ScriptureMetadata.chapter, verse: ScriptureMetadata.verse })
+    .from(ScriptureMetadata)
+    .innerJoin(Notes, eq(ScriptureMetadata.noteId, Notes.id))
+    .where(and(eq(Notes.userId, userId), ne(Notes.noteType, 'scripture')));
 }
 
 /**
@@ -383,15 +409,19 @@ export async function getRelatedNotesForPassages(
     .limit(maxThemes);
   const themeIds = [...new Set(themeRows.map((t) => t.topicId))];
 
-  const candidateWhere = excludeNoteId
-    ? and(eq(Notes.userId, userId), ne(Notes.noteType, 'scripture'), ne(ScriptureMetadata.noteId, excludeNoteId))
-    : and(eq(Notes.userId, userId), ne(Notes.noteType, 'scripture'));
-
-  const candidates = await db
-    .select({ noteId: ScriptureMetadata.noteId, book: ScriptureMetadata.book, chapter: ScriptureMetadata.chapter, verse: ScriptureMetadata.verse })
-    .from(ScriptureMetadata)
-    .innerJoin(Notes, eq(ScriptureMetadata.noteId, Notes.id))
-    .where(candidateWhere);
+  // Filtering the supplied rows rather than re-querying keeps the two paths identical: the
+  // SQL exclusion below is the same `!= excludeNoteId` predicate, just pushed to the database.
+  const candidates = opts.candidates
+    ? (excludeNoteId ? opts.candidates.filter((c) => c.noteId !== excludeNoteId) : opts.candidates)
+    : await db
+        .select({ noteId: ScriptureMetadata.noteId, book: ScriptureMetadata.book, chapter: ScriptureMetadata.chapter, verse: ScriptureMetadata.verse })
+        .from(ScriptureMetadata)
+        .innerJoin(Notes, eq(ScriptureMetadata.noteId, Notes.id))
+        .where(
+          excludeNoteId
+            ? and(eq(Notes.userId, userId), ne(Notes.noteType, 'scripture'), ne(ScriptureMetadata.noteId, excludeNoteId))
+            : and(eq(Notes.userId, userId), ne(Notes.noteType, 'scripture')),
+        );
 
   const verseToNotes = new Map<string, Set<string>>();
   for (const c of candidates) {


### PR DESCRIPTION
## Why

`/api/notes/connect-suggestions` took **4189ms** warm, and that mattered well beyond itself. The Home dashboard's readiness gate waits on the slowest query it renders from, so Home never once settled on that gate — it settled on the 2500ms backstop deadline, on every cold load. Silently, because dots for 2.6s read as a slow network rather than as a query nothing was resolving.

`getConnectSuggestions` walked up to twenty candidate notes in series. Each iteration awaited two passage lookups, then a ranking pass whose own per-user candidate scan is identical on every call. Roughly 120 serial round trips, twenty of them the same scan repeated.

## What changed

Three changes, none of which alter the result:

- `getNotePassagesBatch` fetches every candidate's passages in two queries rather than two per candidate.
- The candidate scan moves out to `getRelatedNoteCandidates` and comes back in through a new `candidates` option, so it runs once per request. The exclusion still happens, in memory, using the same predicate the SQL used.
- Ranking runs four at a time, still stopping early once there are enough pairs. Four rather than all twenty because the Supabase session pooler caps clients per process, and exhausting it surfaces as unrelated requests failing rather than as this one being slow.

| Measurement | Before | After |
|---|---|---|
| `/api/notes/connect-suggestions`, warm | 4189ms | 724–886ms |
| Home cold settle | 2638ms, always via deadline | 1894–2814ms, always via gate |

## On the tests

The suggestions returned are byte-identical — verified by comparing payloads before and after. That is precisely why the new tests assert the *shape* of the work rather than the answer: a test on the result would neither have caught this nor catch it coming back. Both new guards were confirmed to fail against the old implementation, not merely to pass against the new one.

## Scope

Server only. This began as a wider branch that also reworked how the Home dashboard presents itself, but that half targets a file structure `new` no longer has — Home is refactored there behind `useHomeSurfaceData`, and the two sibling dashboards are renamed. The client work is going to `new` as a separate PR instead. The server fix belongs here because `new.harvous.com` runs `main`'s API.

Worth knowing for whoever reviews the `new` side: `new` already landed the chunked-concurrency half of this independently, with the same chunk size and the same reasoning about the 2.5s deadline. It does not have the passage batching or the hoisted scan, so only those two are being ported.

## Still open

Cold settle is still around 2s, and that is now the request fan-out rather than any one query — roughly 25 endpoints against one API process, with every readiness flag landing in a 1.6–2.8s band. No further per-endpoint tuning moves it. The two real levers are persisting the query cache so a reload paints from it, or splitting the single readiness gate so a late carousel card can arrive on its own. Both are product calls, and the second contradicts a documented invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)