### PR TITLE
3.3.0's pricing entry takes the title the site published

### DIFF
--- a/Changelog/3.3.0.md
+++ b/Changelog/3.3.0.md
@@ -4,7 +4,7 @@
 
 ## Features
 
-- $6/mo and $36/yr, and the founding discount retired
+- Harvous Plus is now $6/mo or $36/yr
 
 ## Improvements
 


### PR DESCRIPTION
harvous.com retitled this row by hand in `b6fbf6d` — **"Harvous Plus is now $6/mo or $36/yr"**, clearer than the commit subject it was generated from. `Changelog/3.3.0.md` and the site's CSV have disagreed ever since.

That isn't cosmetic. The exporter fingerprints on **version+title**, so it never recognised the retitled row as the same entry, and re-added its own wording on every sync while 3.3.0 sat inside the backfill window. `/release-notes/v3-3-11/` showed the same price change twice.

Deleting the stray row on the site ([harvous.com#5](https://github.com/harvouscom/harvous.com/pull/5)) did **not** hold — the next sync put it straight back. Matching the title here is what actually stops it.

## Verified

Ran a real backfill against a CSV with the stray row removed and this change in place:

```
ℹ️  CSV already up to date.
stray row present afterwards: 0
```

The fingerprint now lands on the row already published, so the exporter skips it and the site's wording wins.

## Worth knowing

A title hand-edited in the CSV is not durable — this file is what the exporter compares against, so any such edit gets undone on the next sync of a version still inside the window. Two ways out: edit the changelog file too (this PR), or fingerprint on **slug** instead of title. Both rows have carried the same slug (`6-mo-and-36-yr-and-the-founding-discoun-382eefc`) the whole time, so the slug would have caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)