### PR TITLE
Dashboards arrive a row at a time, and the dots stop flashing

### DIFF
--- a/Changelog/2.133.0.md
+++ b/Changelog/2.133.0.md
@@ -1,0 +1,12 @@
+# Version 2.133.0
+
+**Release Date**: September 2, 2026
+
+## Features
+
+- Dashboards arrive a row at a time, and the dots stop flashing
+
+## Other Changes
+
+- Never let a .env backup be staged
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 2.132.8
+**Version:** 2.133.0
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "2.132.8",
+  "version": "2.133.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v2-132-8';
+const CACHE_NAME = 'harvous-cache-v2-133-0';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 const CRITICAL_ASSETS = [

--- a/scripts/perf-budget.json
+++ b/scripts/perf-budget.json
@@ -1,8 +1,8 @@
 {
-  "initialPayloadGzip": 1144292,
+  "initialPayloadGzip": 1148606,
   "chunks": {
-    "index.js": 751816,
-    "index.css": 139453,
+    "index.js": 753848,
+    "index.css": 141735,
     "tiptap.js": 120673,
     "react-vendor.js": 60895,
     "router.js": 29131,

--- a/server/utils/__tests__/connect-suggestions-batching.test.ts
+++ b/server/utils/__tests__/connect-suggestions-batching.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The shape of the work, not the answer it produces.
+ *
+ * `getConnectSuggestions` used to walk its candidates one at a time, awaiting two passage
+ * queries and a full ranking pass for each before starting the next. Every one of those
+ * ranking passes re-ran the same per-user candidate scan, so twenty candidates meant twenty
+ * identical scans and roughly a hundred and twenty round trips in series — measured at 4.2
+ * seconds against a real database, which was long enough to hold the entire Home dashboard
+ * on its loading dots until the presentation deadline gave up waiting.
+ *
+ * Nothing about the result changed, so a test on the returned suggestions would not have
+ * caught the regression and would not catch it coming back. These assertions are about
+ * per-candidate work: the scan happens once, the passages are fetched in one pass, and the
+ * ranking runs concurrently. Sibling file `connect-suggestions.test.ts` covers the ranking
+ * itself.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const selectCalls: unknown[][] = [];
+let selectBatches: unknown[][] = [];
+
+/** One chainable stub standing in for `select().from().where()`, resolving the next batch. */
+function makeChain() {
+  const rows = selectBatches.shift() ?? [];
+  const chain: Record<string, unknown> = {};
+  for (const method of ['from', 'where', 'innerJoin', 'orderBy', 'limit']) {
+    chain[method] = () => chain;
+  }
+  chain.then = (resolve: (v: unknown) => unknown) => Promise.resolve(rows).then(resolve);
+  return chain;
+}
+
+vi.mock('../../db', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../db')>();
+  return {
+    ...actual,
+    db: {
+      ...actual.db,
+      select: (...args: unknown[]) => {
+        selectCalls.push(args);
+        return makeChain();
+      },
+    },
+  };
+});
+
+const mockGetRelatedNoteCandidates = vi.fn();
+const mockGetRelatedNotesForPassages = vi.fn();
+
+vi.mock('../scripture-knowledge', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../scripture-knowledge')>();
+  return {
+    ...actual,
+    getRelatedNoteCandidates: (...a: unknown[]) => mockGetRelatedNoteCandidates(...a),
+    getRelatedNotesForPassages: (...a: unknown[]) => mockGetRelatedNotesForPassages(...a),
+  };
+});
+
+const { getConnectSuggestions } = await import('../connect-suggestions');
+
+/** Five notes, each tagged with a distinct verse, none of them connected to each other. */
+function seedFiveUnconnectedNotes() {
+  const noteIds = ['n1', 'n2', 'n3', 'n4', 'n5'];
+  selectBatches = [
+    // userNotes
+    noteIds.map((id) => ({ id, title: `Note ${id}` })),
+    // NoteConnections edges — none
+    [],
+    // getNotePassagesBatch: NoteScriptureReferences links — none
+    [],
+    // getNotePassagesBatch: ScriptureMetadata rows, one verse per note
+    noteIds.map((id, i) => ({ noteId: id, book: 'Romans', chapter: 8, verse: i + 1 })),
+  ];
+  return noteIds;
+}
+
+beforeEach(() => {
+  selectCalls.length = 0;
+  selectBatches = [];
+  mockGetRelatedNoteCandidates.mockReset();
+  mockGetRelatedNotesForPassages.mockReset();
+  mockGetRelatedNoteCandidates.mockResolvedValue([
+    { noteId: 'n9', book: 'Romans', chapter: 8, verse: 1 },
+  ]);
+  mockGetRelatedNotesForPassages.mockResolvedValue([]);
+});
+
+describe('getConnectSuggestions does its lookups in bulk', () => {
+  it('scans for candidates once for the whole run, not once per candidate', async () => {
+    seedFiveUnconnectedNotes();
+    await getConnectSuggestions('user_1');
+
+    expect(mockGetRelatedNoteCandidates).toHaveBeenCalledTimes(1);
+    // Five candidates were ranked, so the old code would have scanned five times.
+    expect(mockGetRelatedNotesForPassages.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('hands every ranking pass the same candidate rows it already fetched', async () => {
+    seedFiveUnconnectedNotes();
+    await getConnectSuggestions('user_1');
+
+    const scanned = await mockGetRelatedNoteCandidates.mock.results[0]!.value;
+    for (const call of mockGetRelatedNotesForPassages.mock.calls) {
+      expect(call[2]).toMatchObject({ candidates: scanned });
+    }
+  });
+
+  it('fetches every candidate note’s passages in one pass', async () => {
+    const noteIds = seedFiveUnconnectedNotes();
+    await getConnectSuggestions('user_1');
+
+    // userNotes, existing edges, then the two that make up the batched passage lookup.
+    // Per-candidate passage queries would put this at 2 + 2 x candidates.
+    expect(selectCalls.length).toBeLessThanOrEqual(2 + 2);
+    expect(selectCalls.length).toBeLessThan(2 + 2 * noteIds.length);
+  });
+
+  it('ranks candidates concurrently rather than one after another', async () => {
+    seedFiveUnconnectedNotes();
+    let inFlight = 0;
+    let peak = 0;
+    mockGetRelatedNotesForPassages.mockImplementation(async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 1));
+      inFlight -= 1;
+      return [];
+    });
+
+    await getConnectSuggestions('user_1');
+    // Serial ranking never exceeds one in flight; the chunk size is 4.
+    expect(peak).toBeGreaterThan(1);
+    expect(peak).toBeLessThanOrEqual(4);
+  });
+
+  it('stops early once it has enough suggestions instead of ranking every candidate', async () => {
+    seedFiveUnconnectedNotes();
+    mockGetRelatedNotesForPassages.mockResolvedValue([
+      { noteId: 'n9', score: 9, sharedPassages: ['Romans|8|1'], sharedCrossRefs: [], sharedThemes: [], sameSection: false },
+    ]);
+
+    await getConnectSuggestions('user_1', { limit: 3 });
+    // The first chunk of four already yields three pairs, so the fifth is never ranked.
+    expect(mockGetRelatedNotesForPassages.mock.calls.length).toBeLessThanOrEqual(4);
+  });
+});

--- a/server/utils/connect-suggestions.ts
+++ b/server/utils/connect-suggestions.ts
@@ -13,13 +13,15 @@ import {
   inArray,
   Notes,
   NoteConnections,
+  NoteScriptureReferences,
   ScriptureMetadata,
   ScriptureTopics,
 } from '../db';
 import {
+  getRelatedNoteCandidates,
   getRelatedNotesForPassages,
-  getNotePassages,
   type RelatedNote,
+  type VerseKey,
 } from './scripture-knowledge';
 import { isNoteConnectionsTableMissing } from './pg-undefined-relation';
 
@@ -138,6 +140,69 @@ async function resolveSharedThemeLabels(pairs: RankedPair[]): Promise<ConnectSug
   });
 }
 
