### PR TITLE
Recognise a row whose title was edited on the site

### DIFF
--- a/Changelog/3.5.3.md
+++ b/Changelog/3.5.3.md
@@ -1,0 +1,19 @@
+# Version 3.5.3
+
+**Release Date**: September 5, 2026
+
+## Fixes
+
+- A row keeps its identity when its title is edited on the site
+
+## Documentation
+
+- A launch note for the suggestion box
+- Describe the whole of September 5, not a third of it
+- Fold the install work into September 5
+
+## Other Changes
+
+- 3.3.0's pricing entry takes the title the site published (#77)
+- Ratchet the bundle budget down to what main actually ships
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.5.2
+**Version:** 3.5.3
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-5-2';
+const CACHE_NAME = 'harvous-cache-v3-5-3';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/scripts/__tests__/export-changelog-csv.test.js
+++ b/scripts/__tests__/export-changelog-csv.test.js
@@ -29,6 +29,37 @@ function csvWith(rows) {
 
 const SEP_5 = "Sat Sep 05 2026 12:00:00 GMT+0000 (Coordinated Universal Time)";
 
+function rowsIn(path) {
+  return readFileSync(path, "utf-8").split("\n").filter((l) => l.trim()).length - 1;
+}
+
+describe("recognising a row that is already published", () => {
+  it("does not re-add an entry whose title was edited in the CSV", () => {
+    // Export once so the CSV holds real rows, slugs included.
+    const csvPath = csvWith([row({ name: "Older row", version: "3.4.0", date: SEP_5 })]);
+    exportChangelogToMarketingSite({ csvPath, backfill: true, quiet: true });
+
+    // Rewrite one Name and leave its Slug alone — what b6fbf6d did by hand.
+    const lines = readFileSync(csvPath, "utf-8").split("\n");
+    // An unquoted Name, so replacing the first field cannot corrupt the row.
+    const idx = lines.findIndex(
+      (l, i) => i > 0 && l.trim() && !l.startsWith('"') && !l.startsWith("Older row")
+    );
+    expect(idx).toBeGreaterThan(0);
+    const originalName = lines[idx].slice(0, lines[idx].indexOf(","));
+    lines[idx] = `A clearer hand-written title${lines[idx].slice(originalName.length)}`;
+    writeFileSync(csvPath, lines.join("\n"), "utf-8");
+
+    const before = rowsIn(csvPath);
+    exportChangelogToMarketingSite({ csvPath, backfill: true, quiet: true });
+
+    // Without the slug check the original wording comes back and the release
+    // note lists the same change twice.
+    expect(rowsIn(csvPath)).toBe(before);
+    expect(readFileSync(csvPath, "utf-8")).toContain("A clearer hand-written title");
+  });
+});
+
 describe("backfill and the high-water mark", () => {
   it("recovers a version that merged below the mark", () => {
     const csvPath = csvWith([row({ name: "Older row", version: "3.4.0", date: SEP_5 })]);

--- a/scripts/export-changelog-csv.js
+++ b/scripts/export-changelog-csv.js
@@ -186,17 +186,40 @@ function rowFingerprint(version, title) {
   return `${version}\n${title.toLowerCase().trim()}`;
 }
 
+/**
+ * The second way to recognise a row that is already published.
+ *
+ * A title can be edited in the CSV after export — harvous.com did it in b6fbf6d,
+ * rewriting "$6/mo and $36/yr, and the founding discount retired" to the clearer
+ * "Harvous Plus is now $6/mo or $36/yr". The version+title fingerprint stopped
+ * matching, so every later sync re-added the original wording and the release
+ * note listed one price change twice.
+ *
+ * Such an edit changes the Name column and leaves Slug alone, so the slug still
+ * identifies the row. This is checked in ADDITION to the title, never instead of
+ * it: a slug is derived from the title (createSlug hashes version:index:name),
+ * so rewording the changelog file itself still produces a new slug and this test
+ * would not catch it. Both together only ever skip more rows than before, which
+ * is why adding it cannot resurrect the legacy backlog.
+ */
+function slugFingerprint(slug) {
+  return `slug\n${slug.toLowerCase().trim()}`;
+}
+
 function loadExistingFingerprints(csvText) {
   const rows = parseCsvRows(csvText);
   const headers = rows[0] ?? [];
   const versionIdx = headers.indexOf("Version Number");
   const nameIdx = headers.indexOf("Name");
+  const slugIdx = headers.indexOf("Slug");
   const seen = new Set();
 
   for (const values of rows.slice(1)) {
     const version = values[versionIdx]?.trim();
     const name = values[nameIdx]?.trim();
+    const slug = values[slugIdx]?.trim();
     if (version && name) seen.add(rowFingerprint(version, name));
+    if (slug) seen.add(slugFingerprint(slug));
   }
 
   return seen;
@@ -396,8 +419,9 @@ export function exportChangelogToMarketingSite(options = {}) {
     const rows = changelogRowsFromFile(filepath);
     for (const row of rows) {
       const fp = rowFingerprint(row.version, row.title);
-      if (seen.has(fp)) continue;
+      if (seen.has(fp) || seen.has(slugFingerprint(row.slug))) continue;
       seen.add(fp);
+      seen.add(slugFingerprint(row.slug));
       newLines.push(buildCsvRow(row));
     }
   }


### PR DESCRIPTION
harvous.com rewrote a row's `Name` by hand in `b6fbf6d` — "$6/mo and $36/yr, and the founding discount retired" became the clearer **"Harvous Plus is now $6/mo or $36/yr"**. The exporter fingerprints **version+title**, so it stopped recognising the row and re-added the original wording on every sync while 3.3.0 sat in the backfill window. `/release-notes/v3-3-11/` listed one price change twice, and deleting the extra row on the site didn't hold — the next sync put it straight back.

[#77](https://github.com/harvouscom/harvous/pull/77) fixed that instance by matching the title in `Changelog/3.3.0.md`. This fixes the shape of it: a row is now also recognised by its **Slug**, which a hand edit to `Name` leaves alone.

## Additive, deliberately

Checked *in addition to* the title, never instead of it — for two reasons:

- **It isn't a superset.** A slug is derived from the title (`createSlug` hashes `version:index:name`), so rewording the changelog file itself still produces a new slug and the slug test would miss it. Only the pair covers both directions.
- **It's what makes this safe.** Two checks can only ever skip *more* rows than before, never fewer. That's the opposite of loosening the version floor, which re-exported 888–1321 legacy rows when I measured it while fixing [#73](https://github.com/harvouscom/harvous/pull/73).

## Measured against the live CSV

| scenario | current | with this change |
|---|---|---|
| normal run | `CSV already up to date` | `CSV already up to date` |
| one row's `Name` rewritten, `Slug` untouched | 1375 → **1376** (duplicate) | 1375 → **1375** |

## Test

Third case added to `scripts/__tests__/export-changelog-csv.test.js`. It exports once so the CSV holds real rows and slugs, rewrites one `Name` leaving its `Slug` alone, and asserts the row count doesn't move. Fails without the change:

```
× does not re-add an entry whose title was edited in the CSV
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)