### PR TITLE
The passage card's Not now had no styles at all

### DIFF
--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -7406,6 +7406,63 @@ button.proto-home-card--tappable:focus-visible {
   border-radius: 4px;
 }
 
+/* The room's passage card, and the "Not now" that rests it.
+
+   The markup puts that control outside the card deliberately — the card is one
+   big button and a button cannot nest in one — but it shipped with no styles at
+   all under either class name. So it fell into the flow as a plain block above
+   the card, left-aligned, reading as a stray link sitting on the card's own
+   "Showing up in your notes" eyebrow.
+
+   Treated as the daily passage pill's dismiss is treated, because it is the
+   same gesture on the same kind of card: a small pill in the corner, out of the
+   way until wanted, and always present where there is no hover to reveal it. */
+.proto-space-passage {
+  position: relative;
+}
+
+.proto-space-passage__rest {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border: none;
+  border-radius: 999px;
+  background: var(--pds-glass-shell);
+  box-shadow: var(--pds-glass-rim);
+  -webkit-backdrop-filter: var(--pds-glass-blur-control);
+  backdrop-filter: var(--pds-glass-blur-control);
+  font-family: var(--pds-font-body);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--pds-text-secondary);
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+.proto-space-passage:hover .proto-space-passage__rest,
+.proto-space-passage:focus-within .proto-space-passage__rest {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.proto-space-passage__rest:hover {
+  color: var(--pds-text-primary);
+}
+
+/* No hover to reveal it on a touch screen, so it simply stays. */
+@media (hover: none) {
+  .proto-space-passage__rest {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
 /* A count on a chip — how many suggestions staff have not read yet. Sized from
    the chip's own text so it stays a badge rather than becoming a second label,
    and tabular so a two-digit count does not shift the chip's width mid-glance. */


### PR DESCRIPTION
You spotted a stray "Not now" floating above the passage card in a shared space. It is worse than a positioning slip: **the two class names that control it appear in no stylesheet in this repo.**

`.proto-space-passage` and `.proto-space-passage__rest` were written into `PrototypeSpaceHub` and never given rules, so the button fell into normal flow — a plain, unstyled block above the card, left-aligned, sitting on top of the card's own "Showing up in your notes" eyebrow. It reads as a link somebody forgot to delete.

The component's own comment explains why it sits outside the card: the card is one big button, and a button cannot nest inside one. That reasoning was right; nothing ever put the control where the arrangement intended.

## The treatment

The same one `.proto-daily-passage-pill__dismiss` already uses, because it is the same gesture on the same kind of card: a small pill in the card's top-right corner, hidden until hover or focus, and always visible under `@media (hover: none)` where there is nothing to hover with.

## Verification

Seeing this required a space with one passage cited across two notes, and no room in the database had one — the space in your screenshot is not in the current account's spaces. So I made the condition in a throwaway room, confirmed both states, and deleted it.

- At rest: `position: absolute`, opacity 0, 8px below the card's top and 10px in from its right. No stray text above the card.
- On hover: the pill appears in the corner, `aria-label` reading "Not now — rest Romans 8:28".

The throwaway room and its two notes are deleted. Colour tokens clean, bundle budget passes, tests pass.

## Note

No version bump — main has moved five times today with other sessions bumping. This joins the install work, the church library fixes and withdraw as unstamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)