### PR TITLE
A launch note for the suggestion box

### DIFF
--- a/release-notes/2026-09-05.md
+++ b/release-notes/2026-09-05.md
@@ -111,14 +111,10 @@ Harvous Plus costs less, and the pricing has one fewer thing to explain. Reminde
 ### Deciding what a shared space studies next
 
 **What changed:**
-- Anyone in a shared space can suggest what the room studies next: a passage, a note, a Thread, or just an idea, with a sentence on why.
-- Whoever runs the room reads the suggestions and picks one. Accepting it makes it the room's current Thread there and then.
-- It stays off until a room turns it on, in the room's settings under "What we study next".
-- A suggestion carries your name to whoever runs the room, and to nobody else in it. You can withdraw one while it is still waiting.
+- Anyone in a shared space can suggest what the room studies next, and whoever runs the room picks. It stays off until a room turns it on. The full story is in [What's next](launches/shared-space-study-suggestions.md) — this is the day's own record.
 - Other things a member of a room can now reach: you can mark a study plan finished for yourself without closing the run for everyone, and closing the run does not claim you finished it. A group with no church behind it can have a co-leader. A room that gathers shows who else is here. You can answer someone's annotation from the note itself, instead of hunting for the exact words they highlighted. The room's note templates sit in its Tools, and the Coming up card can open the passage in the reader rather than only starting a note about it.
 
 **How it helps you:**
-- "What should we study next?" stops falling to whoever speaks first, without becoming a vote nobody asked for. The room suggests; the person who runs it still decides, and does it in the open.
 - Your progress through a plan is yours. Finishing it is a thing you say about your own study, not a thing that ends the study for the room.
 
 ### Adding Harvous to your home screen

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -100,6 +100,8 @@ These release notes help you understand:
 
 Start with the most recent file to see the latest updates!
 
+**What's next: how a room decides what to study** (September 2026): [launches/shared-space-study-suggestions.md](launches/shared-space-study-suggestions.md) — members of a shared space suggest what to study next and whoever runs the room picks; opt-in per room, shipped in v3.4.0.
+
 **Harvous 3.0** (September 2026): [launches/harvous-3-0.md](launches/harvous-3-0.md) — the release in one place. Home became Activity, the sidebar became Search, and Review arrived; built across the 2.x numbers on the 3.0 branch and shipped as v3.0.0.
 
 **Harvous for churches** (August 2026): [launches/harvous-for-churches.md](launches/harvous-for-churches.md) — the whole church release in one place, across v2.14.0–v2.33.0.

--- a/release-notes/launches/shared-space-study-suggestions.md
+++ b/release-notes/launches/shared-space-study-suggestions.md
@@ -1,0 +1,75 @@
+# What's next: how a room decides what to study
+
+**Launched:** September 2026
+**Shipped in:** v3.4.0
+
+Every group that studies together has to answer the same question eventually: what should we do after this?
+
+It is a question that usually gets answered badly. Either it falls to whoever speaks first on the night, or it falls to whoever runs the room, alone, between meetings, guessing at what everyone else would want. The people with an idea have nowhere to put it, and the person deciding has nothing to go on.
+
+What's next is a way for a room to answer that question together, without turning it into a committee.
+
+---
+
+## How it works
+
+### Anyone in the room can suggest
+
+A member of a shared space can propose what to study next. Four kinds of thing:
+
+- **A passage.** Romans 8, Psalm 23, the Sermon on the Mount.
+- **An idea.** Something on grief. The parables. Prayer.
+- **A note** already in the room.
+- **A Thread** the room has, but is not currently walking.
+
+Every suggestion can carry a sentence on why. That sentence is often the whole difference between a good suggestion and a link somebody liked, so it gets the room to say it in.
+
+The form asks for nothing else. No title, no category, no scope. Those are the jobs of whoever runs the room, and asking a member to do them before anyone has agreed the thing belongs is asking for homework.
+
+### Whoever runs the room picks
+
+Suggestions arrive in a queue for the room's owner and its leaders. Each one shows what was suggested, who suggested it, and their sentence about why.
+
+There are two answers, and they sit at the same weight on screen: **Make it our next study**, or **Not now**. Declining is an ordinary answer that a room will give often, and making it the quiet red option would push people toward saying yes to things to avoid pressing it.
+
+### Accepting it changes the room
+
+Accepting a suggestion makes it the room's current Thread, immediately. A suggested Thread is pinned as it is; a passage, a note or an idea becomes a new Thread named after it, ready for the room to write into.
+
+There is no second step, and no state where the room has agreed on something but has nowhere to put it.
+
+---
+
+## What it deliberately does not do
+
+**The room does not vote.** Whoever runs the room decides. A vote sounds fairer and mostly is not: it turns a pastoral judgment about what a particular group needs next into a popularity contest, and it puts the leader in the position of either following it or publicly overruling it. The room says what it wants; the person responsible for the room still chooses.
+
+**Nothing happens on a clock.** No deadline, no reminder, no notification. A suggestion waits until somebody looks.
+
+**It is off until a room turns it on.** A room that has never wanted this never sees it. Nothing appears in a space until its settings say so.
+
+---
+
+## Who sees what
+
+This is worth being exact about, because a suggestion is a small act of exposure.
+
+**A suggestion carries your name to the people who run the room, and to nobody else in it.** Whoever is deciding cannot weigh a stack of anonymous proposals, and cannot come back to you about one either. So they see who asked.
+
+The other members of your room do not see your suggestion at all. Not while it waits, not after it is accepted, not after it is declined. You see your own, and what became of each one.
+
+While a suggestion is still waiting you can withdraw it. Once it has been answered it stays as part of the room's record, the same way the room's Threads do.
+
+---
+
+## Turning it on
+
+In a shared space, open the room's settings and find **What we study next**. Two choices: off, or members can suggest.
+
+Once it is on, a **What's next** row appears in the room's Tools for everyone in it. Whoever runs the room sees how many suggestions are waiting and how many are new. Everyone else sees an invitation to say something, and their own suggestions underneath it.
+
+Hosting a shared space needs the Shared Spaces add-on. Joining one, and suggesting in one, is free.
+
+---
+
+For the day's own record of this release, see [2026-09-05](../2026-09-05.md).


### PR DESCRIPTION
"What should we study next?" is a question every group that studies together has to answer, and the thing that answers it is a product story rather than a line in a day's record. So it gets a launch note, the third one, alongside Harvous for churches and Harvous 3.0.

`release-notes/launches/shared-space-study-suggestions.md` covers what a member can suggest and the sentence on why, how the room's owner and leaders answer, what accepting one does to the room, and who sees what.

## What it says the feature does not do

Three decisions people will otherwise read as omissions, said plainly:

- **The room does not vote.** Whoever runs it decides. A vote turns a pastoral judgment about what a particular group needs next into a popularity contest, and puts the leader in the position of either following it or publicly overruling it.
- **Nothing happens on a clock.** No deadline, no reminder, no notification.
- **It is off until a room turns it on.**

The privacy section is exact, because a suggestion is a small act of exposure: it carries your name to the people who run the room and to nobody else in it, other members never see it at any stage, and you can withdraw one while it waits.

Nothing about voting or slates is described as coming. That work is designed and unbuilt, and a launch note is not the place to promise it.

## The dated note loses its retelling

Per the folder's own rule — "the dated notes stay terse and link to it rather than retelling it; duplicated copy in two places is how this folder rots" — September 5's section is now a pointer. The study-tools half of v3.4.0 stays there, since co-leaders, presence, annotation replies and note templates are not part of this story.

`README.md` gains an index entry above Harvous 3.0, newest first.

## Checks

Every claim was read back against the shipped code rather than written from memory: the setting is labelled "What we study next", the Tools row is "What's next", the mode is `'off' | 'suggest'`, and the queue meta counts waiting and new. No emoji in any of the three files, and both relative links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)