### PR TITLE
Tell the suggester what happened, and make unread mean unread

### DIFF
--- a/server/routes/__tests__/church-library-routes.test.ts
+++ b/server/routes/__tests__/church-library-routes.test.ts
@@ -328,6 +328,33 @@ describe('suggestion box', () => {
     expect(body).toMatch(/status !== 'open'/);
   });
 
+  it('marks read on reading, not on deciding', () => {
+    /* The bug this closes: `staffReadAt` was only ever written by a review, so
+       every waiting suggestion had a null in it and an unread badge counting
+       nulls would have counted the queue. Reading is its own event now, the way
+       `admin-support-tickets.ts` stamps a ticket when it is opened. */
+    const body = handlerBody(suggestions(), "app.post('/api/church/library/suggestions/mark-read'");
+    expect(body).toContain('assertCanManageChurchLibrary');
+    expect(body).toContain('staffReadAt: new Date()');
+    expect(body).toMatch(/status, 'open'/);
+    expect(body).toContain('isNull(LibraryItemSuggestions.staffReadAt)');
+  });
+
+  it('never lets marking read overwrite when a decision was made', () => {
+    // A reviewed row carries the time it was decided. Someone scrolling past it
+    // afterwards must not restamp that.
+    const body = handlerBody(suggestions(), "app.post('/api/church/library/suggestions/mark-read'");
+    expect(body).toContain('isNull(LibraryItemSuggestions.staffReadAt)');
+    expect(body).not.toMatch(/status, 'approved'/);
+    expect(body).not.toMatch(/status, 'declined'/);
+  });
+
+  it('marking read names nobody', () => {
+    const body = handlerBody(suggestions(), "app.post('/api/church/library/suggestions/mark-read'");
+    expect(body).not.toContain('suggestedByName');
+    expect(body).not.toContain('displayNamesFor');
+  });
+
   it('caps open suggestions per person', () => {
     const text = suggestions();
     expect(text).toContain('OPEN_SUGGESTIONS_MAX');

--- a/server/routes/church-library-suggestions.ts
+++ b/server/routes/church-library-suggestions.ts
@@ -23,6 +23,7 @@ import {
   and,
   eq,
   desc,
+  isNull,
   Churches,
   LibraryItems,
   LibraryItemSuggestions,
@@ -236,6 +237,50 @@ app.get('/api/church/library/suggestions', requireAuth, async (c) => {
     const standardError = handleAPIError(error, {
       endpoint: '/api/church/library/suggestions',
       action: 'library_suggestion_queue',
+    });
+    return c.json({ error: standardError.message, code: standardError.code }, 500);
+  }
+});
+
+// ─── POST /api/church/library/suggestions/mark-read ─────────────────────────
+/**
+ * Staff have looked at the queue.
+ *
+ * `staffReadAt` was only ever stamped by a review, which made it useless as the
+ * unread signal its docblock claims to be: every waiting suggestion had a null
+ * there by definition, so a badge counting nulls would have counted the queue
+ * itself and never gone down until someone approved or declined. It is stamped
+ * on *reading* now, which is what `SupportTickets.adminReadAt` does — see
+ * `admin-support-tickets.ts`, where opening a ticket marks it read.
+ *
+ * Only open rows, and only ones not already stamped: a reviewed suggestion
+ * carries the time it was decided, and that must not be overwritten by someone
+ * scrolling past it afterwards.
+ */
+app.post('/api/church/library/suggestions/mark-read', requireAuth, async (c) => {
+  try {
+    const auth = getAuthenticatedAuth(c);
+    const body = (await c.req.json().catch(() => ({}))) as { orgId?: string };
+
+    const gate = await assertCanManageChurchLibrary(auth.userId, (body.orgId ?? '').trim());
+    if (!gate.ok) return c.json({ error: gate.error, code: gate.code }, gate.status);
+
+    await db
+      .update(LibraryItemSuggestions)
+      .set({ staffReadAt: new Date() })
+      .where(
+        and(
+          eq(LibraryItemSuggestions.churchId, gate.church.id),
+          eq(LibraryItemSuggestions.status, 'open'),
+          isNull(LibraryItemSuggestions.staffReadAt),
+        ),
+      );
+
+    return c.json({ success: true });
+  } catch (error) {
+    const standardError = handleAPIError(error, {
+      endpoint: '/api/church/library/suggestions/mark-read',
+      action: 'library_suggestion_mark_read',
     });
     return c.json({ error: standardError.message, code: standardError.code }, 500);
   }

--- a/spa/src/hooks/queries/__tests__/library-suggestion-unread.test.ts
+++ b/spa/src/hooks/queries/__tests__/library-suggestion-unread.test.ts
@@ -1,0 +1,38 @@
+/**
+ * The unread count on the Suggestions chip.
+ *
+ * Unread means "waiting, and staff have not looked" — not "waiting". Before the
+ * mark-read route existed, `staffReadAt` was written only by a review, so a
+ * count of nulls was the queue's own length and a badge built on it could never
+ * reach zero without someone approving or declining every last row.
+ */
+import { describe, expect, it } from 'vitest';
+import { unreadLibrarySuggestionCount } from '../useChurchLibrary';
+
+describe('unreadLibrarySuggestionCount', () => {
+  it('counts only waiting suggestions nobody has looked at', () => {
+    expect(
+      unreadLibrarySuggestionCount([
+        { status: 'open', staffReadAt: null },
+        { status: 'open', staffReadAt: null },
+        { status: 'open', staffReadAt: '2026-09-06T00:00:00Z' },
+      ]),
+    ).toBe(2);
+  });
+
+  it('does not count what has already been decided', () => {
+    // A reviewed row carries the time it was decided, which is not a "read"
+    // signal — and it is answered either way, so it is not waiting on anyone.
+    expect(
+      unreadLibrarySuggestionCount([
+        { status: 'approved', staffReadAt: null },
+        { status: 'declined', staffReadAt: null },
+      ]),
+    ).toBe(0);
+  });
+
+  it('is zero for an empty queue and for one that has not loaded', () => {
+    expect(unreadLibrarySuggestionCount([])).toBe(0);
+    expect(unreadLibrarySuggestionCount(undefined)).toBe(0);
+  });
+});

--- a/spa/src/hooks/queries/useChurchLibrary.ts
+++ b/spa/src/hooks/queries/useChurchLibrary.ts
@@ -343,6 +343,35 @@ export function useSuggestLibraryItem() {
 }
 
 /**
+ * Staff have looked at the queue. Clears the unread count, changes nothing else.
+ *
+ * Separate from reviewing on purpose: seeing a suggestion is not deciding it,
+ * and a badge that only cleared on a decision would sit there counting the
+ * queue back at whoever had just read it.
+ */
+export function useMarkLibrarySuggestionsRead(orgId: string | null | undefined) {
+  const queryClient = useQueryClient();
+  const trimmed = orgId?.trim() || null;
+
+  return useMutation({
+    mutationFn: () =>
+      api.post<{ success: boolean }>('/api/church/library/suggestions/mark-read', {
+        orgId: trimmed,
+      }),
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['library', 'suggestions', 'queue'] });
+    },
+  });
+}
+
+/** How many waiting suggestions staff have not seen yet. */
+export function unreadLibrarySuggestionCount(
+  suggestions: readonly Pick<LibrarySuggestionForReview, 'status' | 'staffReadAt'>[] | undefined,
+): number {
+  return (suggestions ?? []).filter((row) => row.status === 'open' && !row.staffReadAt).length;
+}
+
+/**
  * Approve or decline. Approving creates the item, so the catalog reads are
  * invalidated too — the new row has to appear where the reviewer expects it.
  */

--- a/spa/src/pages/prototype/PrototypeSuggestResourceSheet.tsx
+++ b/spa/src/pages/prototype/PrototypeSuggestResourceSheet.tsx
@@ -15,13 +15,34 @@ import { createPortal } from 'react-dom';
 import { Drawer, DrawerContent } from '@/components/ui/drawer';
 import Icon from '@/components/react/Icon';
 import { APIError } from '../../lib/api';
-import { useSuggestLibraryItem } from '../../hooks/queries/useChurchLibrary';
+import {
+  useMyLibrarySuggestions,
+  useSuggestLibraryItem,
+  type MyLibrarySuggestion,
+} from '../../hooks/queries/useChurchLibrary';
 import ProtoPopoverShell from './ProtoPopoverShell';
 import ProtoDialogBackdrop, { portaledDialogShellClassName } from './ProtoDialogBackdrop';
 import { useDismissOnOutside } from '../../hooks/usePopoverDismiss';
 import { useProtoOverlayMotion } from '../../hooks/useProtoOverlayMotion';
 import { useSheetPresentation } from './design-system/useSheetPresentation';
 import { useProtoAnchoredPopoverPosition } from './useProtoAnchoredPopoverPosition';
+
+const MINE_STATUS_LABEL: Record<MyLibrarySuggestion['status'], string> = {
+  open: 'Waiting',
+  approved: 'Added to the library',
+  declined: 'Not added',
+};
+
+function relativeDay(iso: string | null): string {
+  if (!iso) return '';
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return '';
+  const days = Math.floor((Date.now() - then.getTime()) / 86_400_000);
+  if (days <= 0) return 'today';
+  if (days === 1) return 'yesterday';
+  if (days < 7) return `${days} days ago`;
+  return then.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
 
 export default function PrototypeSuggestResourceSheet({
   open,
@@ -35,11 +56,24 @@ export default function PrototypeSuggestResourceSheet({
   const { mounted, exiting } = useProtoOverlayMotion(open);
   const cardRef = useRef<HTMLDivElement | null>(null);
   const suggest = useSuggestLibraryItem();
+  /*
+    What you sent, and what became of it.
+
+    The endpoint and this hook shipped with the suggestion box and had no
+    caller, so a congregant sent a link into silence: no confirmation it was
+    still waiting, and no word when it was added or turned down. The queue told
+    staff everything and the person who asked nothing.
+  */
+  const mine = useMyLibrarySuggestions();
 
   const [url, setUrl] = useState('');
   const [note, setNote] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [sent, setSent] = useState(false);
+
+  /* Five is enough to answer "what happened to mine" without the sheet
+     becoming a history page; the endpoint returns up to fifty. */
+  const mineRows = (mine.data?.suggestions ?? []).slice(0, 5);
 
   const { asSheet: shouldUseSheetPresentation } = useSheetPresentation();
   const usePopoverPresentation = !shouldUseSheetPresentation;
@@ -169,6 +203,42 @@ export default function PrototypeSuggestResourceSheet({
         <p className="proto-connect-note-sheet__error" role="alert">
           {error}
         </p>
+      ) : null}
+
+      {/* Shown under the form and under the confirmation alike: the answer to
+          "did that go anywhere" is the same question either way. */}
+      {mineRows.length > 0 ? (
+        <div className="proto-suggest-mine">
+          <p className="proto-inspector-section-title proto-create-folder-sheet__field-label">
+            What you have sent
+          </p>
+          <div className="proto-glass-surface proto-glass-surface--panel proto-church-tools">
+            {mineRows.map((row) => (
+              <div
+                key={row.id}
+                className="proto-church-tools__row proto-church-tools__row--status"
+              >
+                <span className="proto-church-tools__row-icon" aria-hidden>
+                  <Icon name={row.status === 'approved' ? 'check' : 'inbox'} size={13} />
+                </span>
+                <span className="proto-church-tools__row-text">
+                  <span
+                    className="pds-list-title proto-church-tools__row-title proto-marquee"
+                    title={row.title ?? row.url}
+                  >
+                    <span>{row.title ?? row.url}</span>
+                  </span>
+                  <span className="proto-caption proto-church-tools__row-meta proto-marquee-self">
+                    {MINE_STATUS_LABEL[row.status]}
+                    {relativeDay(row.reviewedAt ?? row.createdAt)
+                      ? ` · ${relativeDay(row.reviewedAt ?? row.createdAt)}`
+                      : ''}
+                  </span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
       ) : null}
 
       <div className="proto-add-notes-sheet__footer proto-sheet-footer--stacked">

--- a/spa/src/pages/prototype/library/PrototypeExpandedLibraryManager.tsx
+++ b/spa/src/pages/prototype/library/PrototypeExpandedLibraryManager.tsx
@@ -11,7 +11,7 @@
  * reviewing is a different posture from curating and mixing them would make the
  * queue something you scroll past.
  */
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Icon, { type IconName } from '@/components/react/Icon';
 import ProtoSidebarExpandedPanel from '../ProtoSidebarExpandedPanel';
 import type { ExpandedSidebarToolProps } from '../PrototypeExpandedSidebarHost';
@@ -22,6 +22,9 @@ import { useChurchStaffStatus } from '../../../hooks/queries/useChurchStaffStatu
 import { useProtoShell } from '../../../layouts/proto-shell-context';
 import {
   useChurchLibraryManage,
+  useLibrarySuggestionQueue,
+  useMarkLibrarySuggestionsRead,
+  unreadLibrarySuggestionCount,
   type ChurchLibraryStaffItem,
 } from '../../../hooks/queries/useChurchLibrary';
 import PrototypeLibraryManagerItems from './PrototypeLibraryManagerItems';
@@ -69,6 +72,33 @@ export default function PrototypeExpandedLibraryManager({
     setSelection(null);
   }, []);
 
+  /*
+    The unread count on the Suggestions chip.
+
+    Same query the queue itself runs, so opening the panel costs one request and
+    both surfaces read the same cache. Unread is "waiting, and staff have not
+    looked" — which is a fact this codebase only started recording when the
+    mark-read route below was added; before that `staffReadAt` was stamped by a
+    review, so a count of nulls would have been the queue's own length.
+  */
+  const suggestionQueue = useLibrarySuggestionQueue(orgId, { enabled: canCurate });
+  const unreadSuggestions = unreadLibrarySuggestionCount(suggestionQueue.data?.suggestions);
+  const markRead = useMarkLibrarySuggestionsRead(orgId);
+
+  /* Marked read when staff actually open the view, once per unread batch —
+     not on mount, or the badge would clear itself for someone who never looked
+     at it. */
+  const markedRef = useRef(false);
+  useEffect(() => {
+    if (view !== 'suggestions') {
+      markedRef.current = false;
+      return;
+    }
+    if (markedRef.current || !canCurate || unreadSuggestions === 0) return;
+    markedRef.current = true;
+    markRead.mutate();
+  }, [view, canCurate, unreadSuggestions, markRead]);
+
   const viewSwitcher = (
     <div
       className="proto-chip-bar proto-planner__views"
@@ -86,6 +116,11 @@ export default function PrototypeExpandedLibraryManager({
         >
           <Icon name={option.icon} size={11} aria-hidden />
           <span>{option.label}</span>
+          {option.id === 'suggestions' && unreadSuggestions > 0 ? (
+            <span className="proto-chip__badge" aria-label={`${unreadSuggestions} not yet read`}>
+              {unreadSuggestions}
+            </span>
+          ) : null}
         </button>
       ))}
     </div>

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -7406,6 +7406,62 @@ button.proto-home-card--tappable:focus-visible {
   border-radius: 4px;
 }
 
+/* A count on a chip — how many suggestions staff have not read yet. Sized from
+   the chip's own text so it stays a badge rather than becoming a second label,
+   and tabular so a two-digit count does not shift the chip's width mid-glance. */
+.proto-chip__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  margin-left: 2px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--pds-accent, var(--pds-text-primary));
+  color: var(--pds-bg-page);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+/* What a congregant has sent, under the form they sent it from.
+
+   Padded to the sheet's own 14px column, because it is a sibling of the form
+   rather than a child of it: without this it ran full-bleed and its rows were
+   clipped by the sheet's edges while every label above them stayed inset.
+
+   The rule spans the full width on purpose, matching the footer's own border
+   under it — the divide is the sheet's, not the section's. */
+.proto-suggest-mine {
+  padding: 12px 14px 0;
+  border-top: 0.5px solid var(--pds-border-control);
+}
+
+/* One surface, not two.
+
+   `proto-church-tools` paints a glass panel because on a page it is a card
+   lying on the background. In here the sheet is already that card, so the
+   panel was a second rounded fill inset inside the first, with its own border
+   and shadow. The rows keep every one of their own styles; only the box they
+   arrived in loses its. Same treatment the space Tools popover gives it. */
+.proto-suggest-mine .proto-church-tools {
+  background: none;
+  background-image: none;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+/* The row then supplies its own left edge, since the panel is no longer
+   indenting it. */
+.proto-suggest-mine .proto-church-tools__row {
+  padding-left: 0;
+  padding-right: 0;
+}
+
 /* ── Add to home screen — platform toggle, then steps that look like steps ──
    The list used to be prose in an <ol>, which read as a paragraph with numbers.
    Each step is a row now: a marker, the instruction, and the glyph of the
@@ -23356,6 +23412,23 @@ button.proto-feed-sheet__stat:hover {
   display: inline-flex;
   align-items: center;
   gap: 5px;
+}
+
+/* One surface, not two — the same fix the church suggestion sheet needed. Both
+   of these row lists arrive wearing a glass panel, which is right on a page and
+   wrong inside a sheet that is already the card. */
+.proto-space-suggestions .proto-church-tools {
+  background: none;
+  background-image: none;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+.proto-space-suggestions .proto-church-tools__row {
+  padding-left: 0;
+  padding-right: 0;
 }
 
 /* Same reason as the library queue: inline beside the row, the quiet action


### PR DESCRIPTION
The two halves of the church library's suggestion box that were built on the server and never reached a screen. Same shape as the bug that opened this whole thread: a decision made in a route that nothing renders.

## A congregant could not see what became of their suggestion

`GET /suggestions/mine` and `useMyLibrarySuggestions` shipped with the feature, contract-tested, with zero callers. Someone sent a link to their church and never learned whether it was added, declined, or still sitting there.

The sheet they send from now lists what they have sent, with its outcome and when, under the form. The status words are the reader's, not the queue's: **Waiting**, **Added to the library**, **Not added**.

Read back against the one real suggestion in the production database — a bibleproject.org link sent on August 8th that had been invisible to its sender ever since.

## The unread badge could not have worked

`staffReadAt` was stamped only by a review. So every *waiting* suggestion carried a null in it, and a badge counting nulls would have counted the queue itself and never reached zero until someone approved or declined every last row. The schema comment claims it "drives the unread badge, the way `SupportTickets.adminReadAt` does" — and that precedent stamps a ticket when it is **opened**, not when it is answered.

So reading is its own event now: `POST /suggestions/mark-read`, gated exactly like the queue, stamping open rows that have not been seen. Only open rows, and only unstamped ones — a reviewed suggestion carries the time it was decided and must not be restamped by someone scrolling past it. The Suggestions chip carries the count; opening the view clears it.

## One presentation fix, in two places

The new section arrived full-bleed and wearing its own glass panel, so it was clipped by the sheet's edges while every label above it stayed inset, and it painted a second card inside the first. It takes the sheet's own 14px column now, and the panel loses its fill — the treatment the space Tools popover already documents as "one surface, not two".

**The space suggestion sheet had the identical nested panel** and is fixed in the same commit. It is already in production, so it was shipping the same flaw.

## Verification

- The congregant half was walked end to end against production data, through the real path: Library panel, Resources, Church Library, "Missing something?". Screenshotted before and after the presentation fix.
- **The staff half could not be walked here.** Neither church in this database can load the queue: one is inactive (409) and the other's plan has lapsed (402), and the gate refuses before any suggestion is returned. It is covered by contract tests instead — that mark-read is gated on `manage_library`, touches only open and unstamped rows, and names nobody — plus unit tests on the count itself.
- Full suite passes. Colour tokens clean, bundle budget passes, typecheck ratchet passes at 125.

## Two notes for the reviewer

**No version bump.** Main moved from 3.5.2 to 3.5.5 while this was open, with several sessions bumping. Racing on the number is a guaranteed four-file conflict; stamp it after merge.

**Withdrawing is still not possible on the church side.** The space box lets you take a suggestion back while it waits; this one has no such route. Out of scope here, and worth adding for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)