### PR TITLE
Staging cannot take over a device's production push subscription

### DIFF
--- a/Changelog/3.5.4.md
+++ b/Changelog/3.5.4.md
@@ -1,0 +1,8 @@
+# Version 3.5.4
+
+**Release Date**: September 6, 2026
+
+## Fixes
+
+- Staging cannot take over a device's production subscription
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.5.3
+**Version:** 3.5.4
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-5-3';
+const CACHE_NAME = 'harvous-cache-v3-5-4';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/release-notes/2026-09-06.md
+++ b/release-notes/2026-09-06.md
@@ -1,0 +1,21 @@
+# What's New in Harvous — September 6, 2026
+
+**Release Date:** September 6, 2026
+**Version:** v3.5.4
+
+> DRAFT — generated from commit subjects, not written for users yet.
+> Rewrite each line as what changed for the reader, then delete this banner.
+> See release-notes/README.md for tone, or run /marketing-agent.
+
+---
+
+## Updates in This Release
+
+### General improvements
+
+**What changed:**
+- Staging cannot take over a device's production subscription
+
+**How it helps you:**
+- TODO — what this does for the reader.
+

--- a/server/routes/__tests__/push-routes.test.ts
+++ b/server/routes/__tests__/push-routes.test.ts
@@ -218,3 +218,35 @@ describe('manifest', () => {
     expect(sizes).toContain('512x512');
   });
 });
+
+/*
+ * Staging and production are two Workers proxying /api/* to one Fly machine, and the live
+ * Clerk cookie reaches both — so enabling reminders on new.harvous.com used to write a row
+ * against the developer's real userId, and the displacement delete (keyed on userId+userAgent,
+ * not origin) then removed their genuine app.harvous.com subscription.
+ */
+describe('subscribe refuses an origin the reminders are not sent for', () => {
+  const push = () => source('server/routes/push.ts');
+
+  it('judges the Origin before writing anything', () => {
+    const text = push();
+    const block = routeBlock(text, "app.post('/api/push/subscribe'");
+    expect(block).toContain('isSubscribableOrigin(c)');
+    // Ordering is the whole point: judged after the insert is a row already written.
+    expect(block.indexOf('isSubscribableOrigin(c)')).toBeLessThan(
+      block.indexOf('.insert(PushSubscriptions)'),
+    );
+  });
+
+  it('answers with a code the client can act on, not a bare failure', () => {
+    expect(routeBlock(push(), "app.post('/api/push/subscribe'")).toContain("code: 'wrong_origin'");
+  });
+
+  it('leaves localhost and non-browser callers alone', () => {
+    const text = push();
+    // Browsers set Origin on every POST, same-origin included, so a request without one is
+    // not a browser — failing those closed would break callers this has no quarrel with.
+    expect(text).toContain('if (!origin) return true;');
+    expect(text).toContain("hostname === 'localhost'");
+  });
+});

--- a/server/routes/push.ts
+++ b/server/routes/push.ts
@@ -32,6 +32,7 @@ import {
 } from '../utils/push-reminders';
 import { isPushRemindersSchemaMissing } from '../utils/pg-undefined-relation';
 import { isValidIanaTimeZone } from '../utils/votd-local-date';