+
+/**
+ * Every candidate's passages in two queries instead of two per candidate.
+ *
+ * `getNotePassages` is the single-note version and stays the right call for a single note.
+ * The chunked loop below already stopped this from being twenty round trips *in series*, but
+ * they were still twenty round trips: parallelising work is not the same as not doing it.
+ * Same rows, same dedupe, one pass.
+ */
+async function getNotePassagesBatch(noteIds: string[]): Promise<Map<string, VerseKey[]>> {
+  const out = new Map<string, VerseKey[]>();
+  if (!noteIds.length) return out;
+
+  // A note's passages are its own scripture metadata plus that of every scripture note it
+  // links to, so the linked ids have to be resolved before the metadata can be asked for.
+  const links = await db
+    .select({ noteId: NoteScriptureReferences.noteId, sid: NoteScriptureReferences.scriptureNoteId })
+    .from(NoteScriptureReferences)
+    .where(inArray(NoteScriptureReferences.noteId, noteIds));
+
+  const linkedByNote = new Map<string, string[]>();
+  for (const l of links) {
+    const list = linkedByNote.get(l.noteId);
+    if (list) list.push(l.sid);
+    else linkedByNote.set(l.noteId, [l.sid]);
+  }
+
+  const metadataIds = [...new Set([...noteIds, ...links.map((l) => l.sid)])];
+  const rows = await db
+    .select({
+      noteId: ScriptureMetadata.noteId,
+      book: ScriptureMetadata.book,
+      chapter: ScriptureMetadata.chapter,
+      verse: ScriptureMetadata.verse,
+    })
+    .from(ScriptureMetadata)
+    .where(inArray(ScriptureMetadata.noteId, metadataIds));
+
+  const rowsByNote = new Map<string, VerseKey[]>();
+  for (const r of rows) {
+    const list = rowsByNote.get(r.noteId);
+    const key = { book: r.book, chapter: r.chapter, verse: r.verse };
+    if (list) list.push(key);
+    else rowsByNote.set(r.noteId, [key]);
+  }
+
+  for (const noteId of noteIds) {
+    const seen = new Set<string>();
+    const passages: VerseKey[] = [];
+    for (const sourceId of [noteId, ...(linkedByNote.get(noteId) ?? [])]) {
+      for (const v of rowsByNote.get(sourceId) ?? []) {
+        const k = `${v.book}|${v.chapter}|${v.verse}`;
+        if (seen.has(k)) continue;
+        seen.add(k);
+        passages.push(v);
+      }
+    }
+    out.set(noteId, passages);
+  }
+
+  return out;
+}
+
 /**
  * Find the strongest pair of the user's notes that are related (by passage/cross-ref/theme) but
  * not yet connected via NoteConnections. Checks the top N notes by meaning weight (from fingerprints)
@@ -190,6 +255,26 @@ export async function getConnectSuggestions(
   const candidates = noteIds.slice(0, candidateLimit);
 
   /*
+   * Both per-candidate lookups, lifted out of the loop and done once.
+   *
+   * Chunking made the remaining round trips concurrent; these two remove them. The passage
+   * lookups collapse into one batched pair of queries, and the related-notes scan — which is
+   * per-*user*, returning every scripture-tagged note they have, and differs between
+   * candidates only by which single note it excludes — now runs once instead of once per
+   * candidate, with the exclusion applied in memory. That scan was the expensive half of
+   * each ranking pass, so it was being paid for twenty times over to throw away one row's
+   * difference each time.
+   */
+  const [passagesByNote, relatedCandidates] = await Promise.all([
+    getNotePassagesBatch(candidates),
+    getRelatedNoteCandidates(userId),
+  ]);
+  // A candidate with no passages has nothing to match on, so it never reaches the ranker.
+  // Dropping those here rather than inside a chunk means the concurrency below is spent
+  // entirely on candidates that can actually produce a pair.
+  const rankable = candidates.filter((noteId) => (passagesByNote.get(noteId) ?? []).length > 0);
+
+  /*
    * A chunk at a time, in parallel — this loop used to be the slowest request the app makes.
    *
    * Each candidate costs at least three sequential round trips (`getNotePassages` is two on
@@ -212,17 +297,15 @@ export async function getConnectSuggestions(
    * twenty candidates' worth of work.
    */
   const CHUNK = 4;
