### PR TITLE
One install explainer, not two

### DIFF
--- a/Changelog/3.5.2.md
+++ b/Changelog/3.5.2.md
@@ -1,0 +1,8 @@
+# Version 3.5.2
+
+**Release Date**: September 5, 2026
+
+## Fixes
+
+- One explainer, not two
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.5.1
+**Version:** 3.5.2
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-5-1';
+const CACHE_NAME = 'harvous-cache-v3-5-2';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -6,9 +6,10 @@ import { hasClerkSessionCookieHint } from './hooks/queries/useProfile';
 import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 import { clearUserClientCaches } from '@/utils/clear-user-client-caches';
 import { RouterProvider } from '@tanstack/react-router';
-import React, { useEffect, useLayoutEffect, useState, useCallback, useRef, useMemo, useSyncExternalStore } from 'react';
+import React, { lazy, Suspense, useEffect, useLayoutEffect, useState, useCallback, useRef, useMemo, useSyncExternalStore } from 'react';
 import { buildClerkAppearance } from './lib/clerk-appearance';
 import { getColorSchemeSnapshot, subscribeColorScheme } from './lib/prototype-background';
+import { getInstallPlatform } from '@/utils/platform-detect';
 import { createPortal } from 'react-dom';
 import { shouldSuppressAppToasts } from '@/utils/should-suppress-app-toasts';
 import { Toaster, toast as sonnerToast } from 'sonner';
@@ -22,7 +23,6 @@ import {
   HARVOUS_TOASTER_MOBILE_BOTTOM_VAR,
 } from '@/utils/mobile-offline-chip-layout';
 import { subscribeSheetOverlayInset } from '@/utils/sheet-overlay-inset';
-import { useDesktopMainModalPortal } from '@/hooks/useDesktopMainModalPortal';
 import { SyncCacheBridge } from './lib/sync-cache-bridge';
 import { SharedSpacesEntitlementBridge } from './lib/SharedSpacesEntitlementBridge';
 import { PostHogBridge } from './components/PostHogBridge';
@@ -430,60 +430,39 @@ function UserIdSync() {
   return null;
 }
 
