### PR TITLE
Describe the whole of September 5 in its release note

### DIFF
--- a/release-notes/2026-09-05.md
+++ b/release-notes/2026-09-05.md
@@ -1,9 +1,9 @@
 # What's New in Harvous — September 5, 2026
 
 **Release Date:** September 5, 2026
-**Versions:** v3.3.0 - v3.3.2, v3.5.0, v3.5.2
+**Versions:** v3.3.0 - v3.5.2
 
-Harvous Plus costs less, and the pricing has one fewer thing to explain.
+Harvous Plus costs less, and the pricing has one fewer thing to explain. Reminders can arrive on Sunday morning and midweek carrying the day's verse, a shared space can decide what it studies next, and adding Harvous to your home screen is one tap on Android.
 
 ---
 
@@ -94,6 +94,32 @@ Harvous Plus costs less, and the pricing has one fewer thing to explain.
 **How it helps you:**
 - "Type" sat between two background choices, where it read as a kind of background rather than a choice of lettering.
 - The name now says both what the setting changes and where you will see it.
+
+### A reminder on Sunday and midweek
+
+**What changed:**
+- Harvous can send you two reminders a week: one on Sunday morning before church, carrying the day's verse, and one midweek on a day you pick, carrying the chapter you left off in. Tapping one opens straight to it.
+- You turn them on under Settings, Reminders. Your browser asks permission once.
+- They work in desktop browsers and in installed web apps. On an iPhone they work once Harvous is on your Home Screen, which is the only way Apple allows a web app to notify you at all.
+- They stay quiet on purpose: never more than two a week, never on a day you have already opened Harvous, and they pause themselves if they go unopened for a few weeks. Changing anything in the settings starts them again.
+- Along the way: notification titles fit on one line, a tap opens the right screen even when the app was not already running, and a test send that fails now tells you why.
+
+**How it helps you:**
+- The reminder carries the thing itself rather than asking you to come back and find it.
+- If they stop being useful to you, they stop on their own. You do not have to remember to switch them off.
+
+### Deciding what a shared space studies next
+
+**What changed:**
+- Anyone in a shared space can suggest what the room studies next: a passage, a note, a Thread, or just an idea, with a sentence on why.
+- Whoever runs the room reads the suggestions and picks one. Accepting it makes it the room's current Thread there and then.
+- It stays off until a room turns it on, in the room's settings under "What we study next".
+- A suggestion carries your name to whoever runs the room, and to nobody else in it. You can withdraw one while it is still waiting.
+- Other things a member of a room can now reach: you can mark a study plan finished for yourself without closing the run for everyone, and closing the run does not claim you finished it. A group with no church behind it can have a co-leader. A room that gathers shows who else is here. You can answer someone's annotation from the note itself, instead of hunting for the exact words they highlighted. The room's note templates sit in its Tools, and the Coming up card can open the passage in the reader rather than only starting a note about it.
+
+**How it helps you:**
+- "What should we study next?" stops falling to whoever speaks first, without becoming a vote nobody asked for. The room suggests; the person who runs it still decides, and does it in the open.
+- Your progress through a plan is yours. Finishing it is a thing you say about your own study, not a thing that ends the study for the room.
 
 ### Adding Harvous to your home screen
 

--- a/release-notes/2026-09-05.md
+++ b/release-notes/2026-09-05.md
@@ -1,7 +1,7 @@
 # What's New in Harvous — September 5, 2026
 
 **Release Date:** September 5, 2026
-**Versions:** v3.3.0 - v3.3.2
+**Versions:** v3.3.0 - v3.3.2, v3.5.0, v3.5.2
 
 Harvous Plus costs less, and the pricing has one fewer thing to explain.
 
@@ -94,3 +94,17 @@ Harvous Plus costs less, and the pricing has one fewer thing to explain.
 **How it helps you:**
 - "Type" sat between two background choices, where it read as a kind of background rather than a choice of lettering.
 - The name now says both what the setting changes and where you will see it.
+
+### Adding Harvous to your home screen
+
+**What changed:**
+- On Android, Chrome can add Harvous for you now. The card on Home has an Install button that opens the browser's own install prompt, so there are no written steps to follow.
+- Where a browser cannot do it for you, the steps have been rebuilt. You pick iPhone or Android, and each step shows the control you are hunting for — the Share box on iPhone, the three dot menu in Chrome — beside the browser's own icon.
+- The instructions used to say that only Safari can add to the home screen on an iPhone. That stopped being true in iOS 16.4, and the wording is corrected.
+- There were two sets of instructions inside Harvous that disagreed with each other. There is one now.
+- The whole card on Home responds to a tap, not only the line at the bottom of it.
+
+**How it helps you:**
+- On Android it is one tap, and you never read a step.
+- On iPhone the steps match what is actually on your screen, and they no longer tell you a browser cannot do something it can.
+- Harvous then opens from your home screen in its own window, with no browser bar around it.


### PR DESCRIPTION
Today's note was written and unbannered while the day was still at v3.3.2. The missing DRAFT banner is the generator's lock, so it correctly refused to touch the file afterwards and printed "already written, leaving it alone" on every bump since. Nine releases never reached it.

The note now covers the day: `**Versions:** v3.3.0 - v3.5.2`.

## Three sections added

**A reminder on Sunday and midweek** (v3.3.3 to v3.4.1). Two a week at most, carrying the day's verse or the chapter you left off in, opening straight to it. Where to turn them on, that iPhone needs Harvous on the Home Screen first, and that they pause themselves when they go unopened.

**Deciding what a shared space studies next** (v3.4.0). Members suggest a passage, note, Thread or idea; whoever runs the room picks; accepting makes it the room's current Thread. Off until a room turns it on. Also the study-tools half of that release: finishing a plan for yourself without closing the run, co-leaders in a group with no church, presence in a room that gathers, replying to an annotation, note templates in Tools.

**Adding Harvous to your home screen** (v3.5.0, v3.5.2). Chrome's one-tap install on Android, the rebuilt steps with the platform toggle and each browser's own icon, the corrected claim about Safari on iPhone, and two disagreeing sets of instructions becoming one.

The summary line at the top was written when the note was only about pricing; it now names what the day actually holds.

## One accuracy check worth recording

The v3.3.3 changelog closes with "Not enabled on the server yet — reminders need VAPID keys and the push schema applied before anyone can turn them on." Announcing a feature nobody can switch on would break the rule against describing unshipped work, so I checked rather than assumed:

```
GET https://app.harvous.com/api/push/vapid-public-key
{"publicKey":"BJque-...","configured":true}
```

`PushSubscriptions` is applied in the production database too. That changelog note was true when written and is stale now.

## Not described

v3.3.4 (development tunnel hostnames) and v3.5.1 (changelog export mechanics) are inside the range and deliberately unmentioned — neither is user-facing.

## Checks

No emoji anywhere in the file, per the release-note invariant; the only non-ASCII character is the em dash the existing copy already used. The DRAFT banner stays absent, so the generator keeps leaving the note alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)