-  for (let i = 0; i < candidates.length && out.length < limit; i += CHUNK) {
-    const chunk = candidates.slice(i, i + CHUNK);
+  for (let i = 0; i < rankable.length && out.length < limit; i += CHUNK) {
+    const chunk = rankable.slice(i, i + CHUNK);
 
     const found = await Promise.all(
       chunk.map(async (noteId) => {
-        const passages = await getNotePassages(noteId);
-        if (!passages.length) return null;
-
-        const related = await getRelatedNotesForPassages(userId, passages, {
+        const related = await getRelatedNotesForPassages(userId, passagesByNote.get(noteId)!, {
           excludeNoteId: noteId,
           limit: 10,
+          candidates: relatedCandidates,
         });
 
         return pickBestUnlinkedPair(

--- a/server/utils/scripture-knowledge.ts
+++ b/server/utils/scripture-knowledge.ts
@@ -332,9 +332,35 @@ export interface RelatedNotesOptions {
   maxCrossRefs?: number;
 }
 
+/** One of the user's scripture-tagged notes, as the candidate scan returns it. */
+export interface RelatedNoteCandidate extends VerseKey {
+  noteId: string;
+}
+
 export interface RelatedNotesForPassagesOptions extends RelatedNotesOptions {
   /** When set, exclude this note from candidate matches (e.g. the source note). */
   excludeNoteId?: string;
+  /**
+   * The user's candidate rows, already fetched.
+   *
+   * The scan is per-user, not per-passage: it returns every scripture-tagged note the user
+   * has, and the only thing the source note changes about it is which single note gets
+   * filtered out. A caller ranking one note should leave this alone. A caller ranking many
+   * in a row — connect-suggestions walks up to twenty — would otherwise run the same scan
+   * once per note and throw away all but one row's difference each time, which was most of
+   * what made that endpoint slow. Pass {@link getRelatedNoteCandidates} once and the
+   * exclusion still happens here, in memory.
+   */
+  candidates?: RelatedNoteCandidate[];
+}
+
+/** The candidate scan on its own, for callers that rank several notes against one user. */
+export async function getRelatedNoteCandidates(userId: string): Promise<RelatedNoteCandidate[]> {
+  return db
+    .select({ noteId: ScriptureMetadata.noteId, book: ScriptureMetadata.book, chapter: ScriptureMetadata.chapter, verse: ScriptureMetadata.verse })
+    .from(ScriptureMetadata)
+    .innerJoin(Notes, eq(ScriptureMetadata.noteId, Notes.id))
+    .where(and(eq(Notes.userId, userId), ne(Notes.noteType, 'scripture')));
 }
 
 /**
@@ -383,15 +409,19 @@ export async function getRelatedNotesForPassages(
     .limit(maxThemes);
   const themeIds = [...new Set(themeRows.map((t) => t.topicId))];
 
-  const candidateWhere = excludeNoteId
-    ? and(eq(Notes.userId, userId), ne(Notes.noteType, 'scripture'), ne(ScriptureMetadata.noteId, excludeNoteId))
-    : and(eq(Notes.userId, userId), ne(Notes.noteType, 'scripture'));
-
-  const candidates = await db
-    .select({ noteId: ScriptureMetadata.noteId, book: ScriptureMetadata.book, chapter: ScriptureMetadata.chapter, verse: ScriptureMetadata.verse })
-    .from(ScriptureMetadata)
-    .innerJoin(Notes, eq(ScriptureMetadata.noteId, Notes.id))
-    .where(candidateWhere);
+  // Filtering the supplied rows rather than re-querying keeps the two paths identical: the
+  // SQL exclusion below is the same `!= excludeNoteId` predicate, just pushed to the database.
+  const candidates = opts.candidates
+    ? (excludeNoteId ? opts.candidates.filter((c) => c.noteId !== excludeNoteId) : opts.candidates)
+    : await db
+        .select({ noteId: ScriptureMetadata.noteId, book: ScriptureMetadata.book, chapter: ScriptureMetadata.chapter, verse: ScriptureMetadata.verse })
+        .from(ScriptureMetadata)
+        .innerJoin(Notes, eq(ScriptureMetadata.noteId, Notes.id))
+        .where(
+          excludeNoteId
+            ? and(eq(Notes.userId, userId), ne(Notes.noteType, 'scripture'), ne(ScriptureMetadata.noteId, excludeNoteId))
+            : and(eq(Notes.userId, userId), ne(Notes.noteType, 'scripture')),
+        );
 
   const verseToNotes = new Map<string, Set<string>>();
   for (const c of candidates) {

--- a/spa/src/layouts/__tests__/proto-motion-home-enter.test.ts
+++ b/spa/src/layouts/__tests__/proto-motion-home-enter.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The dashboard enter window and the CSS it has to outlast.
+ *
+ * Same pairing the morph and expanded-sidebar tests keep, with a sharper failure. The
+ * `--enter` class is *removed* by a JS timeout while the animations it started are CSS, so
+ * a window shorter than the cascade cuts rows off mid-fade: they snap from part-way to
+ * fully opaque, which is precisely the "settles twice" artefact the single-settle gate
+ * exists to prevent. Three numbers feed the window here rather than one, so it can drift
+ * from any of them.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { PROTO_HOME_ENTER_WINDOW_MS } from '../proto-motion';
+
+function read(relative: string): string {
+  return readFileSync(resolve(process.cwd(), relative), 'utf8');
+}
+
+function durationMs(css: string, token: string): number {
+  const declared = new RegExp(`${token}:\\s*(\\d+)ms`).exec(css);
+  expect(declared, `${token} should be declared in prototype-tokens.css`).not.toBeNull();
+  return Number(declared![1]);
+}
+
+/** The cascade stops stepping after this many rows — keep in step with the `nth-child` rules. */
+const CASCADE_ROW_CAP = 6;
+
+describe('the home enter window matches the CSS it waits for', () => {
+  it('outlasts the section fade, the row fade, and the full cascade', () => {
+    const tokens = read('spa/src/styles/prototype-tokens.css');
+    const section = durationMs(tokens, '--pds-duration-home-section');
+    const row = durationMs(tokens, '--pds-duration-home-row');
+    const step = durationMs(tokens, '--pds-duration-home-row-step');
+
+    const lastRowEnds = row + step * (CASCADE_ROW_CAP - 1);
+    expect(PROTO_HOME_ENTER_WINDOW_MS).toBeGreaterThanOrEqual(Math.max(section, lastRowEnds));
+
+    // Slack, not a second animation's worth. A window far past the last frame leaves an
+    // inert class on the view; one far short of it is the snap this test exists to catch.
+    expect(PROTO_HOME_ENTER_WINDOW_MS).toBeLessThan(Math.max(section, lastRowEnds) + 400);
+  });
+
+  it('the cascade steps exactly as many rows as the window budgets for', () => {
+    const css = read('spa/src/styles/prototype-components.css');
+    const indices = [...css.matchAll(/\.proto-home-cascade > :nth-child\(([^)]+)\)\s*\{\s*--proto-home-row-i: (\d+);/g)];
+    // Five explicit positions plus the `n + 6` catch-all that pins every later row.
+    expect(indices).toHaveLength(CASCADE_ROW_CAP);
+    expect(indices[indices.length - 1]![1]).toContain('n + 6');
+    expect(Number(indices[indices.length - 1]![2])).toBe(CASCADE_ROW_CAP - 1);
+  });
+
+  it('both home animations are timed by tokens, not literals', () => {
+    const css = read('spa/src/styles/prototype-components.css');
+    const lines = css
+      .split('\n')
+      .filter((line) => /animation:\s*proto-home-(section|row)-in/.test(line));
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(line).toMatch(/var\(--pds-duration-home-(section|row)\)/);
+      expect(line).not.toMatch(/\d+(\.\d+)?s/);
+    }
+  });
+
+  it('the row cascade is honoured by reduced motion', () => {
+    const css = read('spa/src/styles/prototype-components.css');
+    const blocks = [...css.matchAll(/@media \(prefers-reduced-motion: reduce\) \{([\s\S]*?)\n\}/g)]
+      .map((m) => m[1]!)
+      .filter((body) => body.includes('.proto-home-cascade > *'));
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatch(/animation:\s*none/);
+  });
+
+  it('every space dashboard opts its row panels into the cascade', () => {
+    // The cascade is a named opt-in, which means a dashboard can lose it by omission: add a
+    // panel, forget the class, and that one section arrives as a block while the rest fill
+    // in. Nothing about the page looks broken, so nobody reports it. These three are the
+    // surfaces that present as a dashboard and are expected to cascade together.
+    const views = [
+      // Home builds every shelf from this one component.
+      'spa/src/pages/prototype/PrototypeHomeSection.tsx',
+      'spa/src/pages/prototype/PrototypeSpaceHub.tsx',
+      'spa/src/pages/prototype/PrototypeChurchHub.tsx',
+      // Lanes those two views delegate whole sections to. Each renders its own panel, so
+      // each has to opt in on its own — and a lane that does not is the visible bug: it
+      // arrives as a block between two lanes that are filling in.
+      'spa/src/pages/prototype/PrototypeChannelPairingSection.tsx',
+      'spa/src/pages/prototype/PrototypeSpaceComingUp.tsx',
+    ];
+    for (const view of views) {
+      const src = read(view);
+      const optsIn = src.includes('proto-home-cascade') || /<ProtoToolsRowList[^>]*\scascade\b/.test(src);
+      expect(optsIn, `${view} should opt its row panels into proto-home-cascade`).toBe(true);
+    }
+  });
+
+  it('the shared row panel keeps the cascade off by default', () => {
+    // ProtoToolsRowList is also inside sheets that animate themselves and inside note search,
+    // whose rows are replaced on every keystroke. Defaulting it on would cascade there too.
+    const src = read('spa/src/pages/prototype/proto-tools-registry.tsx');
+    expect(src).toMatch(/cascade = false/);
+  });
+
+  it('the loading dots are honoured by reduced motion', () => {
+    // No guard existed at all: the one mark on screen for every wait, repeating forever,
+    // was the one piece of motion the setting could not switch off.
+    const css = read('src/styles/global.css');
+    const blocks = [...css.matchAll(/@media \(prefers-reduced-motion: reduce\) \{([\s\S]*?)\n\}/g)]
+      .map((m) => m[1]!)
+      .filter((body) => body.includes('.load-more-indicator__dot'));
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toMatch(/animation:\s*none/);
+  });
+});

--- a/spa/src/layouts/proto-motion.ts
+++ b/spa/src/layouts/proto-motion.ts
@@ -135,3 +135,20 @@ export const PROTO_FOUNDER_LETTER_SHEET_EXIT_MS = 920;
  * clears — the timer replaces the card, it does not block anything.
  */
 export const PROTO_REVIEW_RESULT_DWELL_MS = 1800;
+
+/**
+ * How long a space dashboard wears `--enter` — MUST outlast every animation the class
+ * starts, which is the section fade (`--pds-duration-home-section`) and, running
+ * alongside it rather than after it, the row cascade: `--pds-duration-home-row` plus the
+ * last row's share of `--pds-duration-home-row-step`. The cascade caps at six rows, so
+ * five steps.
+ *
+ * The two are concurrent, so this is the longer of them and not their sum:
+ * max(420, 320 + 5×28) = 460, plus slack for a row that starts a frame late. Adding them
+ * would hold an inert class on the view for most of a second after everything had settled.
+ *
+ * Generous in one direction only. The class is *removed* when the window ends, and removing
+ * it mid-animation snaps a half-faded row to full opacity — visible, and worse than the
+ * wait. `proto-motion-home-enter.test.ts` holds both bounds.
+ */
+export const PROTO_HOME_ENTER_WINDOW_MS = 560;

--- a/spa/src/pages/prototype/ProtoSpaceLoading.tsx
+++ b/spa/src/pages/prototype/ProtoSpaceLoading.tsx
@@ -1,9 +1,23 @@
 /** Three-dot loading indicator shared by Home and other sidebar space views. */
 import ProtoLoadingDots from './ProtoLoadingDots';
 
-export default function ProtoSpaceLoading({ label = 'Loading' }: { label?: string }) {
+export default function ProtoSpaceLoading({
+  label = 'Loading',
+  /**
+   * Fade out in place while the content that replaces it paints underneath.
+   *
+   * Positioning is part of leaving, not decoration: a block still in flow would keep
+   * reserving its own height and push the dashboard down for the length of the fade, so
+   * the pane would settle twice — once for the content and once for the dots finally
+   * going. See `useProtoSpaceLoaderState`, which owns the timing.
+   */
+  leaving = false,
+}: {
+  label?: string;
+  leaving?: boolean;
+}) {
   return (
-    <div className="proto-home-loading">
+    <div className={`proto-home-loading${leaving ? ' proto-home-loading--leaving' : ''}`}>
       <ProtoLoadingDots label={label} />
     </div>
   );

--- a/spa/src/pages/prototype/PrototypeChannelPairingSection.tsx
+++ b/spa/src/pages/prototype/PrototypeChannelPairingSection.tsx
@@ -56,7 +56,7 @@ export default function PrototypeChannelPairingSection({
   return (
     <div className="proto-home-section">
       <p className="proto-caption proto-home-section__eyebrow">Channels for spaces</p>
-      <div className="proto-glass-surface proto-glass-surface--panel proto-church-tools">
+      <div className="proto-glass-surface proto-glass-surface--panel proto-church-tools proto-home-cascade">
         {sharedSpaces.map((space) => {
           const paired = channelForSpace.get(space.id) ?? null;
           const isOpen = openFor === space.id;

--- a/spa/src/pages/prototype/PrototypeChurchHub.tsx
+++ b/spa/src/pages/prototype/PrototypeChurchHub.tsx
@@ -46,7 +46,7 @@ import PrototypeChurchTeachingPlanSection from './PrototypeChurchTeachingPlanSec
 import PrototypeChurchEngagementSection from './PrototypeChurchEngagementSection';
 import PrototypeChurchStarterSection from './PrototypeChurchStarterSection';
 import PrototypeChurchSettingsSection from './PrototypeChurchSettingsSection';
-import { useProtoHomeViewClassName } from './useProtoHomeViewEnter';
+import { useProtoHomeViewClassName, useProtoSpaceLoaderState } from './useProtoHomeViewEnter';
 import PrototypeChannelPairingSection from './PrototypeChannelPairingSection';
 
 function normalizeSpaceId(id: string): string {
@@ -418,6 +418,7 @@ export default function PrototypeChurchHub() {
     (!billingEnabled || isQuerySettled(billingQuery.isPending, billingQuery.data != null));
   // Each tools pane is its own destination, so it replays on the way in and back.
   const homeViewClassName = useProtoHomeViewClassName(contentReady, `${orgId ?? 'none'}:${toolsView}`);
+  const { showLoader, loaderLeaving } = useProtoSpaceLoaderState(contentReady);
 
   /** What the header reads — the pane's own name once you drill into one. */
   const headerTitle =
@@ -502,9 +503,14 @@ export default function PrototypeChurchHub() {
     two.
   */
   const content = !contentReady ? (
-    <ProtoSpaceLoading label="Loading church" />
+    // Withheld for the first 150ms so a warm remount shows nothing rather than a flash of
+    // dots. See useProtoSpaceLoaderState.
+    showLoader ? <ProtoSpaceLoading label="Loading church" /> : null
   ) : (
         <div className={homeViewClassName}>
+          {/* Fading out over the hub arriving underneath, so the two states overlap rather
+              than swapping between frames. Out of flow; costs the layout nothing. */}
+          {showLoader ? <ProtoSpaceLoading label="Loading church" leaving={loaderLeaving} /> : null}
           {toolsView === 'teaching-plan' ? (
             /*
               Both lanes are plannable: a church Shared Space gathers as surely
@@ -590,7 +596,7 @@ export default function PrototypeChurchHub() {
                   <p className="proto-caption proto-home-section__eyebrow">Shared spaces</p>
                   {sharedSpaces.length > 0 ? (
                     <>
-                      <ul className="proto-church-hub__list">
+                      <ul className="proto-church-hub__list proto-home-cascade">
                         {sharedSpaces.map((space) => (
                           <li key={space.id}>
                             <ChurchHubSpaceButton space={space} ministry={false} onOpen={openSpace} />
@@ -639,7 +645,7 @@ export default function PrototypeChurchHub() {
                   <p className="proto-caption proto-home-section__eyebrow">Channels</p>
                   {ministryChannels.length > 0 ? (
                     <>
-                      <ul className="proto-church-hub__list">
+                      <ul className="proto-church-hub__list proto-home-cascade">
                         {ministryChannels.map((space) => (
                           <li key={space.id}>
                             <ChurchHubSpaceButton space={space} ministry onOpen={openSpace} />
@@ -689,7 +695,7 @@ export default function PrototypeChurchHub() {
                     <p className="proto-caption proto-home-section__eyebrow">
                       {manageOpen ? 'All channels' : 'Discover'}
                     </p>
-                    <ul className="proto-church-hub__list">
+                    <ul className="proto-church-hub__list proto-home-cascade">
                       {browseChannels.map((channel) => (
                         <li key={channel.id}>
                           <ChurchHubBrowseRow
@@ -717,7 +723,7 @@ export default function PrototypeChurchHub() {
             canManageChurchSettings ? (
               <div className="proto-home-section">
                 <p className="proto-caption proto-home-section__eyebrow">Tools</p>
-                <ProtoToolsRowList rows={churchToolRows}>
+                <ProtoToolsRowList rows={churchToolRows} cascade>
                   {/* Silent while the church is paid and healthy. */}
                   <PrototypeChurchPlanRow orgId={orgId} isStaff={canCreateChurchContent} />
                 </ProtoToolsRowList>

--- a/spa/src/pages/prototype/PrototypeHomeSection.tsx
+++ b/spa/src/pages/prototype/PrototypeHomeSection.tsx
@@ -7,7 +7,9 @@
  *
  * The `proto-home-section__list` class stays on the panel because the empty-group rule keys
  * off it: a section whose children all render null should collapse rather than leave a
- * heading over an empty box.
+ * heading over an empty box. `proto-home-cascade` is the separate opt-in that makes the rows
+ * arrive in sequence — separate because the shared space and church hub build their panels
+ * their own way and need the cascade without inheriting the empty-group behaviour.
  */
 import type { ReactNode } from 'react';
 
@@ -27,7 +29,7 @@ export default function PrototypeHomeSection({
       data-proto-spotlight={spotlight}
     >
       <p className="proto-caption proto-home-section__eyebrow">{title}</p>
-      <div className="proto-glass-surface proto-glass-surface--panel proto-list-panel proto-home-section__list">
+      <div className="proto-glass-surface proto-glass-surface--panel proto-list-panel proto-home-section__list proto-home-cascade">
         {children}
       </div>
     </section>

--- a/spa/src/pages/prototype/PrototypeSidebarHomeView.tsx
+++ b/spa/src/pages/prototype/PrototypeSidebarHomeView.tsx
@@ -185,6 +185,8 @@ export default function PrototypeSidebarHomeView({
   const {
     contentReady,
     homeViewClassName,
+    showLoader,
+    loaderLeaving,
     lead,
     recallTrendGreeting,
     continueNote,
@@ -218,12 +220,19 @@ export default function PrototypeSidebarHomeView({
     destinations: { proposeThread, openThread, createThread: onOpenCreateThreadPrefill },
   });
 
+  // Nothing at all for the first 150ms of a wait, so a warm remount does not flash dots at
+  // a reader who is looking straight at the content they already had.
+  // `useProtoSpaceLoaderState` owns that grace period, and the fade-out below.
   if (!contentReady) {
-    return <ProtoSpaceLoading label="Loading home" />;
+    return showLoader ? <ProtoSpaceLoading label="Loading home" /> : null;
   }
 
   return (
     <div className={homeViewClassName}>
+      {/* Still here for a beat, fading, while the dashboard paints underneath — so the two
+          states overlap instead of one replacing the other between frames. Out of flow, so
+          it costs the layout below it nothing. */}
+      {showLoader ? <ProtoSpaceLoading label="Loading home" leaving={loaderLeaving} /> : null}
       <div className="proto-home-section">
         <PrototypeHomeGreeting
           notes={notes}

--- a/spa/src/pages/prototype/PrototypeSpaceComingUp.tsx
+++ b/spa/src/pages/prototype/PrototypeSpaceComingUp.tsx
@@ -146,7 +146,7 @@ export default function PrototypeSpaceComingUp({ spaceId, enabled }: PrototypeSp
         {sermonEyebrow(gathering)}
         {rhythm ? ` · ${rhythm}` : ''}
       </p>
-      <div className="proto-glass-surface proto-glass-surface--panel proto-church-tools">
+      <div className="proto-glass-surface proto-glass-surface--panel proto-church-tools proto-home-cascade">
         <button
           type="button"
           className="proto-church-tools__row"

--- a/spa/src/pages/prototype/PrototypeSpaceHub.tsx
+++ b/spa/src/pages/prototype/PrototypeSpaceHub.tsx
@@ -63,7 +63,7 @@ import ProtoSpaceMenuIcon from './ProtoSpaceMenuIcon';
 import ProtoSpaceLoading from './ProtoSpaceLoading';
 import PrototypeHomeRow from './PrototypeHomeRow';
 import HomeSection from './PrototypeHomeSection';
-import { useProtoHomeViewClassName } from './useProtoHomeViewEnter';
+import { useProtoHomeViewClassName, useProtoSpaceLoaderState } from './useProtoHomeViewEnter';
 import {
   buildSharedSpaceNoteCardSlots,
   buildSharedSpaceSocialIntro,
@@ -576,6 +576,7 @@ function PrototypeSpaceHubLive() {
     groupThreadsSettled &&
     scriptureSettled;
   const homeViewClassName = useProtoHomeViewClassName(contentReady, activeSpaceId);
+  const { showLoader, loaderLeaving } = useProtoSpaceLoaderState(contentReady);
 
   /*
    * Into the Library panel, which is where a list lives now.
@@ -823,7 +824,9 @@ function PrototypeSpaceHubLive() {
   }
 
   if (!contentReady) {
-    return frame(<ProtoSpaceLoading label="Loading space" />);
+    // Withheld for the first 150ms so a warm remount shows nothing rather than a flash of
+    // dots. See useProtoSpaceLoaderState.
+    return frame(showLoader ? <ProtoSpaceLoading label="Loading space" /> : null);
   }
 
 
@@ -979,6 +982,9 @@ function PrototypeSpaceHubLive() {
 
       <div className="proto-sidebar-scroll">
         <div className={homeViewClassName}>
+          {/* Fading out over the dashboard arriving underneath, so the two states overlap
+              rather than swapping between frames. Out of flow; costs the layout nothing. */}
+          {showLoader ? <ProtoSpaceLoading label="Loading space" leaving={loaderLeaving} /> : null}
           {/*
             What this room is studying next. Staff-gated server-side, so it is
             only requested for someone who can already see the church's plans;
@@ -1094,7 +1100,7 @@ function PrototypeSpaceHubLive() {
                 <>
                   {/* Rows in one panel, not a pile of cards to expand. A list you can read
                       beats a stack you have to open. */}
-                  <div className="proto-glass-surface proto-glass-surface--panel proto-list-panel">
+                  <div className="proto-glass-surface proto-glass-surface--panel proto-list-panel proto-home-cascade">
                     {availableThreads.map((thread) => renderThreadRow(thread))}
                   </div>
                   {threadPinError ? (
@@ -1105,7 +1111,7 @@ function PrototypeSpaceHubLive() {
                 </>
               ) : threadStackItems.length > 0 ? (
                 <>
-                  <div className="proto-glass-surface proto-glass-surface--panel proto-list-panel">
+                  <div className="proto-glass-surface proto-glass-surface--panel proto-list-panel proto-home-cascade">
                     {threadStackItems.map((thread) => renderThreadRow(thread))}
                   </div>
                   {threadPinError ? (
@@ -1218,7 +1224,7 @@ function PrototypeSpaceHubLive() {
           {companionRows.length > 0 ? (
             <div className="proto-home-section">
               <p className="proto-caption proto-home-section__eyebrow">Paired with</p>
-              <ProtoToolsRowList rows={companionRows} />
+              <ProtoToolsRowList rows={companionRows} cascade />
             </div>
           ) : null}
 

--- a/spa/src/pages/prototype/proto-tools-registry.tsx
+++ b/spa/src/pages/prototype/proto-tools-registry.tsx
@@ -33,13 +33,27 @@ export type ProtoToolRow = {
 export function ProtoToolsRowList({
   rows,
   children,
+  cascade = false,
 }: {
   rows: ProtoToolRow[];
   /** Non-row card content — today the billing banner, silent when healthy. */
   children?: ReactNode;
+  /**
+   * Fade the rows in one after another as the panel arrives.
+   *
+   * Opt-in, and off by default, because this list is the shell's general row panel: it is
+   * also inside sheets that are already animating themselves, and inside note search, whose
+   * results are replaced on every keystroke and would re-run the cascade each time. The
+   * space dashboards ask for it; nothing that re-renders under the reader's hands does.
+   */
+  cascade?: boolean;
 }) {
   return (
-    <div className="proto-glass-surface proto-glass-surface--panel proto-church-tools">
+    <div
+      className={`proto-glass-surface proto-glass-surface--panel proto-church-tools${
+        cascade ? ' proto-home-cascade' : ''
+      }`}
+    >
       {rows.map((row) => (
         <button
           key={row.key}

--- a/spa/src/pages/prototype/use-home-surface-data.ts
+++ b/spa/src/pages/prototype/use-home-surface-data.ts
@@ -64,6 +64,7 @@ import type { PrototypeNotesListPhase } from '@/utils/prototype-notes-list-phase
 import {
   isPrototypeHomeContentReady,
   isPrototypeHomePresentationReady,
+  type PrototypeHomePresentationReadyInput,
   isQuerySettled,
 } from '@/utils/prototype-home-ready';
 import {
@@ -133,7 +134,8 @@ import { buildRecallCandidates } from './proto-recall-candidates';
 
 import { type RecallOpportunity } from './PrototypeRecallCarousel';
 
-import { useProtoHomeViewClassName } from './useProtoHomeViewEnter';
+import { useProtoHomeViewClassName, useProtoSpaceLoaderState } from './useProtoHomeViewEnter';
+import { useHomeSettleTrace } from './useHomeSettleTrace';
 
 /** Force Home to present even if an auxiliary query never settles. */
 const HOME_PRESENTATION_DEADLINE_MS = 2500;
@@ -360,7 +362,11 @@ export function useHomeSurfaceData({
   // each time one of ~9 independent queries landed — the visible jumping. Wait for them
   // all, then present once. isPrototypeHomeContentReady only ever read notesListPhase;
   // the other flags passed to it were silently dropped.
-  const presentationReady = isPrototypeHomePresentationReady({
+  // Annotated, not inferred. The gate's whole contract is that every flag it declares is
+  // actually passed: hoisting the literal into a variable would otherwise drop the
+  // excess-property check that catches a flag added here and never declared there — the
+  // exact mistake that let five queries sit outside the gate for months.
+  const presentationInput: PrototypeHomePresentationReadyInput = {
     notesReady: isPrototypeHomeContentReady(notesListPhase),
     clerkLoaded,
     fingerprintsSettled,
@@ -378,7 +384,8 @@ export function useHomeSurfaceData({
     churchFeedSettled,
     readingPositionSettled,
     studyBibleSettled,
-  });
+  };
+  const presentationReady = isPrototypeHomePresentationReady(presentationInput);
 
   // Backstop: a disabled query stays `isPending` forever in React Query v5, so without a
   // deadline one misconfigured auxiliary would strand Home on loading dots. Trading a
@@ -395,7 +402,10 @@ export function useHomeSurfaceData({
 
   const contentReady = presentationReady || presentationDeadlinePassed;
 
+  useHomeSettleTrace(presentationInput, contentReady, presentationReady);
+
   const homeViewClassName = useProtoHomeViewClassName(contentReady, homeSpaceId);
+  const { showLoader, loaderLeaving } = useProtoSpaceLoaderState(contentReady);
 
   const tags = tagsQuery.data?.tags ?? [];
   const threads = threadsQuery.data ?? [];
@@ -1463,6 +1473,8 @@ export function useHomeSurfaceData({
     /* Gate — the view decides what to paint while this is false. */
     contentReady,
     homeViewClassName,
+    showLoader,
+    loaderLeaving,
 
     /* Greeting. */
     lead,

--- a/spa/src/pages/prototype/useHomeSettleTrace.ts
+++ b/spa/src/pages/prototype/useHomeSettleTrace.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+import type { PrototypeHomePresentationReadyInput } from '@/utils/prototype-home-ready';
+
+/**
+ * DEV-only: how long Home waited, and what it was waiting on.
+ *
+ * Home presents once, when every query it renders from has settled, with a 2.5s deadline
+ * behind that as a backstop. Both halves fail quietly. If a flag never flips — a query
+ * disabled for this account, say — the gate never fires and every cold load silently pays
+ * the full deadline instead; the reader just sees dots for two and a half seconds and has
+ * no way to tell that from a slow network. That is exactly the bug this was written to
+ * find (`churchSermonsSettled`, which stayed false forever for anyone without a church).
+ *
+ * So the trace reports the number *and* the reason: `gate` means readiness fired, and
+ * `deadline` names the flags that were still false when the backstop gave up.
+ */
+export function useHomeSettleTrace(
+  input: PrototypeHomePresentationReadyInput,
+  contentReady: boolean,
+  presentationReady: boolean,
+): void {
+  // The clock starts when the view first mounts, which is the first frame the reader sees dots.
+  const startedAtRef = useRef<number | null>(null);
+  const reportedRef = useRef(false);
+  /** When each flag first went true, so the report can name the long pole rather than guess. */
+  const settledAtRef = useRef<Map<string, number>>(new Map());
+  // Read through a ref so the effect depends only on the two booleans: the input object is a
+  // fresh literal every render, and a dependency on it would re-run this every commit.
+  const inputRef = useRef(input);
+  inputRef.current = input;
+
+  if (import.meta.env.DEV && startedAtRef.current === null) {
+    startedAtRef.current = performance.now();
+  }
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    const now = performance.now();
+    for (const [flag, settled] of Object.entries(inputRef.current)) {
+      if (settled && !settledAtRef.current.has(flag)) settledAtRef.current.set(flag, now);
+    }
+  });
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    if (!contentReady || reportedRef.current) return;
+    reportedRef.current = true;
+
+    const startedAt = startedAtRef.current ?? performance.now();
+    const elapsed = Math.round(performance.now() - startedAt);
+    const unsettled = Object.entries(inputRef.current)
+      .filter(([, settled]) => !settled)
+      .map(([flag]) => flag);
+
+    const slowest = [...settledAtRef.current.entries()]
+      .map(([flag, at]) => `${flag} ${Math.round(at - startedAt)}ms`)
+      .slice(-4)
+      .join(', ');
+
+    if (presentationReady) {
+      console.info(`[home] settled via gate in ${elapsed}ms — last to land: ${slowest}`);
+    } else {
+      console.warn(
+        `[home] settled via DEADLINE in ${elapsed}ms — still waiting on: ${unsettled.join(', ') || '(none)'} — last to land: ${slowest}`,
+      );
+    }
+  }, [contentReady, presentationReady]);
+}

--- a/spa/src/pages/prototype/useProtoHomeViewEnter.ts
+++ b/spa/src/pages/prototype/useProtoHomeViewEnter.ts
@@ -1,11 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-
-/**
- * How long `--enter` stays on the view: the 0.42s section animation plus slack.
- * Sections no longer stagger, so this no longer has to cover a sequence — it
- * just has to outlast the one animation in `prototype-components.css`.
- */
-const ENTER_WINDOW_MS = 560;
+import { PROTO_HOME_ENTER_WINDOW_MS, PROTO_POPOVER_MOTION_MS } from '../../layouts/proto-motion';
+import { useSettledFlag } from '../../hooks/useSettledFlag';
 
 /** Distinguishes "never entered" from a genuine `undefined`/`null` replayKey. */
 const NO_KEY_YET = Symbol('no-key-yet');
@@ -30,9 +25,62 @@ export function useProtoHomeViewClassName(ready: boolean, replayKey?: string | n
     if (enteredForKeyRef.current === replayKey) return;
     enteredForKeyRef.current = replayKey;
     setEntering(true);
-    const id = window.setTimeout(() => setEntering(false), ENTER_WINDOW_MS);
+    const id = window.setTimeout(() => setEntering(false), PROTO_HOME_ENTER_WINDOW_MS);
     return () => window.clearTimeout(id);
   }, [ready, replayKey]);
 
   return entering ? 'proto-home-view proto-home-view--enter' : 'proto-home-view';
+}
+
+/**
+ * How long a wait has to last before it is worth admitting to.
+ *
+ * A dashboard that comes back from cache is ready within a frame or two, and putting the
+ * loading dots up for that long is worse than showing nothing: the reader sees a flicker
+ * where the content already was and reads it as the app losing its place. Long enough to
+ * cover a warm remount, short enough that a real wait still gets its indicator promptly.
+ */
+const LOADER_GRACE_MS = 150;
+
+export interface ProtoSpaceLoaderState {
+  /** Render the dots. False both before the grace period and after the fade-out. */
+  showLoader: boolean;
+  /** The dots are on their way out — content is ready and being handed the pane. */
+  loaderLeaving: boolean;
+}
+
+/**
+ * When a space dashboard should show its loading dots, and when it should let go of them.
+ *
+ * Two problems, one state machine, because they are the same moment seen from either side.
+ *
+ * Going in: `ProtoSpaceLoading` used to appear on the first frame `ready` was false, so
+ * every warm remount flashed dots for a few milliseconds. The grace period holds them back.
+ *
+ * Coming out: the dots used to be replaced by a full dashboard between one frame and the
+ * next — the hardest cut in the shell, and the reason the arrival read as a jolt however
+ * gently the content itself faded in. Keeping them mounted for a beat while they fade lets
+ * the two states overlap instead of swapping, so nothing on screen is ever simply gone.
+ *
+ * A wait that never showed dots skips the fade entirely: there is nothing to hand over.
+ */
+export function useProtoSpaceLoaderState(ready: boolean): ProtoSpaceLoaderState {
+  const graced = useSettledFlag(!ready, LOADER_GRACE_MS);
+  // Whether the dots were ever actually on screen for this wait, which decides if there is
+  // anything to fade. Read in an effect, never rendered from, so it cannot desync the pair.
+  const wasShownRef = useRef(false);
+  const [leaving, setLeaving] = useState(false);
+
+  if (!ready && graced) wasShownRef.current = true;
+
+  useEffect(() => {
+    if (!ready) return;
+    if (!wasShownRef.current) return;
+    wasShownRef.current = false;
+    setLeaving(true);
+    const id = window.setTimeout(() => setLeaving(false), PROTO_POPOVER_MOTION_MS);
+    return () => window.clearTimeout(id);
+  }, [ready]);
+
+  return { showLoader: (!ready && graced) || leaving, loaderLeaving: leaving };
 }

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -6898,6 +6898,29 @@ html.harvous-prototype-route .proto-list-empty-state h2.proto-list-empty-state__
   padding: 24px 14px 14px;
 }
 
+/*
+  The dots handing the pane over, rather than being cut away.
+
+  Out of flow for the length of the fade so the dashboard underneath takes its final height
+  immediately — left in flow, the block would hold its own 24px of padding open and the
+  content would drop by that much when it finally unmounted, which is a second settle for
+  the sake of a fade meant to prevent one. `pointer-events: none` because a mark that is
+  already leaving should not be able to swallow the first click on what replaced it.
+*/
+.proto-home-loading--leaving {
+  position: absolute;
+  inset-inline: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--pds-duration-popover) var(--pds-ease-standard);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .proto-home-loading--leaving {
+    transition: none;
+  }
+}
+
 @keyframes proto-home-section-in {
   from {
     opacity: 0;
@@ -6914,6 +6937,8 @@ html.harvous-prototype-route .proto-list-empty-state h2.proto-list-empty-state__
   flex-direction: column;
   gap: 10px;
   padding: 8px 14px 14px;
+  /* Anchors the loading dots while they fade out over the arriving dashboard. */
+  position: relative;
 }
 
 /* Same edge, same reason — see `.proto-home-greeting`. The 2px here was the other half of
@@ -6963,8 +6988,71 @@ html.harvous-prototype-route .proto-list-empty-state h2.proto-list-empty-state__
 
 .proto-home-view--enter .proto-home-section {
   opacity: 0;
-  animation: proto-home-section-in 0.42s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: proto-home-section-in var(--pds-duration-home-section) var(--pds-ease-emphasized) both;
 }
+
+/*
+  The rows inside a panel arrive in sequence rather than as one block.
+
+  This is the part that makes a dashboard read as filling in rather than being pasted on.
+  The section fade alone moves a rectangle; nothing inside it has any order, so eight rows
+  land on the same frame and the panel is simply there. A 28ms step is barely a delay per
+  row, but it gives the eye a direction to follow down the panel — and because the step is
+  so small the last of six rows is only 140ms behind the first, well inside the section's
+  own animation. The whole thing is still one arrival.
+
+  Not gated on `--enter`, deliberately, and this is the important difference from the
+  section rule above.
+
+  A rule that only applies while a class is present *restarts* when that class is added and
+  snaps when it is removed — which is exactly why per-section stagger had to be deleted: a
+  section mounting inside the enter window replayed the slide and shoved its siblings. An
+  unconditional rule cannot do that. Each row animates once, when it mounts, and never
+  again. That also buys the case the enter window was never able to cover: a card that
+  appears on its own later — the Continue card swapping after a note is written, a recall
+  card returning when a snooze lapses — arrives with the same short fade instead of popping
+  into an otherwise still panel.
+*/
+@keyframes proto-home-row-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/*
+  `proto-home-cascade` marks a container whose direct children are rows to cascade.
+
+  A named opt-in rather than a selector over the panel classes, because the three space
+  dashboards do not share one. Home builds its panels from `PrototypeHomeSection`, the space
+  hub hand-rolls `proto-list-panel` for its Thread rows, the church hub uses a plain `ul`,
+  and both of the latter reach for `ProtoToolsRowList` as well. Matching all of those by class
+  would have meant either a list that silently stops covering a panel someone adds later, or
+  `.proto-glass-surface--panel > *`, which is every panel in the shell — including
+  `proto-home-card`, whose children are a card's own icon and text rather than rows, and which
+  would have been staggered apart from the inside.
+*/
+.proto-home-cascade > * {
+  animation: proto-home-row-in var(--pds-duration-home-row) var(--pds-ease-emphasized) both;
+  animation-delay: calc(var(--proto-home-row-i, 0) * var(--pds-duration-home-row-step));
+}
+
+/* The cascade is an index, and CSS has no counter to read here, so the positions are
+   written out. Six is where it stops: past that the delay would be doing more than
+   pointing down the panel, and a long list would finish visibly after the section it
+   sits in. Everything from the seventh row on shares the sixth row's delay — which is
+   what keeps a church's Discover lane, or any list that can run long, from cascading
+   for a second and a half. */
+.proto-home-cascade > :nth-child(1) { --proto-home-row-i: 0; }
+.proto-home-cascade > :nth-child(2) { --proto-home-row-i: 1; }
+.proto-home-cascade > :nth-child(3) { --proto-home-row-i: 2; }
+.proto-home-cascade > :nth-child(4) { --proto-home-row-i: 3; }
+.proto-home-cascade > :nth-child(5) { --proto-home-row-i: 4; }
+.proto-home-cascade > :nth-child(n + 6) { --proto-home-row-i: 5; }
 
 /*
   No per-section stagger. The delays were keyed on `:nth-child`, so the last
@@ -6980,7 +7068,8 @@ html.harvous-prototype-route .proto-list-empty-state h2.proto-list-empty-state__
 */
 
 @media (prefers-reduced-motion: reduce) {
-  .proto-home-view--enter .proto-home-section {
+  .proto-home-view--enter .proto-home-section,
+  .proto-home-cascade > * {
     opacity: 1;
     animation: none;
     transform: none;

--- a/spa/src/styles/prototype-tokens.css
+++ b/spa/src/styles/prototype-tokens.css
@@ -491,6 +491,24 @@
      than a cut, and it is a collapse of a full pane so it does not go under ~200ms. Paired
      with PROTO_PAPER_STACK_EXIT_MS. */
   --pds-duration-paper-stack-exit: 200ms;
+  /*
+   * A space dashboard presenting itself — Home, a shared space, the church hub.
+   *
+   * Two durations, because two things arrive: the section is a block of the page settling
+   * into place, and the rows inside it are the contents of that block. The section is the
+   * longer of the pair on purpose — it is a larger object making a smaller move, and a row
+   * that outlasted its own container would still be arriving after the frame it arrives in
+   * had stopped.
+   *
+   * The step is what makes the panel read as filling rather than appearing. It is small
+   * deliberately: at 28ms a six-row panel finishes 140ms after it starts, which is inside
+   * the section's own animation, so the whole dashboard is still one arrival. Anything near
+   * 60ms and the last row is visibly a straggler — the failure the section stagger was
+   * removed for. Paired with PROTO_HOME_ENTER_WINDOW_MS, which has to outlast all three.
+   */
+  --pds-duration-home-section: 420ms;
+  --pds-duration-home-row: 320ms;
+  --pds-duration-home-row-step: 28ms;
   /* How much of the base paper stays visible above a stacked sheet — the edge you
      tap to go back. Enough for a line of caption with breathing room; tightened on
      phones where the toolbar already owns the top of the pane. */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1301,29 +1301,59 @@ button.translation-dropdown-trigger {
   height: 4px;
   border-radius: 50%;
   background-color: var(--color-stone-grey);
-  animation: load-more-pulse 1.4s ease-in-out infinite;
+  /* Falls back for pages that load this sheet without prototype-tokens.css on :root. */
+  animation: load-more-pulse 1.5s var(--pds-ease-standard, cubic-bezier(0.32, 0.72, 0.24, 1)) infinite;
 }
 
+/* A shorter step than the old 0.2s. The three dots are 4px apart, so a long gap reads as
+   three things blinking in turn rather than as one movement passing along them. */
 .load-more-indicator__dot:nth-child(1) {
   animation-delay: 0s;
 }
 
 .load-more-indicator__dot:nth-child(2) {
-  animation-delay: 0.2s;
+  animation-delay: 0.14s;
 }
 
 .load-more-indicator__dot:nth-child(3) {
-  animation-delay: 0.4s;
+  animation-delay: 0.28s;
 }
 
+/*
+  A wave that lifts along the row, rather than three dots throbbing.
+
+  The previous version scaled 0.8 → 1 against an opacity floor of 0.3, which at 4px is a
+  dot visibly changing size and most of the way to disappearing between beats — busy, and
+  slightly anxious, for a mark whose whole job is to say "still here" while someone waits.
+  This keeps the size fixed and moves it a single pixel, so what reads is the travel from
+  left to right and not the individual dots. The floor comes up to 0.4 so the row never
+  half-vanishes, and the cycle rests at the end: the long tail from 70% to 100% is what
+  makes it a pulse with a pause rather than a continuous shimmer.
+*/
 @keyframes load-more-pulse {
-  0%, 80%, 100% {
-    opacity: 0.3;
-    transform: scale(0.8);
+  0%, 70%, 100% {
+    opacity: 0.4;
+    transform: translateY(0);
   }
-  40% {
+  35% {
     opacity: 1;
-    transform: scale(1);
+    transform: translateY(-1px);
+  }
+}
+
+/*
+  Reduced motion gets a static row, not a slower one.
+
+  There was no guard here at all, so the one mark that is on screen for the entire length of
+  every wait — and repeats forever — was also the one piece of motion the setting could not
+  turn off. Held at the bright end so the dots still read as present rather than as three
+  disabled specks.
+*/
+@media (prefers-reduced-motion: reduce) {
+  .load-more-indicator__dot {
+    animation: none;
+    opacity: 0.75;
+    transform: none;
   }
 }
 


### PR DESCRIPTION
Targets `new`, not `main`. Companion to #59, which carries the server half against `main`'s API.

## Why

Home presents once, when every query it renders from has settled. That is deliberate and worth keeping — it is why the dashboard no longer jumps as late queries land. But it also meant the whole surface arrived on a single frame: correct, and completely inert. The space hub and church hub did the same.

## The cascade

Rows inside a panel now fade in on a 28ms step. Six rows finish 140ms apart, inside the section's own fade, so it is still *one* arrival rather than the straggler effect that got the per-section stagger deleted.

The rule is unconditional rather than keyed on `--enter`, and that difference is the point. A class-scoped rule restarts when the class is added and snaps when it is removed — precisely why the old stagger had to go. An unconditional rule cannot do that, and it covers what the enter window never could: a card appearing later on its own, like Continue swapping after a note is written, now arrives the same way instead of popping in.

**Why a named opt-in class rather than a selector.** The three dashboards share no panel class. Home builds its shelves from `PrototypeHomeSection`, the space hub hand-rolls `proto-list-panel` for its Thread rows, the church hub uses a plain `ul`, and both reach for `ProtoToolsRowList` as well. Matching them structurally would have meant `.proto-glass-surface--panel > *` — every panel in the shell, including `proto-home-card`, whose children are one card's icon and text rather than rows, and which would have been staggered apart from the inside.

So each panel asks for `proto-home-cascade` by name. `ProtoToolsRowList` takes it as a prop **defaulting to off**, because it also lives inside sheets that animate themselves, inside note search whose rows are replaced on every keystroke, and inside the space hub's own floating tools popover. The two lanes the hubs delegate whole sections to — channel pairing and Coming Up — render their own panels and opt in themselves.

## The dots

- A **150ms grace period**, so a warm remount shows nothing rather than a flicker where the content already was. Home settles in 19–36ms on a warm remount, comfortably inside it.
- Then **held a beat to fade** over the content painting underneath, out of flow so the fade costs no layout, instead of being cut away between frames.
- They **lift rather than throb**, and they answer `prefers-reduced-motion` — which they never did. The one mark on screen for the whole of every wait, repeating forever, was the one piece of motion the setting could not switch off.

## Server: the half `new` was missing

`new` already landed the chunked ranking for `getConnectSuggestions`, independently and with the same reasoning. What it did not have was the batching, so this adds only that:

- `getNotePassagesBatch` collapses twenty pairs of passage queries into one pair.
- The per-user candidate scan — which differs between candidates only by which single note it excludes — is hoisted to run once per request rather than once per candidate.

Chunking made those round trips concurrent; this removes them. Measured on `main`'s copy of the same code: **4189ms → 724–886ms**, byte-identical results. `new`'s own comments are kept.

## The budget raise is mostly not this branch

`perf:check` failed here, and it was going to fail on the next change of any size regardless of what that change was. The recorded budget carries a 2048-byte tolerance floor and `new` had grown into nearly all of it — index.css sat **two bytes** under the line before this branch touched anything.

Both assets, built from the same tree:

| asset | old budget | origin/new | here | new's drift | this branch |
|---|---|---|---|---|---|
| index.js | 751,816 | 753,459 | 753,848 | +1,643 | +389 |
| index.css | 139,453 | 141,499 | 141,735 | +2,046 | +236 |

83% of what the re-baseline absorbs predates this branch and had been coasting inside the tolerance rather than being recorded. This branch's own 625 bytes buys a motion keyframe, a cascade rule with six index positions, a dots fade, three duration tokens, and the grace-period hook plus a DEV-only settle trace whose bodies are eliminated in production.

## Guards

Timings are tokens paired with `PROTO_HOME_ENTER_WINDOW_MS`, held together by `proto-motion-home-enter.test.ts`. It has already earned its keep twice: it caught the enter window being computed as the *sum* of two concurrent animations rather than their max, and it caught this port pointing its cascade-coverage assertion at the pre-rename dashboard filenames.

The server tests assert the shape of the work rather than the answer, since the answer is unchanged; both were confirmed to fail against the unbatched implementation.

## Verification

Browser-verified against `new`'s shell on all three dashboards — Home's Continue/Following/Suggested shelves, the space hub, and the church hub — with the cascade captured mid-flight and no loader flash on warm return. The DEV trace confirms Home settling on its gate at ~1.9s rather than its 2.5s deadline.

Full suite 4992 passing, typecheck ratchet clean at 125 (identical to clean `origin/new`, so this adds none), `perf:check` passing after the re-baseline above.

## Still open

Cold settle is ~1.9s, and the trace shows *every* readiness flag landing in a 1.6–2.9s band rather than one straggler. That is the request fan-out, and no per-endpoint tuning moves it. The two levers are persisting the query cache so a reload paints from it, or splitting the single gate so a late carousel card can arrive alone — the second contradicts the documented single-settle invariant, so it is a product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)