### PR TITLE
Staging stops reporting itself as production analytics

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -77,7 +77,18 @@ jobs:
           # across is what failed all three Fly cutovers.
           VITE_CLERK_PUBLISHABLE_KEY: ${{ github.ref_name == 'main' && secrets.VITE_CLERK_PUBLISHABLE_KEY_LIVE || secrets.VITE_CLERK_PUBLISHABLE_KEY_DEV }}
           PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ github.ref_name == 'main' && secrets.VITE_CLERK_PUBLISHABLE_KEY_LIVE || secrets.VITE_CLERK_PUBLISHABLE_KEY_DEV }}
-          PUBLIC_POSTHOG_KEY: ${{ secrets.PUBLIC_POSTHOG_KEY }}
+          # Staging gets no key, so posthog.ts returns before init() and sends nothing.
+          # Unconditional, this was the one var that made new.harvous.com indistinguishable
+          # from production in the dashboard: every staging pageview, identify and capture
+          # landed in the live project, against real user ids because staging authenticates
+          # off the same Clerk cookie. env.DEV is false in a CI build, so the dev suppression
+          # in initPostHog() never applied here.
+          #
+          # Production is untouched — `main` still reads the same secret, so its bundle stays
+          # byte-identical, which is what the "EXACTLY 10 vars" note above is protecting.
+          # A staging-only project would go here as PUBLIC_POSTHOG_KEY_STAGING if the events
+          # ever turn out to be worth keeping.
+          PUBLIC_POSTHOG_KEY: ${{ github.ref_name == 'main' && secrets.PUBLIC_POSTHOG_KEY || '' }}
           PUBLIC_POSTHOG_HOST: ${{ secrets.PUBLIC_POSTHOG_HOST }}
           VITE_CLERK_SHARED_SPACES_PLAN_ID: ${{ secrets.VITE_CLERK_SHARED_SPACES_PLAN_ID }}
           # Public plan identifiers, not secrets (netlify.toml carried them in
@@ -134,6 +145,18 @@ jobs:
           if find dist-spa -type f -size +5242880c ! -name '*.map' | grep -q .; then
             echo "Asset over the 5 MiB Workers limit:" >&2
             find dist-spa -type f -size +5242880c ! -name '*.map' -exec ls -lh {} \; >&2
+            exit 1
+          fi
+
+      # The env expression above is easy to make unconditional again by accident, and the
+      # symptom — staging traffic quietly counted as production — shows up in a dashboard
+      # weeks later rather than in a failed deploy. So the built bundle is asked directly.
+      - name: Assert staging ships no analytics key
+        if: github.ref_name != 'main'
+        run: |
+          if grep -rlq 'phc_' dist-spa; then
+            echo "A PostHog project key was inlined into a staging bundle:" >&2
+            grep -rl 'phc_' dist-spa >&2
             exit 1
           fi
 

--- a/Changelog/3.5.5.md
+++ b/Changelog/3.5.5.md
@@ -1,0 +1,8 @@
+# Version 3.5.5
+
+**Release Date**: September 6, 2026
+
+## Fixes
+
+- Staging stops reporting itself as production
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.5.4
+**Version:** 3.5.5
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-5-4';
+const CACHE_NAME = 'harvous-cache-v3-5-5';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/release-notes/2026-09-06.md
+++ b/release-notes/2026-09-06.md
@@ -1,7 +1,7 @@
 # What's New in Harvous — September 6, 2026
 
 **Release Date:** September 6, 2026
-**Version:** v3.5.4
+**Versions:** v3.5.4–v3.5.5
 
 > DRAFT — generated from commit subjects, not written for users yet.
 > Rewrite each line as what changed for the reader, then delete this banner.
@@ -15,6 +15,7 @@
 
 **What changed:**
 - Staging cannot take over a device's production subscription
+- Staging stops reporting itself as production
 
 **How it helps you:**
 - TODO — what this does for the reader.


### PR DESCRIPTION
`PUBLIC_POSTHOG_KEY` was the one build var set **without a branch condition** — two lines below the Clerk keys that have one:

```yaml
VITE_CLERK_PUBLISHABLE_KEY:  ${{ github.ref_name == 'main' && ...LIVE || ...DEV }}
PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ github.ref_name == 'main' && ...LIVE || ...DEV }}
PUBLIC_POSTHOG_KEY:           ${{ secrets.PUBLIC_POSTHOG_KEY }}          # ← no condition
```

So `new.harvous.com` shipped the live project key, and every staging pageview, identify and capture landed in the production dashboard — **against real user ids**, because staging authenticates off the same Clerk cookie as `app.harvous.com`.

The dev suppression inside `initPostHog()` doesn't cover this: it's gated on `env.DEV`, which is false in a CI build.

## The fix

Staging gets no key. `getPostHogKey()` returns `undefined`, so `initPostHog()` returns before `init()` and nothing is sent.

Production reads the same secret it always did, so its bundle stays byte-identical — which is what the *"EXACTLY the 10 build-time vars Netlify's PRODUCTION context sets"* note above this block exists to protect. A staging-only project would slot in as `PUBLIC_POSTHOG_KEY_STAGING` if those events ever turn out to be worth keeping.

## Why there's an assertion too

This failure is invisible. The expression is easy to make unconditional again, and the symptom is a dashboard slowly filling with staging traffic weeks later — not a deploy that goes red. So the built bundle is asked directly:

```yaml
- name: Assert staging ships no analytics key
  if: github.ref_name != 'main'
  run: |
    if grep -rlq 'phc_' dist-spa; then ... exit 1; fi
```

Checked for false positives before adding it: `phc_` appears nowhere in `posthog-js` (dist or package) and nowhere in our own source, so the only way it reaches `dist-spa` is the injected var.

## Verified

- Workflow parses; the step list is intact and the new assertion sits before `wrangler-action`.
- The staging path of this PR exercises the assertion itself on the way in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)