-function PwaInstallInstructionsModal({ onClose }: { onClose: () => void }) {
-  const { portalTarget } = useDesktopMainModalPortal();
-  return createPortal(
-    <div
-      className="pwa-install-modal-overlay"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="pwa-install-modal-title"
-      onClick={(e) => e.target === e.currentTarget && onClose()}
-      onKeyDown={(e) => e.key === 'Escape' && onClose()}
-    >
-      <div className="pwa-install-modal" onClick={(e) => e.stopPropagation()}>
-        <h2 id="pwa-install-modal-title" className="pwa-install-modal__title">
-          Add Harvous to your home screen
-        </h2>
-        <div className="pwa-install-modal__section">
-          <strong>iPhone (Safari)</strong>
-          <ol>
-            <li>Tap the <strong>Share</strong> icon (square with arrow)</li>
-            <li>Scroll down and tap <strong>Add to Home Screen</strong></li>
-            <li>Tap <strong>Add</strong></li>
-          </ol>
-        </div>
-        <div className="pwa-install-modal__section">
-          <strong>Android (Chrome)</strong>
-          <ol>
-            <li>Tap the menu (⋮)</li>
-            <li>Tap <strong>Install app</strong> or <strong>Add to Home Screen</strong></li>
-          </ol>
-        </div>
-        <p className="pwa-install-modal__footer">
-          Then open Harvous from your home screen for a faster, app-like experience.
-        </p>
-        <button
-          type="button"
-          className="btn btn--primary btn--sm btn-animate-squish pwa-install-modal__close"
-          onClick={onClose}
-        >
-          <span className="btn__content">Close</span>
-          <span className="btn__shadow-overlay" aria-hidden="true" />
-        </button>
-      </div>
-    </div>,
-    portalTarget
-  );
-}
+/*
+  The install explainer, which is the one the prototype shell already has.
+
+  This was a second copy written out here: a plain two-list modal whose own
+  class names (`pwa-install-modal*`) are defined in no stylesheet in this repo,
+  so anything reaching it would have got unstyled text — and it still carried
+  the claim that only Safari can add to a home screen on iPhone, which stopped
+  being true in iOS 16.4.
+
+  Two explainers that disagree is one too many. The event stays as the seam, so
+  `window.harvousToast.pwaPrompt`'s action keeps working; what it opens is now
+  the sheet the home card opens, with the platform toggle, the browser's own
+  icon, and the one-tap install where the browser offers one.
+
+  Lazy, for the reason the card's is: most sessions never ask for it.
+*/
+const PrototypeInstallWebAppSheet = lazy(
+  () => import('./pages/prototype/PrototypeInstallWebAppSheet'),
+);
 
 function SpaToaster() {
   const [isMobile, setIsMobile] = useState(false);
   const [isSmallScreen, setIsSmallScreen] = useState(false);
   const [showPwaInstructions, setShowPwaInstructions] = useState(false);
+  /* Mounted from the first request onward rather than only while open, so the
+     sheet can animate itself out; before that its chunk is never fetched. */
+  const [pwaInstructionsRequested, setPwaInstructionsRequested] = useState(false);
 
   useEffect(() => {
-    const handler = () => setShowPwaInstructions(true);
+    const handler = () => {
+      setPwaInstructionsRequested(true);
+      setShowPwaInstructions(true);
+    };
     window.addEventListener(PWA_INSTALL_INSTRUCTIONS_EVENT, handler);
     return () => window.removeEventListener(PWA_INSTALL_INSTRUCTIONS_EVENT, handler);
   }, []);
@@ -552,8 +531,14 @@ function SpaToaster() {
 
   return (
     <>
-      {showPwaInstructions && (
-        <PwaInstallInstructionsModal onClose={() => setShowPwaInstructions(false)} />
+      {pwaInstructionsRequested && (
+        <Suspense fallback={null}>
+          <PrototypeInstallWebAppSheet
+            open={showPwaInstructions}
+            onClose={() => setShowPwaInstructions(false)}
+            platform={getInstallPlatform()}
+          />
+        </Suspense>
       )}
       <Toaster
         position={isMobile ? 'bottom-center' : 'bottom-right'}


### PR DESCRIPTION
The app shell carried its own copy of the add-to-home-screen instructions, reached from the "How to install" action on the PWA toast. Three things were wrong with it.

- **It taught something untrue.** It said the steps only work in Safari on iPhone. That stopped being true in iOS 16.4, when the API opened to any supporting browser — the same claim I corrected in the sheet earlier ([MDN](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Installing)).
- **It had no styling at all.** Its class names (`pwa-install-modal`, `pwa-install-modal__title`, and the rest) are defined in no stylesheet in this repo. Anything reaching it would have got unstyled text on a bare white block.
- **It was a second answer to a settled question.** The prototype sheet answers it with a platform toggle, the browser's own app icon, the real iOS share glyph, and Chrome's one-tap install where the browser offers one.

The event stays as the seam, so `window.harvousToast.pwaPrompt`'s action keeps working. What it opens is now that sheet, loaded lazily and mounted from the first request onward so it can animate itself out.

## Worth saying plainly

**Nothing in this repo calls `pwaPrompt` today.** The toast is declared on the window API and implemented twice, but no caller exists, so this path is currently unreachable. That is a reason to make it correct rather than to leave a wrong answer waiting behind an event anyone could fire — but it does mean this fixes something no user is hitting right now.

Deleting the path outright was the alternative. I kept it because the window API is documented in `src/env.d.ts` and a future caller should land on the good sheet, not on nothing.

## Verification

- Dispatched `showPwaInstallInstructions` in the running app: the real sheet opens with the corrected copy, closes cleanly, and reopens. No legacy modal in the DOM.
- The sheet's chunk is fetched once, on the event, not at boot.
- Full suite passes: 5,698 tests across 534 files. Build clean, bundle budget passes.

**One typecheck caveat.** The ratchet reports a single new error in `server/utils/web-push-client.ts`, which is not a file this touches. It is a local environment artifact: the reminders work added `web-push` to package.json and this machine's shared `node_modules` has not installed it. CI installs from the lockfile, so it should be clean there — worth a glance at the check result to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)