### PR TITLE
One tap on Android, and add-to-home-screen steps that look like steps

### DIFF
--- a/public/scripts/service-worker-manager.js
+++ b/public/scripts/service-worker-manager.js
@@ -376,12 +376,65 @@
     }
   }
   
-  // Add to homescreen prompt handler
-  let deferredPrompt;
+  /*
+    Chrome's own install prompt, held for the app to fire.
+
+    `preventDefault()` is what suppresses Chrome's mini-infobar, and it stays:
+    the app asks at a moment it chose, from a card the reader is already
+    looking at. What was missing is the other half. The event used to be
+    assigned to a variable nothing read, so the prompt was cancelled and then
+    thrown away, and Android's one-tap install could never happen.
+
+    Captured here, in a script that runs before React mounts, because the event
+    fires early and only once per page load — a listener registered after
+    hydration would miss it.
+
+    The bridge is a global rather than an import because this file is a plain
+    script outside the bundle. `spa/src/lib/install-prompt.ts` is the reader.
+  */
+  let deferredPrompt = null;
+
+  const announceInstallAvailability = () => {
+    window.dispatchEvent(new CustomEvent('harvous:install-availability'));
+  };
+
+  window.__harvousInstallPrompt = {
+    get available() {
+      return deferredPrompt !== null;
+    },
+    /**
+     * Show Chrome's install dialog. Resolves 'accepted' | 'dismissed' |
+     * 'unavailable'. A captured prompt is single-use, so it is cleared before
+     * being fired — Chrome offers a fresh one on a later visit if the reader
+     * says no.
+     */
+    prompt: function () {
+      const event = deferredPrompt;
+      if (!event) return Promise.resolve('unavailable');
+      deferredPrompt = null;
+      announceInstallAvailability();
+      try {
+        event.prompt();
+      } catch (err) {
+        return Promise.resolve('unavailable');
+      }
+      return Promise.resolve(event.userChoice)
+        .then((choice) => (choice && choice.outcome === 'accepted' ? 'accepted' : 'dismissed'))
+        .catch(() => 'dismissed');
+    },
+  };
 
   window.addEventListener('beforeinstallprompt', (e) => {
     e.preventDefault();
     deferredPrompt = e;
+    announceInstallAvailability();
+  });
+
+  /* Installed by any route — Chrome's menu, another tab, the prompt above.
+     The held event is spent either way, and the card should stop offering. */
+  window.addEventListener('appinstalled', () => {
+    deferredPrompt = null;
+    announceInstallAvailability();
   });
 })();
 