+import { getPublicAppOrigin } from '../utils/public-app-origin';
 import {
   countSubscriptionsForUser,
   deleteSubscriptionForUser,
@@ -98,6 +99,40 @@ app.get('/api/push/vapid-public-key', (c) => {
   return c.json({ publicKey: key, configured });
 });
 
+/**
+ * Whether this subscribe came from the origin the reminders are actually sent for.
+ *
+ * `new.harvous.com` (staging) and `app.harvous.com` are two Workers proxying `/api/*` to the
+ * same Fly machine, one database, one VAPID keypair. The live Clerk cookie is scoped wide
+ * enough that `auth.ts` lists both origins in PRODUCTION_AUTHORIZED_PARTIES, so a developer
+ * opening staging is authenticated as their real self.
+ *
+ * Without this check, enabling notifications on staging wrote a subscription against that
+ * real userId — and the displacement delete below, which keys on (userId, userAgent) and not
+ * on origin, then removed their genuine app.harvous.com row. Their production reminders
+ * silently began arriving in the staging PWA instead. Storing it under a second origin rather
+ * than displacing would be no better: sendToUser() selects every row for the user, so the
+ * next reminder would go out twice.
+ *
+ * A subscription belongs to one origin, so the honest answer is to decline the ones that
+ * cannot be served, and say so.
+ *
+ * Absent Origin is allowed. Browsers set it on every POST, same-origin included, so a request
+ * without one is not a browser — and failing those closed would break callers this has no
+ * quarrel with, to guard against a case that cannot occur.
+ */
+function isSubscribableOrigin(c: Context): boolean {
+  const origin = c.req.header('Origin')?.trim();
+  if (!origin) return true;
+  try {
+    const url = new URL(origin);
+    if (url.hostname === 'localhost' || url.hostname === '127.0.0.1') return true;
+  } catch {
+    return false;
+  }
+  return origin.replace(/\/$/, '') === getPublicAppOrigin(c).replace(/\/$/, '');
+}
+
 // ─── POST /api/push/subscribe ────────────────────────────────────────────────
 
 app.post('/api/push/subscribe', requireAuth, rateLimit('write'), async (c) => {
@@ -106,6 +141,17 @@ app.post('/api/push/subscribe', requireAuth, rateLimit('write'), async (c) => {
     const body = await c.req.json();
     const subscription = readSubscription(body?.subscription);
     if (!subscription) return c.json({ error: 'Invalid subscription' }, 400);
+
+    if (!isSubscribableOrigin(c)) {
+      return c.json(
+        {
+          error: 'Reminders are set up on the main app, not this preview',
+          code: 'wrong_origin',
+          appOrigin: getPublicAppOrigin(c),
+        },
+        409,
+      );
+    }
 
     const userAgent =
       typeof body?.userAgent === 'string' ? body.userAgent.slice(0, 512) : c.req.header('User-Agent')?.slice(0, 512) ?? null;

--- a/spa/src/lib/push-reminders.ts
+++ b/spa/src/lib/push-reminders.ts
@@ -18,7 +18,7 @@
  * subscription re-sync, so anything heavy here would land in the eager bundle.
  */
 import { reportDiagnosticEvent } from '@/utils/diagnostics-client';
-import { api } from './api';
+import { api, APIError } from './api';
 import { isPWA } from '@/utils/content-list-helpers';
 import { isIOS } from '@/utils/platform-detect';
 import { browserIanaTimeZone } from './votd-today';
@@ -107,6 +107,11 @@ async function postSubscription(subscription: PushSubscription): Promise<number>
   return response.deviceCount ?? 1;
 }
 
+/** The server declined to store this subscription because the origin is not the app's. */
+function isWrongOrigin(error: unknown): boolean {
+  return error instanceof APIError && error.code === 'wrong_origin';
+}
+
 export interface EnableResult {
   ok: boolean;
   support: PushSupport;
@@ -157,6 +162,19 @@ export async function enablePushReminders(): Promise<EnableResult> {
      * So the reader gets a sentence they can act on, and the raw text goes where it is
      * useful instead.
      */
+    /*
+     * Staging asked to be sent production's reminders and the server declined. Saying the
+     * browser would not complete the setup would be a lie, and the one thing a developer
+     * needs to know here is that the button works — just not on this host.
+     */
+    if (isWrongOrigin(error)) {
+      return {
+        ok: false,
+        support: 'granted',
+        error: 'Reminders are set up on the main app, not this preview.',
+      };
+    }
+
     const raw = error instanceof Error ? error.message : String(error);
     reportDiagnosticEvent({
       source: 'client_js',


### PR DESCRIPTION
`new.harvous.com` and `app.harvous.com` are two Workers proxying `/api/*` to the **same Fly machine** — one database, one VAPID keypair, one Clerk secret. `auth.ts:28` lists both origins in `PRODUCTION_AUTHORIZED_PARTIES`, so a developer who opens staging is authenticated as their real self.

## The bug

Enabling notifications on staging wrote a subscription against that real `userId`. The displacement delete at `server/routes/push.ts:153` keys on `(userId, userAgent)` with **no mention of origin**, so it removed their genuine `app.harvous.com` row.

Their production reminders then arrived in the staging PWA, and the same request overwrote their production `UserMetadata.timezone`. Nobody else's account is reachable this way — it's the developer's own reminders that quietly stop.

## Why not just scope the delete by origin

Storing both rows instead of displacing doesn't help. `sendToUser()` selects **every** subscription for the user, so the next reminder simply goes out twice. A subscription belongs to one origin, so the honest answer is to decline the ones that can't be served and name the host that can.

## Decisions worth reviewing

- **A missing `Origin` is allowed through.** Browsers set it on every POST, same-origin included, so a request without one isn't a browser. Failing those closed would break callers this has no quarrel with, to guard a case that can't arise. `localhost` is allowed for the usual reason.
- **The client stops blaming the browser.** A reader previously saw *"Your browser would not complete the setup"* — untrue and unactionable. The 409 carries `code: 'wrong_origin'`, and `APIError` already surfaces `code`, so the settings page can say the button works, just not on this host.

## A trap I hit, noted for the next person

`routeBlock()` in `push-routes.test.ts` slices a handler at the next occurrence of `"app."`. An error string ending in *"the main app."* truncated the block and failed **two unrelated pre-existing tests**. Hence the comma in the message. Worth knowing before anyone writes `app.harvous.com` into a route body.

## Verified

- `push-routes.test.ts` 33/33; push + reminders suites 86/86 across 4 files.
- Three new cases: the guard runs *before* the insert, the response carries the code, and localhost / no-Origin still pass.
- `tsc --noEmit`: **278 error lines before and after**, none in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)