### PR TITLE
Take back your own library suggestion while it waits

### DIFF
--- a/server/routes/__tests__/church-library-routes.test.ts
+++ b/server/routes/__tests__/church-library-routes.test.ts
@@ -256,6 +256,7 @@ describe('suggestion box', () => {
     for (const marker of [
       "app.post('/api/church/library/suggestions/create'",
       "app.get('/api/church/library/suggestions/mine'",
+      "app.post('/api/church/library/suggestions/withdraw'",
     ]) {
       const body = handlerBody(suggestions(), marker);
       expect(body, marker).not.toMatch(/c\.req\.query\(['"]orgId/);
@@ -326,6 +327,35 @@ describe('suggestion box', () => {
     const body = handlerBody(suggestions(), "app.post('/api/church/library/suggestions/review'");
     expect(body).toContain('ALREADY_REVIEWED');
     expect(body).toMatch(/status !== 'open'/);
+  });
+
+  it('lets someone take back only their own, and only while it waits', () => {
+    const body = handlerBody(suggestions(), "app.post('/api/church/library/suggestions/withdraw'");
+    // All four in the query. Filtering after the fact is how a delete reaches a
+    // row that was never the caller's.
+    expect(body).toContain('eq(LibraryItemSuggestions.suggestedByUserId, auth.userId)');
+    expect(body).toContain("eq(LibraryItemSuggestions.status, 'open')");
+    expect(body).toContain('eq(LibraryItemSuggestions.churchId, viewer.church.id)');
+    expect(body).toContain('db\n      .delete(LibraryItemSuggestions)');
+  });
+
+  it('will not delete a suggestion that has been decided', () => {
+    // An approved one has a library item behind it; a delete here orphans it.
+    // A declined one is the church's record of what was asked.
+    const body = handlerBody(suggestions(), "app.post('/api/church/library/suggestions/withdraw'");
+    expect(body).not.toMatch(/status, 'approved'/);
+    expect(body).not.toMatch(/status, 'declined'/);
+  });
+
+  it('answers a withdraw the same way whoever asks', () => {
+    // Never yours, already decided, or never existed all read as not found, so
+    // a probe cannot tell them apart.
+    const body = handlerBody(suggestions(), "app.post('/api/church/library/suggestions/withdraw'");
+    expect(body.match(/SUGGESTION_NOT_FOUND/g)?.length).toBeGreaterThanOrEqual(2);
+    /* The emitted key, not the word — a handler slice runs to the next `app.`
+       and picks up the following docblock, which names the field it explains.
+       The same trap the attribution test above documents. */
+    expect(body).not.toContain('suggestedByName:');
   });
 
   it('marks read on reading, not on deciding', () => {

--- a/server/routes/church-library-suggestions.ts
+++ b/server/routes/church-library-suggestions.ts
@@ -190,6 +190,65 @@ app.get('/api/church/library/suggestions/mine', requireAuth, async (c) => {
   }
 });
 
+// ─── POST /api/church/library/suggestions/withdraw ──────────────────────────
+/**
+ * Taking your own suggestion back, while it is still waiting.
+ *
+ * A congregant endpoint, so it takes no `orgId` like the other two: the church
+ * comes from the caller's own connection, and the row is found by the caller's
+ * id rather than by a church anyone can name.
+ *
+ * Own and open, both in the query rather than checked afterwards. A reviewed
+ * suggestion is the church's record — the staff decision is how it leaves the
+ * queue — and an approved one has a library item behind it that a delete here
+ * would orphan.
+ *
+ * Not sponsorship-gated, unlike creating one. A lapsed plan should not trap
+ * somebody's link in a queue nobody can act on; taking it back is the one thing
+ * that still ought to work.
+ */
+app.post('/api/church/library/suggestions/withdraw', requireAuth, rateLimit('write'), async (c) => {
+  try {
+    const auth = getAuthenticatedAuth(c);
+    const viewer = await resolveChurchLibraryViewer(auth.userId);
+    if (viewer.kind === 'none') {
+      return c.json({ error: 'Suggestion not found', code: 'SUGGESTION_NOT_FOUND' }, 404);
+    }
+
+    const body = (await c.req.json().catch(() => ({}))) as { suggestionId?: string };
+    const suggestionId = clean(body.suggestionId, 200);
+    if (!suggestionId) {
+      return c.json({ error: 'suggestionId is required', code: 'BAD_REQUEST' }, 400);
+    }
+
+    const deleted = await db
+      .delete(LibraryItemSuggestions)
+      .where(
+        and(
+          eq(LibraryItemSuggestions.id, suggestionId),
+          eq(LibraryItemSuggestions.churchId, viewer.church.id),
+          eq(LibraryItemSuggestions.suggestedByUserId, auth.userId),
+          eq(LibraryItemSuggestions.status, 'open'),
+        ),
+      )
+      .returning({ id: LibraryItemSuggestions.id });
+
+    if (deleted.length === 0) {
+      /* Same answer whether it was never yours, already decided, or never
+         existed — a probe should not learn which. */
+      return c.json({ error: 'Suggestion not found', code: 'SUGGESTION_NOT_FOUND' }, 404);
+    }
+
+    return c.json({ success: true });
+  } catch (error) {
+    const standardError = handleAPIError(error, {
+      endpoint: '/api/church/library/suggestions/withdraw',
+      action: 'library_suggestion_withdraw',
+    });
+    return c.json({ error: standardError.message, code: standardError.code }, 500);
+  }
+});
+
 // ─── GET /api/church/library/suggestions ────────────────────────────────────
 /**
  * The staff review queue.

--- a/spa/src/hooks/queries/useChurchLibrary.ts
+++ b/spa/src/hooks/queries/useChurchLibrary.ts
@@ -343,6 +343,27 @@ export function useSuggestLibraryItem() {
 }
 
 /**
+ * Take your own suggestion back, while it is still waiting.
+ *
+ * No `orgId`, like the other two congregant hooks: the church is the caller's
+ * own. Invalidates the staff queue as well as your list — a withdrawn row has
+ * to leave the queue someone else may be looking at.
+ */
+export function useWithdrawLibrarySuggestion() {
+  const queryClient = useQueryClient();
+  const { userId } = useAuth();
+
+  return useMutation({
+    mutationFn: (input: { suggestionId: string }) =>
+      api.post<{ success: boolean }>('/api/church/library/suggestions/withdraw', input),
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: librarySuggestionsMineQueryKey(userId) });
+      void queryClient.invalidateQueries({ queryKey: ['library', 'suggestions', 'queue'] });
+    },
+  });
+}
+
+/**
  * Staff have looked at the queue. Clears the unread count, changes nothing else.
  *
  * Separate from reviewing on purpose: seeing a suggestion is not deciding it,

--- a/spa/src/pages/prototype/PrototypeSuggestResourceSheet.tsx
+++ b/spa/src/pages/prototype/PrototypeSuggestResourceSheet.tsx
@@ -18,6 +18,7 @@ import { APIError } from '../../lib/api';
 import {
   useMyLibrarySuggestions,
   useSuggestLibraryItem,
+  useWithdrawLibrarySuggestion,
   type MyLibrarySuggestion,
 } from '../../hooks/queries/useChurchLibrary';
 import ProtoPopoverShell from './ProtoPopoverShell';
@@ -65,6 +66,7 @@ export default function PrototypeSuggestResourceSheet({
     staff everything and the person who asked nothing.
   */
   const mine = useMyLibrarySuggestions();
+  const withdraw = useWithdrawLibrarySuggestion();
 
   const [url, setUrl] = useState('');
   const [note, setNote] = useState('');
@@ -235,6 +237,18 @@ export default function PrototypeSuggestResourceSheet({
                       : ''}
                   </span>
                 </span>
+                {/* Only while it waits. Once staff have answered it, the row is
+                    the church's record of what was asked and decided. */}
+                {row.status === 'open' ? (
+                  <button
+                    type="button"
+                    className="proto-sheet-quiet-action"
+                    disabled={withdraw.isPending}
+                    onClick={() => withdraw.mutate({ suggestionId: row.id })}
+                  >
+                    Withdraw
+                  </button>
+                ) : null}
               </div>
             ))}
           </div>

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -7462,6 +7462,14 @@ button.proto-home-card--tappable:focus-visible {
   padding-right: 0;
 }
 
+/* Inline beside the row rather than stacked under it — `proto-sheet-quiet-action`
+   carries `width: 100%` for the footer's stacked case, which here would push the
+   row's text off its own line. Same fix the library queue's actions needed. */
+.proto-suggest-mine .proto-sheet-quiet-action {
+  width: auto;
+  flex-shrink: 0;
+}
+
 /* ── Add to home screen — platform toggle, then steps that look like steps ──
    The list used to be prose in an <ol>, which read as a paragraph with numbers.
    Each step is a row now: a marker, the instruction, and the glyph of the


### PR DESCRIPTION
The last difference between the church suggestion box and the space one. Since yesterday a congregant can see what became of their link; now they can change their mind about it while it is still waiting.

## What it refuses to do

**Own and open, both in the query.** Filtering after the fact is how a delete reaches a row that was never the caller's.

**A decided suggestion stays.** An approved one has a library item behind it that a delete here would orphan; a declined one is the church's record of what was asked. Withdrawing is for the window before anyone has answered.

**Not yours, already decided, or never existed all answer the same** — not found — so a probe cannot tell them apart.

**No orgId**, like the other congregant endpoints: the church comes from the caller's own connection, so a suggestion can only ever be withdrawn from the church they actually belong to. The contract test enforcing that now covers three handlers rather than two.

**Not sponsorship-gated**, unlike creating one. A lapsed plan should not trap somebody's link in a queue nobody can act on — taking it back is the one thing that ought to keep working. That is a deliberate difference from `create`, which is gated.

## Verification

The button renders inline beside the waiting row, on open suggestions only — walked through the real path and screenshotted.

**I did not press it.** The only suggestion in this database is a real one of Derek's from August 8th, and because that church's plan has lapsed, `create` returns 402 — so a withdrawn row could not be put back. Deleting real data to demonstrate a delete is not a trade worth making.

Instead the route was exercised live without touching it:

```
POST /withdraw {"suggestionId":"libsg_0000…"}  -> 404 SUGGESTION_NOT_FOUND
POST /withdraw {}                              -> 400 BAD_REQUEST
GET  /suggestions/mine                         -> the real row still present
```

That covers auth, the viewer resolution, the scoped query and the not-found path end to end. The delete path itself is covered by the contract tests.

Full suite passes at 5,711. Typecheck ratchet passes at 125, bundle budget passes.

## Note

**No version bump.** The hook drafted 3.6.0, but main has moved four times today with several sessions bumping. Stamp it after merge, along with yesterday's install work and the church library fixes, which are also unstamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)