--- a/spa/src/lib/__tests__/appearance-companion-image.test.ts
+++ b/spa/src/lib/__tests__/appearance-companion-image.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The picture a surface borrows from the reader's appearance.
+ *
+ * Three branches, and the one worth guarding is the middle: a reader who chose
+ * a colour has never seen an image preset, so the pairing has to come from the
+ * catalogue rather than from anything they stored. Per mode, because the light
+ * and dark halves are different files.
+ */
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  appearanceCompanionImage,
+  appearanceCompanionPresetId,
+} from '../appearance-companion-image';
+import {
+  IMAGE_PRESETS_DARK,
+  IMAGE_PRESETS_LIGHT,
+  PROTO_BG_DARK_KEY,
+  PROTO_BG_LIGHT_KEY,
+} from '../prototype-background';
+
+function chooseLight(bg: unknown): void {
+  localStorage.setItem(PROTO_BG_LIGHT_KEY, JSON.stringify(bg));
+}
+
+function chooseDark(bg: unknown): void {
+  localStorage.setItem(PROTO_BG_DARK_KEY, JSON.stringify(bg));
+}
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('appearanceCompanionPresetId', () => {
+  it('uses the very image the reader chose', () => {
+    chooseLight({ kind: 'image-preset', presetId: 'meadow' });
+    expect(appearanceCompanionPresetId('light')).toBe('meadow');
+
+    chooseDark({ kind: 'image-preset', presetId: 'flare' });
+    expect(appearanceCompanionPresetId('dark')).toBe('flare');
+  });
+
+  it('pairs a chosen colour with the catalogue image beside it, per mode', () => {
+    chooseLight({ kind: 'color', value: '#c9e3b8', presetId: 'mint' });
+    expect(appearanceCompanionPresetId('light')).toBe('meadow');
+
+    chooseDark({ kind: 'color', value: '#1e2e22', presetId: 'mint' });
+    expect(appearanceCompanionPresetId('dark')).toBe('depths');
+  });
+
+  it('falls back to the first image of the mode for Paper and for no choice', () => {
+    expect(appearanceCompanionPresetId('light')).toBe(IMAGE_PRESETS_LIGHT[0].id);
+    expect(appearanceCompanionPresetId('dark')).toBe(IMAGE_PRESETS_DARK[0].id);
+
+    // Paper carries no preset pairing of its own.
+    chooseLight({ kind: 'color', value: '#fcfbf7', presetId: 'paper' });
+    expect(appearanceCompanionPresetId('light')).toBe(IMAGE_PRESETS_LIGHT[0].id);
+  });
+
+  it('reads the mode it was asked about, not the one that happens to be active', () => {
+    chooseLight({ kind: 'image-preset', presetId: 'dawn' });
+    chooseDark({ kind: 'image-preset', presetId: 'twilight' });
+    expect(appearanceCompanionPresetId('light')).toBe('dawn');
+    expect(appearanceCompanionPresetId('dark')).toBe('twilight');
+  });
+});
+
+describe('appearanceCompanionImage', () => {
+  it('resolves to a file in the appearance catalogue, with a colour to hold the space', () => {
+    chooseLight({ kind: 'color', value: '#c2dcf8', presetId: 'sky' });
+    const companion = appearanceCompanionImage('light');
+    expect(companion?.presetId).toBe('breeze');
+    expect(companion?.url).toMatch(/\.webp$/);
+    expect(companion?.tint).toMatch(/^#/);
+  });
+
+  it('falls back to the neutral image when the stored preset has left the catalogue', () => {
+    /* The background parser drops an image preset it cannot find
+       (`parseProtoBg`), so a retired id reads here as "chose nothing" and takes
+       the same path Paper does. Worth pinning: the alternative — a stored id
+       reaching the DOM as a broken url — is a blank strip nobody can explain. */
+    chooseLight({ kind: 'image-preset', presetId: 'a-preset-that-was-retired' });
+    expect(appearanceCompanionImage('light')?.presetId).toBe(IMAGE_PRESETS_LIGHT[0].id);
+  });
+});

--- a/spa/src/lib/__tests__/install-prompt.test.ts
+++ b/spa/src/lib/__tests__/install-prompt.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The install prompt bridge.
+ *
+ * What these guard is the failure the feature shipped with for a year: the
+ * event captured, cancelled, and then dropped, so Chrome's mini-infobar was
+ * suppressed and nothing ever replaced it. A held prompt must be reachable,
+ * single-use, and gone the moment it is spent.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  INSTALL_AVAILABILITY_EVENT,
+  installPromptAvailable,
+  promptInstall,
+  subscribeInstallAvailability,
+} from '../install-prompt';
+
+type Bridge = {
+  readonly available: boolean;
+  prompt: () => Promise<'accepted' | 'dismissed' | 'unavailable'>;
+};
+
+function setBridge(bridge: Bridge | undefined): void {
+  (window as unknown as { __harvousInstallPrompt?: Bridge }).__harvousInstallPrompt = bridge;
+}
+
+afterEach(() => {
+  setBridge(undefined);
+});
+
+describe('install prompt bridge', () => {
+  it('reports nothing to install when the capture script never held one', () => {
+    // iOS, and every browser without the event. Not an error state.
+    setBridge(undefined);
+    expect(installPromptAvailable()).toBe(false);
+  });
+
+  it('resolves "unavailable" rather than throwing when asked with no prompt held', async () => {
+    setBridge(undefined);
+    await expect(promptInstall()).resolves.toBe('unavailable');
+  });
+
+  it('reports what the reader chose', async () => {
+    setBridge({ available: true, prompt: () => Promise.resolve('accepted') });
+    expect(installPromptAvailable()).toBe(true);
+    await expect(promptInstall()).resolves.toBe('accepted');
+
+    setBridge({ available: true, prompt: () => Promise.resolve('dismissed') });
+    await expect(promptInstall()).resolves.toBe('dismissed');
+  });
+
+  it('subscribes to availability changes and unsubscribes cleanly', () => {
+    const onChange = vi.fn();
+    const unsubscribe = subscribeInstallAvailability(onChange);
+
+    window.dispatchEvent(new CustomEvent(INSTALL_AVAILABILITY_EVENT));
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    window.dispatchEvent(new CustomEvent(INSTALL_AVAILABILITY_EVENT));
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('the capture script', () => {
+  const source = () =>
+    readFileSync(resolve(process.cwd(), 'public/scripts/service-worker-manager.js'), 'utf8');
+
+  it('still cancels the mini-infobar, and now keeps what it cancelled', () => {
+    const text = source();
+    expect(text).toContain('e.preventDefault()');
+    expect(text).toContain('window.__harvousInstallPrompt');
+    // The bug: assigned and never read. The bridge is what makes it readable.
+    expect(text).toContain('deferredPrompt = e');
+    expect(text).toContain('event.prompt()');
+  });
+
+  it('spends the held prompt before firing it, so it cannot be fired twice', () => {
+    const text = source();
+    const clearAt = text.indexOf('deferredPrompt = null;\n      announceInstallAvailability();');
+    const fireAt = text.indexOf('event.prompt()');
+    expect(clearAt).toBeGreaterThan(-1);
+    expect(fireAt).toBeGreaterThan(clearAt);
+  });
+
+  it('drops the prompt when the app is installed by any other route', () => {
+    expect(source()).toContain("window.addEventListener('appinstalled'");
+  });
+
+  it('announces every change, so a rendered surface is never stale', () => {
+    const text = source();
+    expect(text).toContain(`new CustomEvent('harvous:install-availability')`);
+    // Gained, spent, and installed elsewhere — three announcements.
+    expect(text.match(/announceInstallAvailability\(\)/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/spa/src/lib/appearance-companion-image.ts
+++ b/spa/src/lib/appearance-companion-image.ts
@@ -1,0 +1,91 @@
+/**
+ * The picture that goes with whatever the reader chose for their canvas.
+ *
+ * Chrome elsewhere in the app already pairs colour with imagery: a space cover
+ * picked as "sky" shows the sky photograph, because the appearance catalogue is
+ * ordered so every colour has an image beside it, per mode
+ * (`APPEARANCE_COLOR_TO_LIGHT_IMAGE_ID` and its dark twin). This applies the
+ * same pairing to a surface that has no cover of its own, so a sheet's header
+ * looks like it belongs to the reader's app rather than to the app in general.
+ *
+ * Three answers, in order:
+ *
+ *   - **They chose an image.** Use that exact image. It is their wallpaper; the
+ *     header is a sliver of the same thing, and it is already in cache.
+ *   - **They chose a colour.** Use the image the catalogue pairs with it.
+ *   - **They chose Paper, or have chosen nothing.** Use the first image of the
+ *     mode. Paper is a preference about the canvas they write on, not an
+ *     instruction to strip decoration from every sheet — and a header that is
+ *     blank for most people is not the feature this was asked to be.
+ */
+import {
+  IMAGE_PRESETS_DARK,
+  IMAGE_PRESETS_LIGHT,
+  imagePresetById,
+  imagePresetUrl,
+  readBackgroundForMode,
+} from './prototype-background';
+import {
+  APPEARANCE_COLOR_TO_DARK_IMAGE_ID,
+  APPEARANCE_COLOR_TO_LIGHT_IMAGE_ID,
+  appearanceAccentHexFromCoverBg,
+} from '@/utils/space-cover';
+
+export type AppearanceCompanionImage = {
+  presetId: string;
+  url: string;
+  /**
+   * The paired colour, for painting the strip while the file decodes.
+   *
+   * Worth carrying because the picture is only pre-cached in one of the three
+   * cases — when it *is* their wallpaper. For the other two a bare strip would
+   * sit empty for a beat, which reads as a bug rather than as loading.
+   */
+  tint: string | null;
+};
+
+/** Neutral fallback: first in the catalogue for the mode (breeze / cinder). */
+function defaultPresetIdForMode(mode: 'light' | 'dark'): string | null {
+  const catalogue = mode === 'dark' ? IMAGE_PRESETS_DARK : IMAGE_PRESETS_LIGHT;
+  return catalogue[0]?.id ?? null;
+}
+
+/** The appearance-paired image preset id for this mode, before it is resolved to a file. */
+export function appearanceCompanionPresetId(mode: 'light' | 'dark'): string | null {
+  const chosen = readBackgroundForMode(mode);
+
+  if (chosen?.kind === 'image-preset') return chosen.presetId;
+
+  if (chosen?.kind === 'color' && chosen.presetId) {
+    const paired =
+      mode === 'dark'
+        ? APPEARANCE_COLOR_TO_DARK_IMAGE_ID[chosen.presetId]
+        : APPEARANCE_COLOR_TO_LIGHT_IMAGE_ID[chosen.presetId];
+    if (paired) return paired;
+  }
+
+  return defaultPresetIdForMode(mode);
+}
+
+/**
+ * `{ presetId, url, tint }` for the image to show.
+ *
+ * Null only if the catalogue itself is empty. A *stored* preset that has since
+ * been retired never reaches here as one: `parseProtoBg` drops an image preset
+ * it cannot find, so that reader is treated as having chosen nothing and gets
+ * the neutral image, which is the outcome you would want anyway.
+ */
+export function appearanceCompanionImage(mode: 'light' | 'dark'): AppearanceCompanionImage | null {
+  const presetId = appearanceCompanionPresetId(mode);
+  if (!presetId) return null;
+  const preset = imagePresetById(presetId);
+  if (!preset) return null;
+  return {
+    presetId,
+    url: imagePresetUrl(preset),
+    /* Every image in the catalogue has a colour beside it, so this asks the
+       same map the space covers ask — through the image, not the reader's
+       choice, so the strip's holding colour matches the picture that lands. */
+    tint: appearanceAccentHexFromCoverBg({ kind: 'image-preset', presetId }, mode),
+  };
+}

--- a/spa/src/lib/install-prompt.ts
+++ b/spa/src/lib/install-prompt.ts
@@ -1,0 +1,70 @@
+/**
+ * Chrome's install prompt, as the app sees it.
+ *
+ * The event itself is captured in `public/scripts/service-worker-manager.js`,
+ * which runs before React mounts — `beforeinstallprompt` fires early and once
+ * per page load, so a listener registered during hydration would miss it. That
+ * script keeps the event and publishes this small bridge on `window`; this file
+ * is the only reader, and it exists so nothing else has to know the global's
+ * name or its shape.
+ *
+ * Availability is a real store rather than a boolean read once: the event can
+ * arrive after a surface has rendered, and it goes away the moment it is spent
+ * or the app is installed in another tab.
+ *
+ * Absent on iOS and on any browser that does not implement the event, where
+ * `available` stays false and the written instructions are the whole answer.
+ */
+import { useSyncExternalStore } from 'react';
+
+export type InstallOutcome = 'accepted' | 'dismissed' | 'unavailable';
+
+/** Fired by the capture script whenever a prompt is gained or spent. */
+export const INSTALL_AVAILABILITY_EVENT = 'harvous:install-availability';
+
+type InstallBridge = {
+  readonly available: boolean;
+  prompt: () => Promise<InstallOutcome>;
+};
+
+function bridge(): InstallBridge | null {
+  if (typeof window === 'undefined') return null;
+  return (
+    (window as unknown as { __harvousInstallPrompt?: InstallBridge }).__harvousInstallPrompt ?? null
+  );
+}
+
+export function subscribeInstallAvailability(onChange: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  window.addEventListener(INSTALL_AVAILABILITY_EVENT, onChange);
+  return () => window.removeEventListener(INSTALL_AVAILABILITY_EVENT, onChange);
+}
+
+export function installPromptAvailable(): boolean {
+  return bridge()?.available ?? false;
+}
+
+/**
+ * Show the dialog. Resolves what the reader chose, or 'unavailable' when there
+ * was no held prompt — which is the ordinary answer on iOS, not an error.
+ */
+export function promptInstall(): Promise<InstallOutcome> {
+  const held = bridge();
+  return held ? held.prompt() : Promise.resolve('unavailable');
+}
+
+/**
+ * `[canInstall, install]` for a surface that offers the one-tap path.
+ *
+ * Server snapshot is false: nothing can be installed before there is a window,
+ * and a card that renders "Install" and then swaps to "Learn how" on hydration
+ * would flicker.
+ */
+export function useInstallPrompt(): { canInstall: boolean; install: () => Promise<InstallOutcome> } {
+  const canInstall = useSyncExternalStore(
+    subscribeInstallAvailability,
+    installPromptAvailable,
+    () => false,
+  );
+  return { canInstall, install: promptInstall };
+}

--- a/spa/src/pages/prototype/PrototypeInstallWebAppCard.tsx
+++ b/spa/src/pages/prototype/PrototypeInstallWebAppCard.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useState } from 'react';
+import { lazy, Suspense, useCallback, useState } from 'react';
 import Icon from '@/components/react/Icon';
 import { isPWA } from '@/utils/content-list-helpers';
+import { useInstallPrompt } from '../../lib/install-prompt';
 import { getInstallPlatform } from '@/utils/platform-detect';
 import {
   PROTO_INSTALL_WEB_APP_DISMISSED_KEY,
@@ -8,13 +9,30 @@ import {
 } from '../../layouts/proto-session-keys';
 import { useProtoShell } from '../../layouts/proto-shell-context';
 import { useDismissibleFlag } from './useDismissibleFlag';
-import PrototypeInstallWebAppSheet from './PrototypeInstallWebAppSheet';
+/*
+  The card is on Home for every mobile session that has not dismissed it; the
+  sheet behind "Learn how" is opened by a fraction of them. Split, so the steps,
+  their glyphs and the brand marks are fetched on the tap that asks for them.
+*/
+const PrototypeInstallWebAppSheet = lazy(() => import('./PrototypeInstallWebAppSheet'));
 
 /** One-time mobile home card — Add to Home Screen until the user dismisses it. */
 export default function PrototypeInstallWebAppCard() {
   const { isMobileSidebar } = useProtoShell();
   const [sheetOpen, setSheetOpen] = useState(false);
+  /* Mounted from the first "Learn how" onward, not only while open: the sheet
+     animates itself out, and unmounting it the instant `open` flips false would
+     cut that exit off. Before the first tap it is not mounted at all, which is
+     the point of the split. */
+  const [sheetRequested, setSheetRequested] = useState(false);
   const [platform] = useState(() => getInstallPlatform());
+  /*
+    Chrome hands us its own install prompt on Android. When we are holding one,
+    the card asks for the install directly — the steps below exist because iOS
+    has no such thing, and making an Android reader read three of them when one
+    tap would do is the app declining a shortcut it was given.
+  */
+  const { canInstall, install } = useInstallPrompt();
   const [visible, dismissFlag] = useDismissibleFlag(PROTO_INSTALL_WEB_APP_DISMISSED_KEY, {
     previewKey: PROTO_INSTALL_WEB_APP_PREVIEW_KEY,
     eligible: isMobileSidebar && !isPWA(),
@@ -24,6 +42,16 @@ export default function PrototypeInstallWebAppCard() {
     setSheetOpen(false);
     dismissFlag();
   }, [dismissFlag]);
+
+  /* Accepted: the card has done its job and should not outlive the install.
+     Dismissed: the prompt is spent, `canInstall` flips false on its own, and
+     the card falls back to the written steps — Chrome offers a fresh prompt on
+     a later visit. */
+  const installNow = useCallback(() => {
+    void install().then((outcome) => {
+      if (outcome === 'accepted') dismissFlag();
+    });
+  }, [install, dismissFlag]);
 
   if (!visible) return null;
 
@@ -45,18 +73,45 @@ export default function PrototypeInstallWebAppCard() {
           for a more app-like experience
         </p>
 
+        {canInstall ? (
+          <button
+            type="button"
+            className="proto-share-popover__primary proto-install-web-app-card__install"
+            onClick={installNow}
+          >
+            Install
+          </button>
+        ) : null}
+
         <button
           type="button"
           className="proto-install-web-app-card__learn"
           aria-label="Learn how to add Harvous to your home screen"
-          onClick={() => setSheetOpen(true)}
+          onClick={() => {
+            setSheetRequested(true);
+            setSheetOpen(true);
+          }}
         >
-          Learn how
+          {/* Kept beside the one-tap path rather than replaced by it: a reader
+              who wants to know what the button is about to do still has a way
+              to look before they tap. */}
+          {canInstall ? 'What this does' : 'Learn how'}
           <Icon name="caret-right" size={10} aria-hidden />
         </button>
       </div>
 
-      <PrototypeInstallWebAppSheet open={sheetOpen} onClose={() => setSheetOpen(false)} platform={platform} />
+      {/* No fallback: the sheet paints its own card, and a placeholder would
+          flash where it is about to be. */}
+      {sheetRequested ? (
+        <Suspense fallback={null}>
+          <PrototypeInstallWebAppSheet
+            open={sheetOpen}
+            onClose={() => setSheetOpen(false)}
+            platform={platform}
+            onInstalled={dismissFlag}
+          />
+        </Suspense>
+      ) : null}
     </>
   );
 }

--- a/spa/src/pages/prototype/PrototypeInstallWebAppCard.tsx
+++ b/spa/src/pages/prototype/PrototypeInstallWebAppCard.tsx
@@ -47,6 +47,11 @@ export default function PrototypeInstallWebAppCard() {
      Dismissed: the prompt is spent, `canInstall` flips false on its own, and
      the card falls back to the written steps — Chrome offers a fresh prompt on
      a later visit. */
+  const openSheet = useCallback(() => {
+    setSheetRequested(true);
+    setSheetOpen(true);
+  }, []);
+
   const installNow = useCallback(() => {
     void install().then((outcome) => {
       if (outcome === 'accepted') dismissFlag();
@@ -62,6 +67,29 @@ export default function PrototypeInstallWebAppCard() {
         role="region"
         aria-label="Add Harvous to your home screen for a more app-like experience"
       >
+        {/*
+          The card's own tap, as a layer under its contents rather than a
+          wrapper around them: the card holds three real controls, and a button
+          containing buttons is invalid markup that browsers resolve by dropping
+          one of them.
+
+          Hidden from assistive tech and skipped by the keyboard on purpose. It
+          repeats what "Learn how" below already does, and a screen reader
+          meeting the same action twice — once unlabelled — is worse served than
+          by the one labelled control it can reach.
+
+          It opens the explainer rather than installing, even where the one-tap
+          path exists: a stray tap on a large card should not put a system
+          dialog on the screen. Installing stays with the button that says so.
+        */}
+        <button
+          type="button"
+          className="proto-install-web-app-card__surface-tap"
+          aria-hidden
+          tabIndex={-1}
+          onClick={openSheet}
+        />
+
         <button type="button" className="proto-daily-passage-pill__dismiss" aria-label="Dismiss" onClick={dismiss}>
           <Icon name="xmark" size={10} aria-hidden />
           <span>Dismiss</span>
@@ -87,10 +115,7 @@ export default function PrototypeInstallWebAppCard() {
           type="button"
           className="proto-install-web-app-card__learn"
           aria-label="Learn how to add Harvous to your home screen"
-          onClick={() => {
-            setSheetRequested(true);
-            setSheetOpen(true);
-          }}
+          onClick={openSheet}
         >
           {/* Kept beside the one-tap path rather than replaced by it: a reader
               who wants to know what the button is about to do still has a way

--- a/spa/src/pages/prototype/PrototypeInstallWebAppSheet.tsx
+++ b/spa/src/pages/prototype/PrototypeInstallWebAppSheet.tsx
@@ -1,62 +1,238 @@
-import { useEffect, type ReactNode } from 'react';
+/**
+ * How to put Harvous on a phone's home screen.
+ *
+ * Two things a reader needs that plain prose was not giving them: which
+ * platform these steps are for, and what the thing they are meant to tap looks
+ * like. So the platform is a segmented control rather than two stacked
+ * headings, and every step carries the glyph of the control it names — the
+ * share square, the three-dot menu — beside a numbered marker.
+ *
+ * **The browser line is the one that saves people.** On iOS only Safari can add
+ * to the home screen; a reader following these steps in Chrome finds no such
+ * menu item and concludes the app is broken. That is said under the toggle,
+ * before the steps, rather than left to be discovered at step two.
+ *
+ * The detected platform preselects the toggle, and both halves are always
+ * offered: detection is a guess (a desktop preview, an iPad reporting as a Mac,
+ * someone reading their partner's phone), and being wrong should cost a tap
+ * rather than hiding the steps that apply.
+ */
+import { useEffect, useState, useSyncExternalStore, type CSSProperties } from 'react';
 import { createPortal } from 'react-dom';
 import Icon from '@/components/react/Icon';
+import { safeRenderHtml } from '@/utils/content-renderer';
+import { useInstallPrompt } from '../../lib/install-prompt';
+import { appearanceCompanionImage } from '../../lib/appearance-companion-image';
+import { getColorSchemeSnapshot, subscribeColorScheme } from '../../lib/prototype-background';
 import type { InstallPlatform } from '@/utils/platform-detect';
 import { useProtoOverlayMotion } from '../../hooks/useProtoOverlayMotion';
+/*
+  Five marks that live here rather than in the shared `Icon` registry.
+  That registry inlines every SVG it knows into the initial bundle, and these
+  are used on exactly one surface — a sheet most sessions never open. Held
+  locally, they ride this file's chunk instead of charging sign-in for the
+  Safari logo. Font Awesome Free ships the brand marks under CC BY 4.0.
+*/
+import appleSvg from '@fortawesome/fontawesome-free/svgs/brands/apple.svg?raw';
+import androidSvg from '@fortawesome/fontawesome-free/svgs/brands/android.svg?raw';
+import safariSvg from '@fortawesome/fontawesome-free/svgs/brands/safari.svg?raw';
+import chromeSvg from '@fortawesome/fontawesome-free/svgs/brands/chrome.svg?raw';
+/* iOS's Share control: a box with an arrow leaving it, which is the shape a
+   reader is hunting for in Safari's bottom bar — not FA's `share` swoosh. */
+import shareIosSvg from '@fortawesome/fontawesome-free/svgs/solid/arrow-up-from-bracket.svg?raw';
+
+const LOCAL_GLYPHS = {
+  apple: appleSvg,
+  android: androidSvg,
+  safari: safariSvg,
+  chrome: chromeSvg,
+  'share-ios': shareIosSvg,
+} as const;
+
+type LocalGlyphName = keyof typeof LOCAL_GLYPHS;
+
+/* One stable `{ __html }` per name+size, for the reason the shared Icon keeps
+   one: React re-applies innerHTML whenever the object identity changes. */
+const glyphMarkup = new Map<string, { __html: string }>();
+
+function glyphHtml(name: LocalGlyphName, size: number): { __html: string } {
+  const key = `${name}|${size}`;
+  let markup = glyphMarkup.get(key);
+  if (!markup) {
+    const sized = LOCAL_GLYPHS[name]
+      .replace(/<svg\s+/, `<svg fill="currentColor" width="${size}" height="${size}" style="display:block" `);
+    markup = { __html: safeRenderHtml(sized) };
+    glyphMarkup.set(key, markup);
+  }
+  return markup;
+}
+
+function BrandGlyph({ name, size = 16 }: { name: LocalGlyphName; size?: number }) {
+  return (
+    <span
+      aria-hidden
+      style={{ display: 'inline-flex', width: size, height: size, color: 'inherit' }}
+      dangerouslySetInnerHTML={glyphHtml(name, size)}
+    />
+  );
+}
 
 type Props = {
   open: boolean;
   onClose: () => void;
   platform: InstallPlatform;
+  /** Called when Chrome reports the install was accepted, so the card can go. */
+  onInstalled?: () => void;
 };
 
-function InstallStepsList({ children }: { children: ReactNode }) {
-  return <ol className="proto-install-web-app-sheet__steps">{children}</ol>;
-}
+/** The two platforms with steps. `other` picks a side rather than showing none. */
+type StepPlatform = 'ios' | 'android';
 
-function IosSteps() {
+type StepGlyph =
+  | { kind: 'icon'; name: 'plus' | 'check' | 'ellipsis-vertical' }
+  | { kind: 'local'; name: LocalGlyphName };
+
+type InstallStep = {
+  /** What to do, with the control's own name in bold where there is one. */
+  text: React.ReactNode;
+  /** The glyph of the thing being tapped; omitted when a step names no control. */
+  glyph?: StepGlyph;
+};
+
+const PLATFORMS: Array<{
+  value: StepPlatform;
+  label: string;
+  icon: LocalGlyphName;
+  browser: { name: string; icon: LocalGlyphName; note: string };
+  steps: InstallStep[];
+}> = [
+  {
+    value: 'ios',
+    label: 'iPhone',
+    icon: 'apple',
+    browser: {
+      name: 'Safari',
+      icon: 'safari',
+      /* Said because the steps below are Safari's. Chrome, Firefox and Edge
+         on iOS can install too — that has been true since iOS 16.4 — but each
+         puts the item somewhere else, so naming the browser the steps describe
+         is the honest version of this warning. Claiming they cannot would be
+         wrong, and wrong in a way a reader can catch. */
+      note: 'Other browsers can do this too, but the menu sits somewhere else.',
+    },
+    steps: [
+      { text: <>Tap <strong>Share</strong> in the bottom bar</>, glyph: { kind: 'local', name: 'share-ios' } },
+      { text: <>Scroll down and tap <strong>Add to Home Screen</strong></>, glyph: { kind: 'icon', name: 'plus' } },
+      { text: <>Tap <strong>Add</strong></>, glyph: { kind: 'icon', name: 'check' } },
+    ],
+  },
+  {
+    value: 'android',
+    label: 'Android',
+    icon: 'android',
+    browser: {
+      name: 'Chrome',
+      icon: 'chrome',
+      note: 'Other browsers may word this differently.',
+    },
+    steps: [
+      { text: <>Tap the menu in the top corner</>, glyph: { kind: 'icon', name: 'ellipsis-vertical' } },
+      { text: <>Tap <strong>Install app</strong> or <strong>Add to Home Screen</strong></>, glyph: { kind: 'icon', name: 'plus' } },
+      /* Which label the confirm carries depends on the Chrome version and
+         which of the two menu items was tapped, so the step names both rather
+         than betting on one. */
+      { text: <>Confirm with <strong>Install</strong> or <strong>Add</strong></>, glyph: { kind: 'icon', name: 'check' } },
+    ],
+  },
+];
+
+/**
+ * A sliver of the reader's own appearance above the title.
+ *
+ * The same picture their canvas is wearing, or the one the catalogue pairs with
+ * the colour they chose — see `appearance-companion-image`. A band above the
+ * header rather than a wash behind it, which is how a room wears its cover, and
+ * the reason is contrast: over the title the picture would have to be faded to
+ * about a third before `--pds-text-primary` was safe on the busiest frame in
+ * the catalogue, and a third of a photograph is a smudge. Given its own strip
+ * it can be itself, and the title keeps the contrast it always had.
+ *
+ * Held back until the file has decoded, the way the space hero is: the paired
+ * image is already cached when it is their wallpaper, and worth one frame of
+ * patience when it is not.
+ */
+function HeaderSliver() {
+  const mode = useSyncExternalStore(
+    subscribeColorScheme,
+    getColorSchemeSnapshot,
+    () => 'light' as const,
+  );
+  const companion = appearanceCompanionImage(mode);
+  const url = companion?.url ?? null;
+  const [readyUrl, setReadyUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!url) {
+      setReadyUrl(null);
+      return undefined;
+    }
+    let cancelled = false;
+    setReadyUrl(null);
+    /* A plain decode rather than the auth-hero preloader: that module downloads
+       its own nine wallpapers the moment it is imported, which is a fair price
+       on the sign-in screen and an absurd one for a 62px strip. A failed load
+       still reveals it — the browser paints what it can, and a blank strip is
+       the worse of the two outcomes. */
+    const img = new Image();
+    const reveal = () => {
+      if (!cancelled) setReadyUrl(url);
+    };
+    img.onload = reveal;
+    img.onerror = reveal;
+    img.src = url;
+    return () => {
+      cancelled = true;
+      img.onload = null;
+      img.onerror = null;
+    };
+  }, [url]);
+
+  if (!url) return null;
+
+  /* The colour lands immediately and the picture crossfades over it, so the
+     strip is never an empty gap above the title. */
   return (
-    <InstallStepsList>
-      <li>
-        Tap the <strong>Share</strong> icon (square with arrow)
-      </li>
-      <li>
-        Scroll down and tap <strong>Add to Home Screen</strong>
-      </li>
-      <li>
-        Tap <strong>Add</strong>
-      </li>
-    </InstallStepsList>
+    <span
+      aria-hidden
+      className="proto-install-web-app-sheet__sliver"
+      style={companion?.tint ? { backgroundColor: companion.tint } : undefined}
+    >
+      <span
+        className={`proto-install-web-app-sheet__sliver-image${
+          readyUrl === url ? ' proto-install-web-app-sheet__sliver-image--ready' : ''
+        }`}
+        style={{ backgroundImage: `url("${url}")` }}
+      />
+    </span>
   );
 }
 
-function AndroidSteps() {
-  return (
-    <InstallStepsList>
-      <li>
-        Tap the menu (<strong>⋮</strong>) in the top corner
-      </li>
-      <li>
-        Tap <strong>Install app</strong> or <strong>Add to Home Screen</strong>
-      </li>
-    </InstallStepsList>
-  );
+/** iOS when nothing was detected — the larger half of the audience this card is shown to. */
+function initialPlatform(platform: InstallPlatform): StepPlatform {
+  return platform === 'android' ? 'android' : 'ios';
 }
 
-function sheetTitle(platform: InstallPlatform): string {
-  if (platform === 'ios') return 'Add Harvous on iPhone';
-  if (platform === 'android') return 'Add Harvous on Android';
-  return 'Add Harvous to your home screen';
-}
-
-function sheetEyebrow(platform: InstallPlatform): string {
-  if (platform === 'ios') return 'iPhone & iPad';
-  if (platform === 'android') return 'Android';
-  return 'Mobile browser';
-}
-
-export default function PrototypeInstallWebAppSheet({ open, onClose, platform }: Props) {
+export default function PrototypeInstallWebAppSheet({ open, onClose, platform, onInstalled }: Props) {
   const { mounted, exiting } = useProtoOverlayMotion(open);
+  const { canInstall, install } = useInstallPrompt();
+  const [selected, setSelected] = useState<StepPlatform>(() => initialPlatform(platform));
+
+  /* Re-armed on each opening rather than only on mount: the sheet stays mounted
+     between visits, so without this a reader who looked at the other platform
+     once would keep landing there. */
+  useEffect(() => {
+    if (open) setSelected(initialPlatform(platform));
+  }, [open, platform]);
 
   useEffect(() => {
     if (!open) return undefined;
@@ -68,6 +244,9 @@ export default function PrototypeInstallWebAppSheet({ open, onClose, platform }:
   }, [open, onClose]);
 
   if (!mounted || typeof document === 'undefined') return null;
+
+  const activeIndex = PLATFORMS.findIndex((p) => p.value === selected);
+  const active = PLATFORMS[activeIndex] ?? PLATFORMS[0];
 
   return createPortal(
     <div
@@ -91,13 +270,17 @@ export default function PrototypeInstallWebAppSheet({ open, onClose, platform }:
           .filter(Boolean)
           .join(' ')}
         role="dialog"
-        aria-label={sheetTitle(platform)}
+        aria-label="Add Harvous to your home screen"
         onClick={(e) => e.stopPropagation()}
       >
-        <header className="proto-votd-sheet__header">
+        <HeaderSliver />
+
+        <header className="proto-votd-sheet__header proto-install-web-app-sheet__header">
           <div className="proto-votd-sheet__header-text">
-            <p className="proto-caption proto-votd-sheet__eyebrow">{sheetEyebrow(platform)}</p>
-            <h2 className="proto-votd-sheet__reference">{sheetTitle(platform)}</h2>
+            {/* What this costs, not what device you are holding — the toggle
+                below already says that, and the old eyebrow said it twice. */}
+            <p className="proto-caption proto-votd-sheet__eyebrow">One-time setup</p>
+            <h2 className="proto-votd-sheet__reference">Add Harvous to your home screen</h2>
           </div>
           <button
             type="button"
@@ -112,20 +295,103 @@ export default function PrototypeInstallWebAppSheet({ open, onClose, platform }:
         <div className="proto-votd-sheet__divider" aria-hidden />
 
         <div className="proto-votd-sheet__body proto-install-web-app-sheet__body">
-          {platform === 'ios' ? <IosSteps /> : null}
-          {platform === 'android' ? <AndroidSteps /> : null}
-          {platform === 'other' ? (
-            <>
-              <p className="proto-migration-sheet__text">
-                <strong>iPhone (Safari)</strong>
+          {/*
+            Where Chrome has handed us a prompt, the button is the answer and
+            the steps below it are the fallback — so it goes first, and the
+            steps get a heading that says what they are for. On iOS there is no
+            prompt to hold, and this whole block is absent.
+          */}
+          {canInstall ? (
+            <div className="proto-install-web-app-sheet__oneTap">
+              <button
+                type="button"
+                className="proto-share-popover__primary"
+                onClick={() => {
+                  void install().then((outcome) => {
+                    if (outcome === 'accepted') {
+                      onInstalled?.();
+                      onClose();
+                    }
+                  });
+                }}
+              >
+                Install Harvous
+              </button>
+              <p className="proto-install-web-app-sheet__outcome">
+                Your browser can add it for you. The steps below are the same
+                thing by hand.
               </p>
-              <IosSteps />
-              <p className="proto-migration-sheet__text">
-                <strong>Android (Chrome)</strong>
-              </p>
-              <AndroidSteps />
-            </>
+            </div>
           ) : null}
+
+          <div
+            className="proto-install-seg proto-seg-track"
+            role="radiogroup"
+            aria-label="Which phone"
+            style={
+              {
+                '--proto-seg-count': PLATFORMS.length,
+                '--proto-seg-index': Math.max(activeIndex, 0),
+              } as CSSProperties
+            }
+          >
+            {PLATFORMS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                role="radio"
+                aria-checked={option.value === selected}
+                data-active={option.value === selected}
+                className="proto-install-seg__btn"
+                onClick={() => setSelected(option.value)}
+              >
+                <BrandGlyph name={option.icon} size={14} />
+                <span>{option.label}</span>
+              </button>
+            ))}
+          </div>
+
+          <p className="proto-install-web-app-sheet__browser">
+            <span className="proto-install-web-app-sheet__browser-icon" aria-hidden>
+              <BrandGlyph name={active.browser.icon} size={16} />
+            </span>
+            <span className="proto-install-web-app-sheet__browser-text">
+              <strong>In {active.browser.name}.</strong> {active.browser.note}
+            </span>
+          </p>
+
+          <ol className="proto-install-web-app-sheet__steps">
+            {active.steps.map((step, i) => (
+              /* Keyed by platform and position: the two lists are different
+                 content in the same slots, and a shared key would let one
+                 platform's row animate into the other's. */
+              <li key={`${active.value}-${i}`} className="proto-install-step">
+                <span className="proto-install-step__marker" aria-hidden>
+                  {i + 1}
+                </span>
+                <span className="proto-install-step__text">{step.text}</span>
+                {step.glyph ? (
+                  <span className="proto-install-step__glyph" aria-hidden>
+                    {step.glyph.kind === 'icon' ? (
+                      <Icon name={step.glyph.name} size={14} />
+                    ) : (
+                      <BrandGlyph name={step.glyph.name} size={14} />
+                    )}
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ol>
+
+          {/* What installing actually changes, and only that. Offline used to be
+              claimed here, which reads as something you get by installing —
+              the service worker gives it either way, so the sentence was
+              selling a benefit the reader already had. `standalone` in the
+              manifest is what makes the window promise true. */}
+          <p className="proto-install-web-app-sheet__outcome">
+            Harvous then opens from your home screen in its own window, with no
+            browser bar around it.
+          </p>
         </div>
       </div>
     </div>,

--- a/spa/src/pages/prototype/PrototypeInstallWebAppSheet.tsx
+++ b/spa/src/pages/prototype/PrototypeInstallWebAppSheet.tsx
@@ -273,6 +273,19 @@ export default function PrototypeInstallWebAppSheet({ open, onClose, platform, o
         aria-label="Add Harvous to your home screen"
         onClick={(e) => e.stopPropagation()}
       >
+        {/* Over the picture in the corner, the way a room's cover carries its
+            own controls — and first in the DOM, so the way out is the first
+            thing a screen reader reaches. Out of the header's flex row, which
+            gives the title back the width the button was holding. */}
+        <button
+          type="button"
+          className="proto-toolbar-icon-btn proto-install-web-app-sheet__close"
+          aria-label="Close"
+          onClick={onClose}
+        >
+          <Icon name="xmark" size={18} />
+        </button>
+
         <HeaderSliver />
 
         <header className="proto-votd-sheet__header proto-install-web-app-sheet__header">
@@ -282,14 +295,6 @@ export default function PrototypeInstallWebAppSheet({ open, onClose, platform, o
             <p className="proto-caption proto-votd-sheet__eyebrow">One-time setup</p>
             <h2 className="proto-votd-sheet__reference">Add Harvous to your home screen</h2>
           </div>
-          <button
-            type="button"
-            className="proto-toolbar-icon-btn proto-votd-sheet__close"
-            aria-label="Close"
-            onClick={onClose}
-          >
-            <Icon name="xmark" size={22} />
-          </button>
         </header>
 
         <div className="proto-votd-sheet__divider" aria-hidden />

--- a/spa/src/pages/prototype/PrototypeInstallWebAppSheet.tsx
+++ b/spa/src/pages/prototype/PrototypeInstallWebAppSheet.tsx
@@ -35,8 +35,6 @@ import { useProtoOverlayMotion } from '../../hooks/useProtoOverlayMotion';
 */
 import appleSvg from '@fortawesome/fontawesome-free/svgs/brands/apple.svg?raw';
 import androidSvg from '@fortawesome/fontawesome-free/svgs/brands/android.svg?raw';
-import safariSvg from '@fortawesome/fontawesome-free/svgs/brands/safari.svg?raw';
-import chromeSvg from '@fortawesome/fontawesome-free/svgs/brands/chrome.svg?raw';
 /* iOS's Share control: a box with an arrow leaving it, which is the shape a
    reader is hunting for in Safari's bottom bar — not FA's `share` swoosh. */
 import shareIosSvg from '@fortawesome/fontawesome-free/svgs/solid/arrow-up-from-bracket.svg?raw';
@@ -44,8 +42,6 @@ import shareIosSvg from '@fortawesome/fontawesome-free/svgs/solid/arrow-up-from-
 const LOCAL_GLYPHS = {
   apple: appleSvg,
   android: androidSvg,
-  safari: safariSvg,
-  chrome: chromeSvg,
   'share-ios': shareIosSvg,
 } as const;
 
@@ -77,6 +73,52 @@ function BrandGlyph({ name, size = 16 }: { name: LocalGlyphName; size?: number }
   );
 }
 
+/**
+ * The browser, as its icon appears on the reader's own device.
+ *
+ * Drawn here rather than taken from the icon set, because the set's brand marks
+ * are single-colour silhouettes: a flat grey disc says "a browser" where the
+ * reader is looking for the *thing on their home screen*. Both are the marks
+ * they are about to tap — Safari's blue compass, Chrome's four-colour wheel —
+ * sitting on the rounded white tile the platform draws under them.
+ *
+ * Small enough to be a label, not an advertisement: this appears once, at 24px,
+ * beside the sentence naming which browser the steps below belong to.
+ */
+function BrowserAppIcon({ browser }: { browser: 'safari' | 'chrome' }) {
+  if (browser === 'safari') {
+    return (
+      <svg viewBox="0 0 24 24" width="20" height="20" role="img" aria-hidden focusable="false">
+        <defs>
+          {/* Lighter at the top, as the icon is on the device. */}
+          <linearGradient id="harvous-safari-face" x1="12" y1="1" x2="12" y2="23" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stopColor="#19B9FF" />
+            <stop offset="1" stopColor="#0A6FE0" />
+          </linearGradient>
+        </defs>
+        <circle cx="12" cy="12" r="11" fill="url(#harvous-safari-face)" />
+        <circle cx="12" cy="12" r="9.1" fill="none" stroke="#ffffff" strokeWidth="0.9" opacity="0.85" />
+        {/* The needle: red to the north-east, white to the south-west, widest
+            where the two halves meet. */}
+        <path d="M17.7 6.3 13.7 13.7 10.3 10.3Z" fill="#FF4133" />
+        <path d="M6.3 17.7 10.3 10.3 13.7 13.7Z" fill="#ffffff" />
+      </svg>
+    );
+  }
+
+  /* Three 120° sectors around the centre, then the white ring and the blue
+     hub — the wheel's actual construction, so it reads correctly at 20px. */
+  return (
+    <svg viewBox="0 0 24 24" width="20" height="20" role="img" aria-hidden focusable="false">
+      <path d="M1.61 6A12 12 0 0 1 22.39 6L12 12Z" fill="#EA4335" />
+      <path d="M22.39 6A12 12 0 0 1 12 24L12 12Z" fill="#FBBC05" />
+      <path d="M12 24A12 12 0 0 1 1.61 6L12 12Z" fill="#34A853" />
+      <circle cx="12" cy="12" r="6.4" fill="#ffffff" />
+      <circle cx="12" cy="12" r="5.1" fill="#4285F4" />
+    </svg>
+  );
+}
+
 type Props = {
   open: boolean;
   onClose: () => void;
@@ -103,7 +145,7 @@ const PLATFORMS: Array<{
   value: StepPlatform;
   label: string;
   icon: LocalGlyphName;
-  browser: { name: string; icon: LocalGlyphName; note: string };
+  browser: { name: string; icon: 'safari' | 'chrome'; note: string };
   steps: InstallStep[];
 }> = [
   {
@@ -358,7 +400,7 @@ export default function PrototypeInstallWebAppSheet({ open, onClose, platform, o
 
           <p className="proto-install-web-app-sheet__browser">
             <span className="proto-install-web-app-sheet__browser-icon" aria-hidden>
-              <BrandGlyph name={active.browser.icon} size={16} />
+              <BrowserAppIcon browser={active.browser.icon} />
             </span>
             <span className="proto-install-web-app-sheet__browser-text">
               <strong>In {active.browser.name}.</strong> {active.browser.note}

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -7417,6 +7417,19 @@ button.proto-home-card--tappable:focus-visible {
   padding-top: 6px;
 }
 
+/* The way out, in the picture's corner.
+   Absolute against the sheet — which already clips its own corners — rather
+   than a member of the header's flex row, so it sits on the band instead of
+   under it, and the title gets the full width back. Same inset top and right,
+   measured from the sheet's own edges. The button carries its own fill, which
+   is what keeps it legible over whatever the reader's appearance put there. */
+.proto-install-web-app-sheet__close {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 3;
+}
+
 /* The one-tap path, where the browser gave us one. Its own block above the
    toggle, with a rule under it, so the steps below read as the alternative
    rather than as more of the same instruction. */

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -674,7 +674,8 @@ html[data-shift-hints='1'] .proto-toolbar-orb-group {
     .proto-toolbar-seg__btn,
     .proto-sidebar-seg__btn,
     .proto-appearance-segmented__btn,
-    .proto-library-kinds__btn
+    .proto-library-kinds__btn,
+    .proto-install-seg__btn
   ) {
   /* Labels and glyphs ride above the thumb they sit on. */
   position: relative;
@@ -689,7 +690,8 @@ html[data-shift-hints='1'] .proto-toolbar-orb-group {
     .proto-toolbar-seg__btn,
     .proto-sidebar-seg__btn,
     .proto-appearance-segmented__btn,
-    .proto-library-kinds__btn
+    .proto-library-kinds__btn,
+    .proto-install-seg__btn
   ):is([data-active='true'], .proto-appearance-segmented__btn--active) {
   background: transparent;
   box-shadow: none;
@@ -7322,17 +7324,232 @@ button.proto-home-card--tappable:focus-visible {
   border-radius: 4px;
 }
 
-.proto-install-web-app-sheet__steps {
-  margin: 0 0 12px;
-  padding-left: 1.2rem;
+/* ── Add to home screen — platform toggle, then steps that look like steps ──
+   The list used to be prose in an <ol>, which read as a paragraph with numbers.
+   Each step is a row now: a marker, the instruction, and the glyph of the
+   control it names, so the reader can match the sentence to what is on their
+   screen. */
+.proto-install-seg {
+  /* Its own geometry, published for the shared thumb — same contract the
+     appearance control keeps. */
+  --proto-seg-pad: 3px;
+  --proto-seg-gap: 2px;
+  --proto-seg-thumb-radius: 8px;
+  display: flex;
+  margin-bottom: 12px;
+  border-radius: 10px;
+  background: var(--pds-bg-control);
+  padding: var(--proto-seg-pad);
+  gap: var(--proto-seg-gap);
+}
+
+.proto-install-seg__btn {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: none;
+  background: transparent;
+  border-radius: var(--proto-seg-thumb-radius);
+  padding: 7px 12px;
   font-family: var(--pds-font-body);
-  font-size: 0.9375rem;
-  line-height: 1.5;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--pds-text-secondary);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.proto-install-seg__btn[data-active='true'] {
+  color: var(--pds-text-primary);
+  font-weight: 600;
+}
+
+/* ── A sliver of the reader's own appearance, above the title ────────────────
+   The picture their canvas wears, or the catalogue's pairing for the colour
+   they chose. A band the header sits under, which is how a room wears its
+   cover — behind the title it would have to be faded to a smudge to keep
+   `--pds-text-primary` safe on the busiest frame. The sheet already clips its
+   own corners, so the band takes the rounded top for free. */
+.proto-install-web-app-sheet__sliver {
+  display: block;
+  position: relative;
+  z-index: 1;
+  /* A sliver: enough to carry a horizon, not enough to become the subject.
+     The room's cover is 140px because it *is* the room's picture; this one is
+     answering "whose app is this" in passing. */
+  height: 62px;
+  flex-shrink: 0;
+  /* Dissolves into the sheet at its foot, so there is no second edge between
+     the picture and the title under it. Masking the strip rather than the
+     image inside it means the holding colour fades on the same curve. */
+  -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 46%, transparent 100%);
+  mask-image: linear-gradient(to bottom, #000 0%, #000 46%, transparent 100%);
+  pointer-events: none;
+}
+
+.proto-install-web-app-sheet__sliver-image {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  /* Biased upward: these wallpapers carry their sky at the top, and a strip
+     this short would otherwise crop to the busiest part of the frame. */
+  background-position: center 28%;
+  background-repeat: no-repeat;
+  opacity: 0;
+  transition: opacity 320ms var(--pds-ease-emphasized, ease-out);
+}
+
+.proto-install-web-app-sheet__sliver-image--ready {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .proto-install-web-app-sheet__sliver-image {
+    transition: none;
+  }
+}
+
+/* The band supplies the space above the title, so the header stops paying for
+   it twice. */
+.proto-install-web-app-sheet__header {
+  padding-top: 6px;
+}
+
+/* The one-tap path, where the browser gave us one. Its own block above the
+   toggle, with a rule under it, so the steps below read as the alternative
+   rather than as more of the same instruction. */
+.proto-install-web-app-sheet__oneTap {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 14px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--pds-border-subtle, rgba(0, 0, 0, 0.08));
+}
+
+.proto-install-web-app-sheet__oneTap .proto-share-popover__primary {
+  width: 100%;
+}
+
+/* The card's install button matches the sheet's, at the card's own width. */
+.proto-install-web-app-card__install {
+  display: block;
+  width: 100%;
+  margin: 12px auto 0;
+}
+
+/* Which browser, said before the steps — on iPhone this is the difference
+   between the steps working and appearing to be wrong. */
+.proto-install-web-app-sheet__browser {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  margin: 0 0 14px;
+  font-family: var(--pds-font-body);
+  font-size: 0.8125rem;
+  line-height: 1.45;
   color: var(--pds-text-secondary);
 }
 
-.proto-install-web-app-sheet__steps li + li {
-  margin-top: 6px;
+.proto-install-web-app-sheet__browser strong {
+  color: var(--pds-text-primary);
+  font-weight: 600;
+}
+
+.proto-install-web-app-sheet__browser-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: var(--pds-text-primary);
+}
+
+/* Without this the sentence sets its own width and runs under the sheet's edge.
+   Both halves are needed: something upstream gives spans in here `flex: 0 0 auto`,
+   so it may not shrink at all, and a flex item will not go below its content
+   width without `min-width: 0` either. */
+.proto-install-web-app-sheet__browser-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.proto-install-web-app-sheet__steps {
+  margin: 0 0 14px;
+  padding: 0;
+  list-style: none;
+  font-family: var(--pds-font-body);
+}
+
+.proto-install-step {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 9px 11px;
+  border-radius: 10px;
+  background: var(--pds-bg-control);
+  font-size: 0.9375rem;
+  line-height: 1.4;
+  color: var(--pds-text-secondary);
+}
+
+.proto-install-step + .proto-install-step {
+  margin-top: 7px;
+}
+
+.proto-install-step__marker {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 21px;
+  height: 21px;
+  border-radius: 50%;
+  background: var(--pds-bg-page);
+  box-shadow: var(--pds-shadow-chip-selected);
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--pds-text-primary);
+}
+
+.proto-install-step__text {
+  flex: 1;
+  min-width: 0;
+}
+
+.proto-install-step__text strong {
+  color: var(--pds-text-primary);
+  font-weight: 600;
+}
+
+/* The control being named, at the end of the row — a reader scanning for the
+   share square finds it without reading the sentence. */
+.proto-install-step__glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  background: var(--pds-bg-page);
+  color: var(--pds-text-primary);
+}
+
+/* What they get for it. Last, because it is the reason rather than a step.
+   Measured rather than full-bleed: at the sheet's full width the sentence ran
+   almost to the edge and dropped a single word onto the second line. `pretty`
+   is the belt to that braces — it is what stops the last line being an orphan
+   at widths the max-width alone does not catch. */
+.proto-install-web-app-sheet__outcome {
+  margin: 0;
+  max-width: 46ch;
+  font-family: var(--pds-font-body);
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  text-wrap: pretty;
+  color: var(--pds-text-tertiary, var(--pds-text-secondary));
 }
 
 @media (min-width: 900px) {

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -7272,6 +7272,10 @@ button.proto-home-card--tappable:focus-visible {
 
 /* Mobile home — Add to Home Screen card (main pane empty state). */
 .proto-install-web-app-card {
+  cursor: pointer;
+  transition:
+    background 0.38s cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 0.38s cubic-bezier(0.22, 1, 0.36, 1);
   position: relative;
   flex-shrink: 0;
   width: fit-content;
@@ -7287,7 +7291,53 @@ button.proto-home-card--tappable:focus-visible {
   pointer-events: auto;
 }
 
+/* The same lift a tappable home card takes, so a card that responds looks like
+   the others that do. */
+.proto-install-web-app-card:hover {
+  background: var(--pds-bg-control-strong);
+  box-shadow:
+    0 2px 4px rgba(60, 64, 67, 0.08),
+    0 8px 18px -10px rgba(60, 64, 67, 0.12),
+    var(--pds-glass-rim);
+}
+
+@media (prefers-color-scheme: dark) {
+  html.harvous-prototype-route:not([data-color-scheme='light']) .proto-install-web-app-card:hover,
+  html[data-color-scheme='dark'].harvous-prototype-route .proto-install-web-app-card:hover {
+    box-shadow:
+      0 2px 4px rgba(0, 0, 0, 0.22),
+      0 8px 18px -10px rgba(0, 0, 0, 0.3),
+      var(--pds-glass-rim);
+  }
+}
+
+/* Covers the card, under its contents. The three real controls are lifted
+   above it so their own taps still reach them; everything else — the heading,
+   the padding, the empty corners — belongs to this. */
+.proto-install-web-app-card__surface-tap {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  width: 100%;
+  padding: 0;
+  border: none;
+  border-radius: inherit;
+  background: transparent;
+  cursor: pointer;
+}
+
+.proto-install-web-app-card .proto-daily-passage-pill__dismiss,
+.proto-install-web-app-card__install,
+.proto-install-web-app-card__learn {
+  position: relative;
+  z-index: 2;
+}
+
 .proto-install-web-app-card__heading {
+  /* Lets a tap on the words reach the card's own layer under them. The
+     heading is not selectable text anyone needs — it is the card's label, and
+     the whole card is the target now. */
+  pointer-events: none;
   margin: 0;
   overflow: visible;
   text-overflow: unset;
@@ -7315,8 +7365,10 @@ button.proto-home-card--tappable:focus-visible {
   cursor: pointer;
 }
 
+/* No underline on hover: the whole card lifts now, which says "this responds"
+   without turning a call to action into a link. */
 .proto-install-web-app-card__learn:hover {
-  text-decoration: underline;
+  opacity: 0.72;
 }
 
 .proto-install-web-app-card__learn:focus-visible {

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -7457,8 +7457,10 @@ button.proto-home-card--tappable:focus-visible {
    between the steps working and appearing to be wrong. */
 .proto-install-web-app-sheet__browser {
   display: flex;
-  align-items: flex-start;
-  gap: 9px;
+  /* Centred on the tile now rather than hung from the first line: the icon is
+     26px against a 13px line, so aligning their tops left it floating. */
+  align-items: center;
+  gap: 10px;
   margin: 0 0 14px;
   font-family: var(--pds-font-body);
   font-size: 0.8125rem;
@@ -7471,11 +7473,22 @@ button.proto-home-card--tappable:focus-visible {
   font-weight: 600;
 }
 
+/* An app tile, because that is what the reader is looking for on their own home
+   screen: the platform's rounded white square with the browser's mark on it.
+   The hairline and the small shadow are what stop it reading as a sticker on a
+   white sheet. */
 .proto-install-web-app-sheet__browser-icon {
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex-shrink: 0;
-  margin-top: 1px;
-  color: var(--pds-text-primary);
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  background: #ffffff;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.16),
+    inset 0 0 0 0.5px rgba(0, 0, 0, 0.08);
 }
 
 /* Without this the sentence sets its own width and runs under the sheet's edge.


### PR DESCRIPTION
Three things about adding Harvous to a home screen: a one-tap install that was being thrown away, steps that read as a paragraph with numbers in front of it, and three claims in the copy that were not true.

## Android's install prompt was captured and discarded

The startup script listened for `beforeinstallprompt`, cancelled Chrome's own banner, and assigned the event to a variable nothing ever read. So the browser's offer was suppressed and nothing replaced it, and the manual steps were the only way in.

It still cancels the banner, deliberately — the app asks from a card the reader is already looking at, rather than letting Chrome interrupt them. What is new is the other half: the event is kept and published for the app to fire.

- A held prompt is single-use, so it is spent before it fires.
- Declining puts the written steps back, and Chrome offers a fresh prompt on a later visit.
- Installing by any other route, another tab or the browser menu, withdraws the offer.
- iOS has no such event. There, `canInstall` stays false and the steps are the whole answer.

The card gains an **Install** button; "Learn how" stays beside it as "What this does", so someone can look before they tap. The sheet leads with the button above a rule, steps below.

## Steps that look like steps

Each step is a row now: a numbered marker, the instruction, and the glyph of the control it names — the iOS share box, the three-dot menu. Platform is a segmented toggle rather than two stacked headings, preselected from what the phone reports, with both halves always reachable because detection is a guess.

The browser is named **before** the steps, with its own mark. On iPhone that line is the difference between the steps working and appearing to be broken.

The header wears a sliver of the reader's own appearance: the image their canvas wears, or the one the catalogue pairs with the colour they chose, per mode, through the same map the space covers use. It is a band above the title rather than a wash behind it — over the title the picture would have to be faded to about a third to keep `--pds-text-primary` legible on the busiest frame, and a third of a photograph is a smudge. The strip paints the paired colour immediately and crossfades the image over it, so it is never an empty gap.

## Three things in the copy were wrong

Found on a second pass, and two of them were mine:

- **"Other browsers on iPhone cannot add to the home screen."** That stopped being true in iOS 16.4, when the API opened to any supporting browser ([MDN](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Installing)). It now says the menu simply sits somewhere else.
- **Android's confirm was named as "Install".** It is Install *or* Add, depending on the Chrome version and which menu item was tapped.
- **The payoff line promised offline.** The service worker gives that whether you install or not, so the sentence was selling something the reader already had. It now claims only what `display: standalone` changes: its own window, no browser bar.

## Cost

Both the sheet and its four brand marks load on the tap, not on boot. The four marks live in the sheet's own chunk rather than the shared icon registry, which inlines every icon it knows into the initial bundle — the Safari logo should not be on the critical path for sign-in.

Initial payload is 1135.0 KB gzipped, under budget, with no budget raised.

## Verification

- Full suite passes: 5,463 tests across 512 files, including 14 new ones for the install bridge and the appearance pairing.
- Typecheck holds at 125 pre-existing errors, none new. Build clean. Colour-token check clean.
- Walked at phone and desktop width, both platforms, plus the sheet's exit animation and reopen behaviour.
- The real install event cannot be summoned in a preview, so the wiring was driven with a synthetic event shaped like Chrome's: accepting fired the prompt once, flipped availability off and dismissed the card; declining left the card with the steps back; the installed-elsewhere signal withdrew the offer.
- Dark mode could not be checked by hand without changing a real account setting, so the light and dark pairing is covered by tests instead.

## Notes for the reviewer

- **No version bump here.** The hook drafted 3.4.0, but harvouscom/harvous#67 already claims that number, and two branches bumping to the same version is a guaranteed conflict in four files. Whichever merges second should be stamped then.
- A second, older copy of these instructions lives in the legacy app shell (`spa/src/App.tsx`), still the plain two-list version. Untouched here, and it will now read as the stale one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)