### PR TITLE
Backfill: a branch that merges below the high-water mark still exports

### DIFF
--- a/Changelog/3.5.1.md
+++ b/Changelog/3.5.1.md
@@ -1,0 +1,8 @@
+# Version 3.5.1
+
+**Release Date**: September 5, 2026
+
+## Fixes
+
+- A branch that merges below the backfill mark still exports
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.5.0
+**Version:** 3.5.1
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-5-0';
+const CACHE_NAME = 'harvous-cache-v3-5-1';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/scripts/__tests__/export-changelog-csv.test.js
+++ b/scripts/__tests__/export-changelog-csv.test.js
@@ -1,0 +1,59 @@
+/**
+ * The backfill's high-water mark, and the branch that merges underneath it.
+ *
+ * 3.4.0 shipped from one branch and synced while 3.3.3–3.3.11 were still
+ * unmerged on another. The mark moved to 3.4.0, and when the second branch
+ * landed its nine files all sorted below it — so the whole Reminders release
+ * was skipped permanently rather than late, and harvous.com announced a feature
+ * its own changelog never mentioned.
+ */
+import { mkdtempSync, readFileSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+import { exportChangelogToMarketingSite } from "../export-changelog-csv.js";
+
+const HEADER =
+  "Name,Slug,Collection ID,Locale ID,Item ID,Archived,Draft,Created On,Updated On,Published On,Version Number,Date,Commit Message,Category";
+
+/** One CSV row, only the columns the exporter reads back. */
+function row({ name, version, date }) {
+  return `${name},slug,cid,lid,iid,false,false,${date},${date},,${version},${date},<p>${name}</p>,Feature`;
+}
+
+function csvWith(rows) {
+  const path = join(mkdtempSync(join(tmpdir(), "changelog-csv-")), "changelog.csv");
+  writeFileSync(path, [HEADER, ...rows].join("\n"), "utf-8");
+  return path;
+}
+
+const SEP_5 = "Sat Sep 05 2026 12:00:00 GMT+0000 (Coordinated Universal Time)";
+
+describe("backfill and the high-water mark", () => {
+  it("recovers a version that merged below the mark", () => {
+    const csvPath = csvWith([row({ name: "Older row", version: "3.4.0", date: SEP_5 })]);
+
+    exportChangelogToMarketingSite({ csvPath, backfill: true, quiet: true });
+    const written = readFileSync(csvPath, "utf-8");
+
+    // 3.3.3 sorts below the 3.4.0 mark but was released alongside it.
+    expect(written).toContain("3.3.3");
+    expect(written).toMatch(/Reminders/);
+  });
+
+  it("stays inside the recovery window, so the legacy backlog is left alone", () => {
+    const csvPath = csvWith([row({ name: "Older row", version: "3.4.0", date: SEP_5 })]);
+
+    exportChangelogToMarketingSite({ csvPath, backfill: true, quiet: true });
+    const versions = readFileSync(csvPath, "utf-8")
+      .split("\n")
+      .slice(1)
+      .map((line) => line.split(",")[10])
+      .filter(Boolean);
+
+    // The CSV began as a Webflow export that never covered 0.x. Treating
+    // "absent" as "unpublished" would drag ~888 of those rows back in.
+    expect(versions.some((v) => v.startsWith("0."))).toBe(false);
+    expect(versions.some((v) => v.startsWith("1."))).toBe(false);
+  });
+});

--- a/scripts/export-changelog-csv.js
+++ b/scripts/export-changelog-csv.js
@@ -202,6 +202,35 @@ function loadExistingFingerprints(csvText) {
   return seen;
 }
 
+/**
+ * How far back a backfill may reach for a version the high-water mark skipped.
+ *
+ * Fourteen days is a long-lived feature branch and not much more. It has to be
+ * a window rather than "any version missing from the CSV", because this CSV
+ * began as a Webflow export and never covered the early history — treating
+ * absence as "unpublished" re-exports 888 rows of 0.x.
+ */
+const BACKFILL_RECOVERY_MS = 14 * 24 * 60 * 60 * 1000;
+
+function releaseDateOf(filepath) {
+  const match = readFileSync(filepath, "utf-8").match(/\*\*Release Date\*\*:\s*(.+)/i);
+  const parsed = match ? Date.parse(match[1].trim()) : NaN;
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function maxDateInCsv(csvText) {
+  const rows = parseCsvRows(csvText);
+  const dateIdx = (rows[0] ?? []).indexOf("Date");
+  let max = 0;
+
+  for (const values of rows.slice(1)) {
+    const parsed = Date.parse(values[dateIdx] ?? "");
+    if (!Number.isNaN(parsed) && parsed > max) max = parsed;
+  }
+
+  return max;
+}
+
 function maxVersionInCsv(csvText) {
   const rows = parseCsvRows(csvText);
   const headers = rows[0] ?? [];
@@ -332,12 +361,27 @@ export function exportChangelogToMarketingSite(options = {}) {
   const csvText = readFileSync(csvPath, "utf-8").trimEnd();
   const seen = loadExistingFingerprints(csvText);
   const minVersion = backfill ? maxVersionInCsv(csvText) : null;
+  const minDate = backfill ? maxDateInCsv(csvText) - BACKFILL_RECOVERY_MS : null;
 
   const files = listChangelogFiles(changelogDir).filter((filepath) => {
     const v = basename(filepath, ".md");
     if (version) return v === version;
     // >= so a new Changelog/2.0.3.md still exports when legacy 2.0.3 rows exist in CSV.
-    if (backfill && minVersion) return compareSemver(v, minVersion) >= 0;
+    if (backfill && minVersion) {
+      if (compareSemver(v, minVersion) >= 0) return true;
+      /*
+        A branch cut before main moved on merges with version numbers already
+        below the mark, and the mark only ever goes up — so those files were
+        skipped permanently rather than late. That is how 3.3.3 through 3.3.11
+        (the whole Reminders release) never reached the site: 3.4.0 shipped
+        from another branch and synced first, and nine rows fell under it.
+
+        Dates are monotonic across branches where version numbers are not, so
+        the recovery window is a date. The row fingerprint still decides what
+        is actually new, and this only widens what gets considered.
+      */
+      return releaseDateOf(filepath) >= minDate;
+    }
     return false;
   });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
       'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'spa/src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
       'server/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      'scripts/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
     ],
     exclude: ['node_modules', 'dist', '.astro'],
     coverage: {


### PR DESCRIPTION
## The symptom

The Reminders release never reached harvous.com. `Changelog/3.3.3.md` through `3.3.11.md` exist, the site now announces the feature on four surfaces, and `/release-notes/` jumps **3.3.2 → 3.4.0** as though it never shipped.

## Root cause

`--backfill` exports files at or above `maxVersionInCsv(csv)`, which assumes versions arrive in ascending order. Two concurrent branches broke that:

| time (UTC) | event | mark after |
|---|---|---|
| 15:42 | 3.4.0 (spaces branch) reaches `main`, syncs | **3.4.0** |
| 23:10 | PR #69 merges with 3.3.3–3.3.11 **and** 3.4.1 | 3.4.1 |

Only 3.4.1 cleared the mark. The other nine sorted underneath it, and because the mark only ever rises they were skipped **permanently, not late**. Any long-lived branch hits this — the version it was cut at is already stale when it lands.

## Why the floor can't just go

Both obvious repairs were measured against the live CSV before writing this:

- **Drop the floor, trust the row fingerprint** → **1321 rows** re-exported. Legacy titles no longer match what this parser produces, so `version+title` fingerprints miss.
- **Export any version absent from the CSV** → **888 rows**. The CSV began as a Webflow export that never covered 0.x, so "absent" doesn't mean "unpublished".

The floor is load-bearing. It's protecting a backlog whose fingerprints have drifted.

## The fix

The floor stays and gains a second way past it. **Dates are monotonic across branches where version numbers are not**, so a file released within 14 days of the newest CSV row is considered even when it sorts low. The row fingerprint still decides what is actually new; this only widens the candidate set.

Against the live CSV it recovers exactly ten rows and nothing older.

## Test

`vitest` didn't reach `scripts/`, so the regression had nowhere to live — the include list now covers it. The test fails without the change:

```
× recovers a version that merged below the mark
  AssertionError: expected 'Name,Slug,Collection ID,…' to contain '3.3.3'
```

Second case pins the other half: no 0.x or 1.x row comes back, so the legacy backlog stays out.

## One manual step after this merges

The backfill will add `3.3.0 | "$6/mo and $36/yr, and the founding discount retired"`, a retitled duplicate of the 3.3.0 row already published as `"Harvous Plus is now $6/mo or $36/yr"`. The fingerprint is version+title, so a retitled entry reads as new. Delete that one row from `harvous.com/data/webflow-changelog.csv` after the sync runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)