### PR TITLE
Ratchet the bundle budget down to what main ships

### DIFF
--- a/scripts/perf-budget.json
+++ b/scripts/perf-budget.json
@@ -1,7 +1,7 @@
 {
-  "initialPayloadGzip": 1170143,
+  "initialPayloadGzip": 1169665,
   "chunks": {
-    "index.js": 774493,
+    "index.js": 774015,
     "index.css": 142627,
     "tiptap.js": 120673,
     "react-vendor.js": 60895,


### PR DESCRIPTION
The initial payload was sitting 0.5 KB under its ceiling. That is headroom a later change can spend without anything noticing, which is what the ratchet exists to prevent.

Recorded from a clean build of `7124dfbf7`, so the numbers are what main actually serves rather than what a branch happened to measure.

```
initialPayloadGzip  1170143 → 1169665
index.js             774493 → 774015
```

Two lines move, by the same 478 bytes. Nothing was optimised here — this is the budget catching up with work already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)