### PR TITLE
Re-enable CSRF protection (observe mode)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -9,10 +9,15 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { requestId } from 'hono/request-id';
 import { clerkAuth } from './middleware/auth';
-// CSRF middleware disabled — Clerk session auth is the primary security layer.
-// Origin-based CSRF was causing false 403s in production (Netlify proxy headers).
-// Re-enable once root cause is identified via Netlify function logs.
-// import { csrfProtection } from './middleware/csrf';
+// CSRF re-enabled 2026-09-04, in OBSERVE mode. It was disabled from ~2025 after
+// false 403s caused by Netlify's proxy duplicating the Origin header — that proxy
+// is gone (the app now sits behind a Cloudflare Worker), and csrf.ts additionally
+// dedupes comma-joined header values now.
+//
+// It does NOT reject yet: set CSRF_ENFORCE=true on Fly to switch from logging to
+// 403s, once the observe logs show an empty or understood rejection set. Grep Fly
+// logs for `[csrf][observe]`.
+import { csrfProtection } from './middleware/csrf';
 
 // Routes
 import health from './routes/health';
@@ -67,7 +72,7 @@ const app = new Hono();
 // Global middleware
 app.use('/api/*', requestId());
 app.use('/api/*', cors());
-// app.use('/api/*', csrfProtection);  // Disabled — see import comment above
+app.use('/api/*', csrfProtection); // observe-only until CSRF_ENFORCE=true — see import comment
 app.use('/api/*', clerkAuth);
 
 // Default cache headers for GET responses — individual endpoints can override

--- a/server/middleware/csrf.ts
+++ b/server/middleware/csrf.ts
@@ -31,6 +31,11 @@ const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
 const DEFAULT_ORIGINS = [
   'https://app.harvous.com',
+  // NOTE: no Capacitor/iOS/Android app ships today — web + PWA only, and the PWA
+  // runs at app.harvous.com so it sends that origin. If a Capacitor build ever
+  // ships, add 'https://localhost' (androidScheme in capacitor.config.ts) and
+  // 'capacitor://localhost' (iOS default), or every mutation from it 403s. The
+  // first-party Swift app needs nothing: URLSession sends no Origin header.
   'https://new.harvous.com',
   'https://status.harvous.com',
   'https://harvous.com',
@@ -39,6 +44,30 @@ const DEFAULT_ORIGINS = [
   'http://localhost:4321',  // Astro dev
   'http://localhost:4322',  // SPA Vite dev
 ];
+
+/**
+ * Enforcement gate. Default is OBSERVE: the checks run and log what they *would*
+ * reject, but let the request through.
+ *
+ * This exists because this middleware was disabled from ~2025 to 2026 after false
+ * 403s in production, and nobody could prove what was being rejected. Turning it
+ * straight back on repeats that bet. Run in observe mode, read the logs, then set
+ * CSRF_ENFORCE=true on Fly once the rejection set is empty or understood.
+ */
+function isEnforcing(): boolean {
+  return process.env.CSRF_ENFORCE === 'true';
+}
+
+/**
+ * Proxies can duplicate a header into "value, value". Netlify did this and it is
+ * what broke CSRF originally — the Origin comparison saw the doubled string and
+ * never matched. getSelfOrigin() already splits Host and X-Forwarded-Proto; this
+ * applies the same rule to Origin and Referer, which it did not.
+ */
+function firstHeaderValue(v: string | undefined): string | undefined {
+  if (!v) return v;
+  return v.split(',')[0].trim();
+}
 
 /** Build the allowed origins set once at startup */
 let allowedOrigins: Set<string> | null = null;
@@ -101,8 +130,8 @@ export async function csrfProtection(c: Context, next: Next) {
     return next();
   }
 
-  const origin = c.req.header('Origin');
-  const referer = c.req.header('Referer');
+  const origin = firstHeaderValue(c.req.header('Origin'));
+  const referer = firstHeaderValue(c.req.header('Referer'));
 
   // If Origin header is present, validate it
   if (origin) {
@@ -110,7 +139,7 @@ export async function csrfProtection(c: Context, next: Next) {
     const selfOrigin = getSelfOrigin(c);
 
     if (!allowed.has(origin) && origin !== selfOrigin) {
-      console.warn('[csrf] Rejected origin:', {
+      console.warn(isEnforcing() ? '[csrf] Rejected origin:' : '[csrf][observe] WOULD reject origin:', {
         origin,
         selfOrigin,
         host: c.req.header('Host'),
@@ -119,6 +148,7 @@ export async function csrfProtection(c: Context, next: Next) {
         allowedCount: allowed.size,
         path: c.req.path,
       });
+      if (!isEnforcing()) return next();
       return c.json(
         { error: 'Forbidden: invalid origin', code: 'CSRF_REJECTED' },
         403
@@ -135,7 +165,7 @@ export async function csrfProtection(c: Context, next: Next) {
       const selfOrigin = getSelfOrigin(c);
 
       if (!allowed.has(refererOrigin) && refererOrigin !== selfOrigin) {
-        console.warn('[csrf] Rejected referer:', {
+        console.warn(isEnforcing() ? '[csrf] Rejected referer:' : '[csrf][observe] WOULD reject referer:', {
           refererOrigin,
           selfOrigin,
           host: c.req.header('Host'),
@@ -143,6 +173,7 @@ export async function csrfProtection(c: Context, next: Next) {
           xfp: c.req.header('X-Forwarded-Proto'),
           path: c.req.path,
         });
+        if (!isEnforcing()) return next();
         return c.json(
           { error: 'Forbidden: invalid referer', code: 'CSRF_REJECTED' },
           403
@@ -151,6 +182,8 @@ export async function csrfProtection(c: Context, next: Next) {
       return next();
     } catch {
       // Malformed referer URL — reject
+      console.warn('[csrf] Malformed referer:', { referer, path: c.req.path, enforcing: isEnforcing() });
+      if (!isEnforcing()) return next();
       return c.json(
         { error: 'Forbidden: malformed referer', code: 'CSRF_REJECTED' },
         403


### PR DESCRIPTION
CSRF has been disabled since ~2025. The cause was Netlify's proxy duplicating `Origin` into `"value, value"`, which the equality check never matched. **That proxy is gone** — the app is behind a Cloudflare Worker now — so the original trigger no longer exists.

**It is enabled but not rejecting.** Every check runs and logs what it *would* reject. Flip to enforcing with `fly secrets set CSRF_ENFORCE=true --app harvous` once the logs are clean. Grep Fly logs for `[csrf][observe]`.

Turning it straight back to enforcing would repeat the original bet — last time nobody could prove what was being rejected, and the control stayed off for over a year as a result.

### Two real defects fixed

- **`Origin`/`Referer` now go through `firstHeaderValue()`** — the same comma-split `getSelfOrigin()` already applied to `Host` and `X-Forwarded-Proto`, but *not* to the header the check actually compares. Without it, any proxy duplicating `Origin` reproduces the original outage.
- **Allowlist verified against what ships.** Web + PWA only, and the PWA runs at `app.harvous.com`, so all real origins were already covered. Capacitor origins deliberately left out with a note — if such a build ever ships it needs `https://localhost` + `capacitor://localhost` or every mutation 403s. The Swift app needs nothing (URLSession sends no `Origin`).

Webhooks, `/api/admin/*` crons and migrations stay exempt, so Clerk/Polar callbacks and scheduled jobs are unaffected in either mode.

### Note on timing

This is a **Fly deploy** (`server/**`), so merging restarts the API. In observe mode it cannot 403 anything, but it is still an API restart — worth choosing the moment if a launch is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)