### PR TITLE
feat(onboarding): offer reminders, appearance and import where new accounts look

### DIFF
--- a/Changelog/3.6.0.md
+++ b/Changelog/3.6.0.md
@@ -1,0 +1,13 @@
+# Version 3.6.0
+
+**Release Date**: September 6, 2026
+
+## Features
+
+- Offer reminders, appearance and import where new accounts look
+- Take back your own suggestion while it waits
+
+## Fixes
+
+- Tell the suggester what happened, and make unread mean unread
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.5.5
+**Version:** 3.6.0
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.5.5",
+  "version": "3.6.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-5-5';
+const CACHE_NAME = 'harvous-cache-v3-6-0';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/release-notes/2026-09-06.md
+++ b/release-notes/2026-09-06.md
@@ -1,7 +1,7 @@
 # What's New in Harvous — September 6, 2026
 
 **Release Date:** September 6, 2026
-**Versions:** v3.5.4–v3.5.5
+**Versions:** v3.5.4–v3.6.0
 
 > DRAFT — generated from commit subjects, not written for users yet.
 > Rewrite each line as what changed for the reader, then delete this banner.
@@ -14,8 +14,18 @@
 ### General improvements
 
 **What changed:**
+- Take back your own suggestion while it waits
 - Staging cannot take over a device's production subscription
 - Staging stops reporting itself as production
+- Tell the suggester what happened, and make unread mean unread
+
+**How it helps you:**
+- TODO — what this does for the reader.
+
+### Visual polish
+
+**What changed:**
+- Offer reminders, appearance and import where new accounts look
 
 **How it helps you:**
 - TODO — what this does for the reader.

--- a/release-notes/2026-09-06.md
+++ b/release-notes/2026-09-06.md
@@ -3,30 +3,62 @@
 **Release Date:** September 6, 2026
 **Versions:** v3.5.4–v3.6.0
 
-> DRAFT — generated from commit subjects, not written for users yet.
-> Rewrite each line as what changed for the reader, then delete this banner.
-> See release-notes/README.md for tone, or run /marketing-agent.
+The getting started list now helps you set Harvous up as well as learn it, and reminders are offered on iPhone for the first time outside Settings. If you have sent your church a suggestion, you can now see what became of it, and take it back while it waits.
 
 ---
 
 ## Updates in This Release
 
-### General improvements
+### The getting started list now helps you set Harvous up
 
 **What changed:**
-- Take back your own suggestion while it waits
-- Staging cannot take over a device's production subscription
-- Staging stops reporting itself as production
-- Tell the suggester what happened, and make unread mean unread
+- Three new rows sit under a "Make it yours" heading: turning on reminders, picking how Harvous looks, and bringing in notes from another app.
+- The reminders row only appears when there is something to ask for. If you have already turned reminders on, or told your browser no, it stays out of the way.
+- On an iPhone or iPad in a Safari tab, the row now says that Harvous has to be on your Home Screen first. Until now that was only findable by going into Settings and looking for it.
+- The list still counts only the six things it started with, so the finish line does not move because you have not picked a background yet.
 
 **How it helps you:**
-- TODO — what this does for the reader.
+- The three settings most worth changing early are where you are already looking, instead of behind a menu you have no reason to open on your first day.
+- Saying "not now" to reminders is remembered on your account rather than on the one device, so it does not follow you to your phone and ask again.
+- If you use Harvous on an iPhone, you now find out reminders exist at all. Before this, nothing on the main screen mentioned them.
+- Nothing interrupts. The rows sit in the list, and you can put any of them away on their own.
 
-### Visual polish
+### You can take back a suggestion you sent your church
 
 **What changed:**
-- Offer reminders, appearance and import where new accounts look
+- A suggestion you have sent to your church library can now be withdrawn while it is still waiting.
+- Once it has been approved or declined it stays, since an approved one has a library item behind it and a declined one is your church's record of what was asked.
+- Taking one back keeps working even if your church's plan has lapsed.
 
 **How it helps you:**
-- TODO — what this does for the reader.
+- Changing your mind no longer means asking someone else to undo it for you.
+- A link you sent by mistake does not sit in a queue with your name on it.
 
+### You can see what happened to the suggestions you sent
+
+**What changed:**
+- The sheet you send a suggestion from now lists what you have already sent, and what became of each one.
+- Until now a suggestion went into silence: there was no way to learn whether it had been added to the library or turned down.
+
+**How it helps you:**
+- You know whether your church acted on what you sent, without having to ask.
+- Suggestions sent weeks ago are no longer invisible to the person who sent them.
+
+### Church staff see an accurate count of unread suggestions
+
+**What changed:**
+- The Suggestions chip carries a count of the ones nobody has looked at yet, and opening the view clears it.
+- Reading is now its own thing. Previously a suggestion only stopped being unread once it had been approved or declined, so the count would have described the whole queue rather than what was new in it.
+
+**How it helps you:**
+- The number next to Suggestions means what it looks like it means: things you have not seen.
+- Working through the queue no longer requires deciding on every item just to make the badge go down.
+
+### Smaller fixes
+
+**What changed:**
+- A preview build of Harvous can no longer take over your device's reminder subscription, and no longer describes itself as the live app.
+- The suggestions list arrived wearing a second panel inside the sheet, which clipped it at the edges. It now uses the sheet's own column.
+
+**How it helps you:**
+- If you have ever opened a preview link, your reminders keep arriving from the real app as normal.

--- a/spa/src/pages/prototype/PrototypeOnboardingDock.tsx
+++ b/spa/src/pages/prototype/PrototypeOnboardingDock.tsx
@@ -13,10 +13,12 @@
  * and what the list shows are deliberately different: the count is your progress, the list
  * is what is left.
  */
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
 import { useHarvousIdentity } from '../../hooks/useHarvousIdentity';
 import { guestSignUpHref, leaveForSignUp } from '../../lib/guest-signup';
 import {
+  remindersRowApplies,
   shownOnboardingProgress,
   stepAppliesTo,
   stepIsDone,
@@ -26,7 +28,18 @@ import PrototypeHomeRow from './PrototypeHomeRow';
 import { useOnboardingState } from './useOnboardingState';
 import { PROTO_ONBOARDING_ROW_EXIT_MS, PROTO_ONBOARDING_ROW_DWELL_MS } from '../../layouts/proto-motion';
 import { showPrototypeFeedbackToast } from '@/utils/prototype-feedback-toast';
-import { ONBOARDING_VERSION, type OnboardingStepId } from '@/utils/onboarding-state';
+import { toast } from '@/utils/toast';
+import {
+  prototypeSettingsAppearanceRouteTo,
+  prototypeSettingsDataRouteTo,
+  prototypeSettingsRemindersRouteTo,
+} from '@/lib/prototype-path';
+import type { PushSupport } from '../../lib/push-reminders';
+import {
+  ONBOARDING_VERSION,
+  type OnboardingCustomizeId,
+  type OnboardingStepId,
+} from '@/utils/onboarding-state';
 
 export interface OnboardingStepCopy {
   id: OnboardingStepId;
@@ -84,7 +97,41 @@ export const ONBOARDING_STEP_COPY: readonly OnboardingStepCopy[] = [
   },
 ];
 
-const COPY_BY_ID = new Map(ONBOARDING_STEP_COPY.map((step) => [step.id, step]));
+/**
+ * "Make it yours" — the three offers that are settings rather than lessons.
+ *
+ * Held apart from the tour above, and not just visually. The tour is what the dock is *for*:
+ * finish it and the dock retires. These three tag along because a new account is already
+ * looking here, and because each of them otherwise lives somewhere nobody new goes — reminders
+ * behind a card most readers never qualify for, appearance behind Settings with no pointer at
+ * all. When the tour ends they go with it, and the standing surfaces (`PrototypeRemindersCard`,
+ * Activity's import row) take the offer back over for anyone who never got round to it.
+ */
+export const CUSTOMIZE_STEP_COPY: readonly OnboardingStepCopy[] = [
+  {
+    id: 'reminders',
+    icon: 'bell',
+    title: 'Turn on reminders',
+    meta: 'A verse Sunday morning, a nudge midweek.',
+  },
+  {
+    id: 'appearance',
+    icon: 'paintbrush',
+    title: 'Pick your look',
+    // The same words Settings uses for this category, so arriving there is not a surprise.
+    meta: 'Background color or image behind the app.',
+  },
+  {
+    id: 'import',
+    icon: 'cloud-arrow-up',
+    title: 'Bring your notes in',
+    meta: 'Markdown, Word, Evernote, or a folder of files.',
+  },
+];
+
+const COPY_BY_ID = new Map(
+  [...ONBOARDING_STEP_COPY, ...CUSTOMIZE_STEP_COPY].map((step) => [step.id, step]),
+);
 
 type Props = {
   /** Take the user to where a step gets done. */
@@ -98,8 +145,9 @@ type Props = {
 };
 
 export default function PrototypeOnboardingDock({ onStepAction, variant = 'home' }: Props) {
-  const { state, visible, dismissStep, dismissAll } = useOnboardingState();
+  const { state, visible, dismissStep, dismissAll, markDone } = useOnboardingState();
   const { isGuest } = useHarvousIdentity();
+  const navigate = useNavigate();
 
   /*
    * Rows mid-goodbye: done, but still on screen playing the check and collapse.
@@ -124,6 +172,80 @@ export default function PrototypeOnboardingDock({ onStepAction, variant = 'home'
   const shownProgress = shownOnboardingProgress(state, isGuest);
 
   /*
+   * Whether this device could receive a push at all, resolved in an effect because it is a
+   * live browser read — and, just as usefully, because resolving it warms the module. The row
+   * has to call `enablePushReminders` straight off the tap, and a dynamic import standing
+   * between the click and `requestPermission()` is exactly what iOS refuses to treat as a
+   * gesture. By the time anyone can press the row, the import has already settled.
+   */
+  const [pushSupport, setPushSupport] = useState<PushSupport | null>(null);
+  useEffect(() => {
+    if (isGuest) return;
+    let cancelled = false;
+    void import('../../lib/push-reminders').then((mod) => {
+      if (!cancelled) setPushSupport(mod.getPushSupport());
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isGuest]);
+
+  const customizeRows = CUSTOMIZE_STEP_COPY.filter((step) => {
+    // Every one of these needs an account: a subscription, a synced preference, an import.
+    if (isGuest) return false;
+    if (exiting.includes(step.id)) return true;
+    if (state.steps[step.id].done || state.steps[step.id].dismissed) return false;
+    // The one row whose availability is a fact about the device — see `remindersRowApplies`.
+    if (step.id === 'reminders') return remindersRowApplies(pushSupport);
+    return true;
+  });
+
+  const [enablingReminders, setEnablingReminders] = useState(false);
+
+  const turnOnReminders = useCallback(async () => {
+    setEnablingReminders(true);
+    try {
+      const mod = await import('../../lib/push-reminders');
+      const result = await mod.enablePushReminders();
+      setPushSupport(result.support);
+      if (result.ok) {
+        markDone('reminders');
+        toast.success('Reminders are on. Sunday morning and midweek.');
+      } else if (result.support === 'denied') {
+        toast.error('Notifications are blocked for Harvous in this browser.');
+      } else if (result.error) {
+        toast.error(result.error);
+      }
+    } finally {
+      setEnablingReminders(false);
+    }
+  }, [markDone]);
+
+  const pressCustomizeRow = useCallback(
+    (id: OnboardingCustomizeId) => {
+      if (id === 'reminders') {
+        // On an iPhone in a Safari tab there is nothing to ask for yet; Settings owns the
+        // sheet that explains getting to the Home Screen first.
+        if (pushSupport === 'needs-home-screen') {
+          void navigate({ to: prototypeSettingsRemindersRouteTo() });
+          return;
+        }
+        void turnOnReminders();
+        return;
+      }
+      /*
+       * The other two only open the door. Neither is marked done here — the row is a
+       * shortcut, and arriving somewhere is not the same as doing the thing. Each page
+       * reports its own step when a preset is actually picked or an import actually lands.
+       */
+      void navigate({
+        to: id === 'appearance' ? prototypeSettingsAppearanceRouteTo() : prototypeSettingsDataRouteTo(),
+      });
+    },
+    [navigate, pushSupport, turnOnReminders],
+  );
+
+  /*
    * A row still finishing its exit keeps the dock up — but only when the dock is leaving of
    * its own accord. Completing the last step should play out; being dismissed should not.
    * Without the `dismissed` term, tapping the cluster's × mid-animation would leave the
@@ -140,7 +262,9 @@ export default function PrototypeOnboardingDock({ onStepAction, variant = 'home'
    * still works; completing it no longer counts as dismissing it.
    */
   const showing = !dismissed && (visible || isGuest || exiting.length > 0);
-  const liveIds = showing ? rows.filter((r) => !exiting.includes(r.id)).map((r) => r.id) : [];
+  const liveIds = showing
+    ? [...rows, ...customizeRows].filter((r) => !exiting.includes(r.id)).map((r) => r.id)
+    : [];
   const liveKey = liveIds.join(',');
 
   useEffect(
@@ -163,7 +287,7 @@ export default function PrototypeOnboardingDock({ onStepAction, variant = 'home'
   }, [liveKey]);
 
   useEffect(() => {
-    const newlyDone = ONBOARDING_STEP_COPY.filter(
+    const newlyDone = [...ONBOARDING_STEP_COPY, ...CUSTOMIZE_STEP_COPY].filter(
       (step) => state.steps[step.id].done && renderedRef.current.has(step.id),
     ).map((step) => step.id);
     if (newlyDone.length === 0) return;
@@ -192,7 +316,10 @@ export default function PrototypeOnboardingDock({ onStepAction, variant = 'home'
   }, [state.completedAt, exiting.length]);
 
   // A guest always has the account row, so an empty step list is not an empty dock for them.
-  if (!showing || (rows.length === 0 && !isGuest)) return null;
+  /* The customization rows can outlive the tour rows by a render or two — someone who
+     finishes the last lesson still has "Pick your look" in front of them until the dock
+     itself retires — so an empty tour list is no longer an empty dock. */
+  if (!showing || (rows.length === 0 && customizeRows.length === 0 && !isGuest)) return null;
 
   const list = (
       <div className="proto-glass-surface proto-glass-surface--panel proto-list-panel proto-onboarding-dock__list">
@@ -245,6 +372,70 @@ export default function PrototypeOnboardingDock({ onStepAction, variant = 'home'
           them; this one is the offer the whole mode exists to make, and the dock's own
           dismiss already puts the entire cluster away for anyone who wants it gone.
         */}
+        {/*
+          * "Make it yours", and the reason it is a heading rather than three more rows.
+          *
+          * The rows above are things to learn; these are things to decide. Run together they
+          * read as a nine-item chore list where the last three never get done — which is also
+          * why the count in the header stays on the tour: the finish line should not move
+          * because someone has not picked a background.
+          */}
+        {customizeRows.length > 0 ? (
+          <p className="proto-caption proto-onboarding-dock__section" aria-hidden>
+            Make it yours
+          </p>
+        ) : null}
+
+        {customizeRows.map((step, index) => {
+          const done = exiting.includes(step.id);
+          return (
+            <div
+              key={step.id}
+              className={`proto-onboarding-dock__row${done ? ' proto-onboarding-dock__row--done' : ''}`}
+              style={
+                { '--proto-onboarding-index': rows.length + index } as React.CSSProperties
+              }
+            >
+              <div className="proto-onboarding-dock__row-inner">
+                <PrototypeHomeRow
+                  icon={step.icon}
+                  title={step.title}
+                  meta={[
+                    /* An iPhone in a Safari tab cannot subscribe, and saying "turn on
+                       reminders" to someone who then lands in Settings reads as a dead end.
+                       Say what the next step actually is. */
+                    step.id === 'reminders' && pushSupport === 'needs-home-screen'
+                      ? 'Add Harvous to your Home Screen first.'
+                      : step.meta,
+                  ]}
+                  onClick={
+                    done || (step.id === 'reminders' && enablingReminders)
+                      ? undefined
+                      : () => pressCustomizeRow(step.id as OnboardingCustomizeId)
+                  }
+                  disabled={done || (step.id === 'reminders' && enablingReminders)}
+                  trailing={
+                    done ? (
+                      <span className="proto-onboarding-dock__check" aria-hidden>
+                        <Icon name="check" size={11} />
+                      </span>
+                    ) : (
+                      <button
+                        type="button"
+                        className="proto-side-panel__action-btn"
+                        aria-label={`Dismiss "${step.title}"`}
+                        onClick={() => dismissStep(step.id)}
+                      >
+                        <Icon name="xmark" size={12} aria-hidden />
+                      </button>
+                    )
+                  }
+                />
+              </div>
+            </div>
+          );
+        })}
+
         {isGuest ? (
           <div className="proto-onboarding-dock__row" style={{ '--proto-onboarding-index': rows.length } as React.CSSProperties}>
             <div className="proto-onboarding-dock__row-inner">

--- a/spa/src/pages/prototype/PrototypeRemindersCard.tsx
+++ b/spa/src/pages/prototype/PrototypeRemindersCard.tsx
@@ -1,5 +1,10 @@
 /**
- * The one place reminders are ever offered outside Settings.
+ * Where reminders are offered to a reader who is past the getting-started checklist.
+ *
+ * The checklist has a "Turn on reminders" row of its own, and while that row is up this card
+ * stands down — see `onboardingOwnsOffer`. Two versions of the same question on one screen is
+ * worse than either. This is the surface that catches everyone else: accounts that finished
+ * the tour, dismissed it, or were established before it existed.
  *
  * A pre-prompt, not a permission prompt. Browsers give a site exactly one chance to ask, and
  * a "denied" is permanent until someone goes into site settings — so the real
@@ -17,27 +22,42 @@ import {
   PROTO_PUSH_REMINDERS_DISMISSED_KEY,
   PROTO_PUSH_REMINDERS_PREVIEW_KEY,
 } from '../../layouts/proto-session-keys';
-import { getOnboardingSnapshot } from '../../lib/proto-onboarding-sync';
+import type { PushSupport } from '../../lib/push-reminders';
+import { markOnboardingStep } from '../../lib/proto-onboarding-sync';
+import { useHarvousIdentity } from '../../hooks/useHarvousIdentity';
+import { onboardingOwnsOffer } from './onboarding-visible-steps';
+import { useOnboardingState } from './useOnboardingState';
 import { useDismissibleFlag } from './useDismissibleFlag';
 
 export default function PrototypeRemindersCard() {
-  const [eligible, setEligible] = useState(false);
+  const [support, setSupport] = useState<PushSupport | null>(null);
   const [busy, setBusy] = useState(false);
+  const { state: onboarding, hydrated } = useOnboardingState();
+  const { isGuest } = useHarvousIdentity();
 
-  // Support and checklist state are both live browser reads, so they resolve in an effect
-  // rather than during render — the card must never flash in for someone already subscribed.
+  // Support is a live browser read, so it resolves in an effect rather than during render —
+  // the card must never flash in for someone already subscribed.
   useEffect(() => {
     let cancelled = false;
     void import('../../lib/push-reminders').then((mod) => {
-      if (cancelled) return;
-      const snapshot = getOnboardingSnapshot();
-      const wroteANote = snapshot.state?.steps?.note?.done === true;
-      setEligible(mod.getPushSupport() === 'default' && snapshot.hydrated && wroteANote);
+      if (!cancelled) setSupport(mod.getPushSupport());
     });
     return () => {
       cancelled = true;
     };
   }, []);
+
+  /*
+   * Read from the store rather than a one-shot snapshot, so the card can appear the moment
+   * the checklist retires. Taken once at mount it would stay hidden for the rest of the
+   * session for exactly the reader who had just become its audience.
+   */
+  const wroteANote = onboarding.steps.note.done === true;
+  const eligible =
+    support === 'default' &&
+    hydrated &&
+    wroteANote &&
+    !onboardingOwnsOffer(onboarding, 'reminders', isGuest);
 
   const [visible, dismiss] = useDismissibleFlag(PROTO_PUSH_REMINDERS_DISMISSED_KEY, {
     previewKey: PROTO_PUSH_REMINDERS_PREVIEW_KEY,
@@ -50,6 +70,9 @@ export default function PrototypeRemindersCard() {
       const mod = await import('../../lib/push-reminders');
       const result = await mod.enablePushReminders();
       if (result.ok) {
+        // The checklist counts this even when the offer came from here, so restoring the
+        // tour later does not present a row for something already switched on.
+        markOnboardingStep('reminders');
         toast.success('Reminders are on. Sunday morning and midweek.');
         dismiss();
       } else if (result.support === 'denied') {

--- a/spa/src/pages/prototype/PrototypeStudyFeedToday.tsx
+++ b/spa/src/pages/prototype/PrototypeStudyFeedToday.tsx
@@ -38,6 +38,8 @@ import { useDismissibleImportPrompt } from './use-dismissible-import-prompt';
 import { useNavigate } from '@tanstack/react-router';
 import { useHarvousIdentity } from '../../hooks/useHarvousIdentity';
 import { prototypeSettingsDataRouteTo } from '@/lib/prototype-path';
+import { onboardingOwnsOffer } from './onboarding-visible-steps';
+import { useOnboardingState } from './useOnboardingState';
 import type { SpaceNoteRow } from '../../hooks/queries/useSpace';
 
 /** A note as a Continue row — the sidebar's `HomeNoteCard`, in this surface's row shape. */
@@ -74,7 +76,12 @@ export default function PrototypeStudyFeedToday({
   const scriptureQuery = usePrototypeSpaceScriptureIndex(homeSpaceId ?? undefined);
   const libraryNav = useLibraryPanelNav();
   const navigate = useNavigate();
+  /* The checklist lists importing too, and both land on this same screen. While its row is
+     up, this one steps aside; when the checklist retires, this becomes the only pointer to
+     importing again — which is the audience it was aimed at in the first place. */
+  const { state: onboardingState } = useOnboardingState();
   const { isGuest } = useHarvousIdentity();
+  const onboardingOwnsImport = onboardingOwnsOffer(onboardingState, 'import', isGuest);
   const { dismissed: importDismissed, dismiss: dismissImportPrompt } = useDismissibleImportPrompt();
 
   const {
@@ -228,7 +235,7 @@ export default function PrototypeStudyFeedToday({
             * ending of its own the way "N notes need a folder" does, so without a way to say
             * no it would be permanent furniture. Saying no is permanent too.
             */}
-          {!isGuest && !importDismissed ? (
+          {!isGuest && !importDismissed && !onboardingOwnsImport ? (
             <PrototypeHomeRow
               icon="cloud-arrow-up"
               title="Bring your notes from another app"

--- a/spa/src/pages/prototype/__tests__/onboarding-customize-offers.test.ts
+++ b/spa/src/pages/prototype/__tests__/onboarding-customize-offers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  dismissOnboarding,
+  dismissStep,
+  emptyOnboardingState,
+  markStep,
+  ONBOARDING_STEP_IDS,
+  type OnboardingState,
+} from '@/utils/onboarding-state';
+import { onboardingOwnsOffer, remindersRowApplies, stepAppliesTo } from '../onboarding-visible-steps';
+
+const T1 = '2026-09-06T10:00:00.000Z';
+
+describe('remindersRowApplies', () => {
+  it('offers the row only where there is something to ask for', () => {
+    expect(remindersRowApplies('default')).toBe(true);
+    // The gap this row closes: an iPhone in a Safari tab is never offered reminders by the
+    // standing card, which renders on 'default' alone.
+    expect(remindersRowApplies('needs-home-screen')).toBe(true);
+  });
+
+  it('stays away when the answer is already in', () => {
+    expect(remindersRowApplies('granted')).toBe(false);
+    expect(remindersRowApplies('denied')).toBe(false);
+    expect(remindersRowApplies('unsupported')).toBe(false);
+  });
+
+  it('hides while support is still unresolved, rather than flashing', () => {
+    expect(remindersRowApplies(null)).toBe(false);
+  });
+});
+
+describe('stepAppliesTo', () => {
+  it('keeps the customization rows away from guests', () => {
+    // Each of the three needs an account: a subscription, a synced preference, an import.
+    for (const id of ['reminders', 'appearance', 'import'] as const) {
+      expect(stepAppliesTo(id, true)).toBe(false);
+      expect(stepAppliesTo(id, false)).toBe(true);
+    }
+  });
+});
+
+describe('onboardingOwnsOffer', () => {
+  const live = (): OnboardingState => emptyOnboardingState();
+  const finishedTour = (): OnboardingState => {
+    let state = emptyOnboardingState();
+    for (const id of ONBOARDING_STEP_IDS) state = markStep(state, id, T1);
+    return state;
+  };
+
+  it('claims the offer while the checklist is up and the row unanswered', () => {
+    expect(onboardingOwnsOffer(live(), 'reminders', false)).toBe(true);
+    expect(onboardingOwnsOffer(live(), 'import', false)).toBe(true);
+  });
+
+  it('hands it back once the tour retires', () => {
+    // The standing card and Activity's import row take over here — nobody loses the offer.
+    expect(onboardingOwnsOffer(finishedTour(), 'reminders', false)).toBe(false);
+    expect(onboardingOwnsOffer(finishedTour(), 'import', false)).toBe(false);
+  });
+
+  it('hands it back when the checklist is dismissed', () => {
+    expect(onboardingOwnsOffer(dismissOnboarding(live()), 'import', false)).toBe(false);
+  });
+
+  it('hands it back for a row the reader has already settled', () => {
+    expect(onboardingOwnsOffer(dismissStep(live(), 'import'), 'import', false)).toBe(false);
+    expect(onboardingOwnsOffer(markStep(live(), 'reminders', T1), 'reminders', false)).toBe(false);
+  });
+
+  it('never claims anything for a guest, whose dock shows no such row', () => {
+    // A guest's dock is always visible but lists none of these, so without the guest term
+    // every guest would look like a reader whose checklist owned an offer it was not showing.
+    expect(onboardingOwnsOffer(live(), 'reminders', true)).toBe(false);
+  });
+
+  it('claims nothing before the account has answered', () => {
+    expect(onboardingOwnsOffer(null, 'reminders', false)).toBe(false);
+  });
+});

--- a/spa/src/pages/prototype/import/useImportEngine.ts
+++ b/spa/src/pages/prototype/import/useImportEngine.ts
@@ -6,6 +6,7 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { refreshClientData } from '../../../lib/refresh-client-data';
+import { markOnboardingStep } from '../../../lib/proto-onboarding-sync';
 import {
   MAX_IMPORT_FILES,
   collectFromDataTransfer,
@@ -270,6 +271,10 @@ export function useImportEngine() {
         } catch {
           /* nothing to clean up */
         }
+        /* Only when notes actually landed. A session that finalized having imported
+           nothing — every file a duplicate, or all of them excluded — is not the reader
+           bringing their notes in, and ticking the row would tell them they had. */
+        if (response.summary.notesImported > 0) markOnboardingStep('import');
         void refreshClientData(queryClient);
       })
       .catch((error) => setFatalError(errorMessage(error, "Couldn't finish the import")))

--- a/spa/src/pages/prototype/onboarding-visible-steps.ts
+++ b/spa/src/pages/prototype/onboarding-visible-steps.ts
@@ -9,9 +9,12 @@
 import {
   ONBOARDING_STEP_IDS,
   onboardingProgress,
+  shouldShowOnboarding,
+  type OnboardingCustomizeId,
   type OnboardingState,
   type OnboardingStepId,
 } from '@/utils/onboarding-state';
+import type { PushSupport } from '../../lib/push-reminders';
 import { guestHighlights } from '../../lib/guest-store';
 
 /**
@@ -67,4 +70,55 @@ export function shownOnboardingProgress(
     (id) => GUEST_STEP_IDS.has(id) && stepIsDone(state, id, true),
   ).length;
   return { done, total: GUEST_STEP_IDS.size + 1 };
+}
+
+/**
+ * Whether the checklist is currently making this offer itself.
+ *
+ * Reminders and import each have a standing surface of their own — the card on Home, the
+ * suggestion row in Activity — and both sit on the same screen as the dock. Without this they
+ * would ask the same question twice in one scroll, which reads less like helpfulness and more
+ * like the app having lost track of what it already said.
+ *
+ * So the dock takes precedence while it is up, and the standing surfaces take the offer back
+ * when it retires — which is also what keeps this change from narrowing anything: the import
+ * row was deliberately aimed at every account rather than new ones, because the likeliest
+ * importer is someone with years of notes elsewhere, and that reader still meets it exactly
+ * where they did before.
+ *
+ * `isGuest` is not decoration. A guest's dock is always visible but never lists these rows,
+ * so without it every guest would look like a reader whose checklist owned an offer it was
+ * not showing.
+ */
+export function onboardingOwnsOffer(
+  state: OnboardingState | null,
+  id: OnboardingCustomizeId,
+  isGuest: boolean,
+): boolean {
+  if (!state || isGuest) return false;
+  if (!shouldShowOnboarding(state)) return false;
+  return !state.steps[id].done && !state.steps[id].dismissed;
+}
+
+/**
+ * Whether the "Turn on reminders" row belongs on screen, given what this device can do.
+ *
+ * The only row whose availability is a fact about the device rather than the account, so it
+ * is answered here rather than by the step's stored state:
+ *
+ * - `default` — nothing has been asked yet. This is the row's whole reason to exist.
+ * - `needs-home-screen` — an iPhone in a Safari tab. It keeps the row, and this is the gap
+ *   the row closes: `PrototypeRemindersCard` renders on `default` alone, so until now an
+ *   iPhone reader was never offered reminders anywhere outside Settings.
+ * - `granted` — already on. Hidden without writing the step down, because this is one device
+ *   and the account may well have another that is not subscribed.
+ * - `denied` — the browser will not ask again, and a permanent no should not be re-put. This
+ *   is the same reasoning that keeps the permission prompt off the render path entirely.
+ * - `unsupported` — nothing to offer.
+ *
+ * `null` is "not resolved yet", which hides the row rather than flashing it at someone who
+ * turns out to be subscribed already.
+ */
+export function remindersRowApplies(support: PushSupport | null): boolean {
+  return support === 'default' || support === 'needs-home-screen';
 }

--- a/spa/src/pages/prototype/settings/PrototypeAppearancePage.tsx
+++ b/spa/src/pages/prototype/settings/PrototypeAppearancePage.tsx
@@ -24,6 +24,7 @@ import {
   type ColorSchemePreference,
   type ProtoBg,
 } from '../../../lib/prototype-background';
+import { markOnboardingStep } from '../../../lib/proto-onboarding-sync';
 import { AppearancePreviewTile } from './AppearancePreviewTile';
 import { SettingsGroup, SettingsShell } from './SettingsShell';
 import {
@@ -73,6 +74,7 @@ export default function PrototypeAppearancePage() {
     setBgKind(bg?.kind === 'image-preset' ? 'photos' : 'colors');
     void applyBackgroundWithImageTint(readActiveBackground());
     schedulePushAppearanceToAccount();
+    markOnboardingStep('appearance');
   };
 
   const applyForMode = (mode: 'light' | 'dark', next: ProtoBg) => {
@@ -81,6 +83,10 @@ export default function PrototypeAppearancePage() {
     writeBackgroundForMode(mode, next);
     void applyBackgroundWithImageTint(readActiveBackground());
     schedulePushAppearanceToAccount();
+    /* Latched beside the account write rather than on arrival: the checklist row is a
+       shortcut to this page, and opening a page is not picking anything. Both write points
+       are covered because every real pick funnels through one of them. */
+    markOnboardingStep('appearance');
   };
 
   const onPickColorPreset = (preset: BgPreset) => {

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -20828,6 +20828,25 @@ html.harvous-prototype-route .proto-appearance-hero__specimen[data-font='dyslexi
 }
 
 /*
+ * The break between the tour and "Make it yours".
+ *
+ * Spacing only, no rule: a line across the panel would make two lists out of one card, and
+ * the whole point is that these rows belong to the same ambient group. The label is
+ * `aria-hidden` because the rows beneath it already say what they are — a screen reader
+ * meeting "Make it yours" as a heading would expect a landmark that is not there.
+ */
+.proto-onboarding-dock__section {
+  margin: 10px 0 2px;
+  padding: 0 4px;
+  opacity: 0.62;
+}
+
+/* Nothing above it to separate from when the tour is already finished. */
+.proto-onboarding-dock__section:first-child {
+  margin-top: 0;
+}
+
+/*
  * Collapse without measuring.
  *
  * `grid-template-rows: 1fr → 0fr` animates a row's height without JS ever reading one,

--- a/src/lib/prototype-path.ts
+++ b/src/lib/prototype-path.ts
@@ -339,6 +339,22 @@ export function prototypeSettingsDataRouteTo(): '/prototype/settings/data' {
   return (isDedicatedPrototypeHost() ? '/settings/data' : '/prototype/settings/data') as '/prototype/settings/data';
 }
 
+export function prototypeSettingsAppearanceRouteTo(): '/prototype/settings/appearance' {
+  return (isDedicatedPrototypeHost() ? '/settings/appearance' : '/prototype/settings/appearance') as '/prototype/settings/appearance';
+}
+
+/**
+ * Settings → Reminders.
+ *
+ * The onboarding row only sends anyone here when the device cannot subscribe where it
+ * stands — an iPhone in a Safari tab — because this page owns the install sheet that
+ * explains why. Everywhere else the row turns reminders on in place, since the permission
+ * prompt has to come straight off the tap.
+ */
+export function prototypeSettingsRemindersRouteTo(): '/prototype/settings/reminders' {
+  return (isDedicatedPrototypeHost() ? '/settings/reminders' : '/prototype/settings/reminders') as '/prototype/settings/reminders';
+}
+
 /**
  * Review's two URLs, and Challenges' two.
  *

--- a/src/utils/__tests__/onboarding-state.test.ts
+++ b/src/utils/__tests__/onboarding-state.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
+  ALL_STEP_IDS,
+  CUSTOMIZE_STEP_IDS,
   ONBOARDING_STEP_IDS,
   ONBOARDING_VERSION,
   deriveInitialLatches,
@@ -53,7 +55,7 @@ describe('parseOnboardingState', () => {
 
   it('drops unknown step keys', () => {
     const state = parseOnboardingState('{"steps":{"nonsense":{"done":true},"read":{"done":true}}}');
-    expect(Object.keys(state!.steps).sort()).toEqual([...ONBOARDING_STEP_IDS].sort());
+    expect(Object.keys(state!.steps).sort()).toEqual([...ALL_STEP_IDS].sort());
     expect(state!.steps.read.done).toBe(true);
   });
 
@@ -210,5 +212,85 @@ describe('onboardingProgress', () => {
     expect(progress.done).toBe(1);
     expect(progress.total).toBe(ONBOARDING_STEP_IDS.length - 1);
     expect(progress.visible).not.toContain('recall');
+  });
+});
+
+/*
+ * The customization rows ride in the same record as the tour but must not touch its
+ * lifecycle. Every assertion here is really the same one: shipping a new row cannot bring
+ * the dock back for an account that already finished or dismissed it.
+ */
+describe('customization steps', () => {
+  const completedTour = (): ReturnType<typeof emptyOnboardingState> => {
+    let state = emptyOnboardingState();
+    for (const id of ONBOARDING_STEP_IDS) state = markStep(state, id, T1);
+    return state;
+  };
+
+  it('are stored, parsed and merged like any other step', () => {
+    let state = emptyOnboardingState();
+    state = markStep(state, 'reminders', T1);
+    state = dismissStep(state, 'import');
+    const round = parseOnboardingState(serializeOnboardingState(state))!;
+    expect(round.steps.reminders.done).toBe(true);
+    expect(round.steps.reminders.at).toBe(T1);
+    expect(round.steps.import.dismissed).toBe(true);
+    expect(round.steps.appearance.done).toBe(false);
+  });
+
+  it('do not keep the dock alive once the tour is finished', () => {
+    const state = completedTour();
+    for (const id of CUSTOMIZE_STEP_IDS) {
+      expect(state.steps[id].done).toBe(false);
+      expect(state.steps[id].dismissed).toBe(false);
+    }
+    expect(shouldShowOnboarding(state)).toBe(false);
+  });
+
+  it('do not reopen a dock that was dismissed', () => {
+    expect(shouldShowOnboarding(dismissOnboarding(emptyOnboardingState()))).toBe(false);
+  });
+
+  it('do not delay completedAt', () => {
+    expect(completedTour().completedAt).toBe(T1);
+  });
+
+  it('are left out of the progress count', () => {
+    let state = emptyOnboardingState();
+    state = markStep(state, 'reminders', T1);
+    const progress = onboardingProgress(state);
+    expect(progress.total).toBe(ONBOARDING_STEP_IDS.length);
+    expect(progress.done).toBe(0);
+    expect(progress.visible).not.toContain('reminders');
+  });
+
+  it('survive a merge with a client that predates them', () => {
+    /* What an older build pushes: the tour keys only. Its copy must not read as a "no" on
+       rows it has never heard of, or one stale device would sweep them for the account. */
+    const legacy = parseOnboardingState(
+      JSON.stringify({
+        version: 1,
+        steps: { read: { done: true }, note: { done: true } },
+      }),
+    )!;
+    let account = emptyOnboardingState();
+    account = markStep(account, 'reminders', T1);
+    account = dismissStep(account, 'appearance');
+
+    for (const merged of [
+      mergeOnboardingStates(legacy, account),
+      mergeOnboardingStates(account, legacy),
+    ]) {
+      expect(merged.steps.reminders.done).toBe(true);
+      expect(merged.steps.appearance.dismissed).toBe(true);
+      expect(merged.steps.import.done).toBe(false);
+      expect(merged.steps.read.done).toBe(true);
+    }
+  });
+
+  it('leave room under the write cap when every row is stamped', () => {
+    let state = emptyOnboardingState();
+    for (const id of ALL_STEP_IDS) state = markStep(state, id, T1);
+    expect(serializeOnboardingState(state).length).toBeLessThan(2048);
   });
 });

--- a/src/utils/onboarding-state.ts
+++ b/src/utils/onboarding-state.ts
@@ -23,7 +23,34 @@
  */
 export const ONBOARDING_VERSION = 1;
 
-export type OnboardingStepId = 'read' | 'note' | 'pill' | 'highlight' | 'thread' | 'recall';
+export type OnboardingStepId =
+  | 'read'
+  | 'note'
+  | 'pill'
+  | 'highlight'
+  | 'thread'
+  | 'recall'
+  | OnboardingCustomizeId;
+
+/**
+ * The customization offers — reminders, appearance, import.
+ *
+ * Deliberately *not* part of `ONBOARDING_STEP_IDS`, which is the tour: the six things that
+ * teach someone what Harvous is. These three teach nothing. They are settings worth knowing
+ * about, ridden along in the same dock because that is where a new account is already looking.
+ *
+ * Keeping them out of the tour set is what makes this change free of blast radius. The dock's
+ * whole lifecycle — `shouldShowOnboarding`, `withCompletion`, `onboardingProgress`,
+ * `canRestoreOnboarding`, and the auto-complete seed — is defined over the tour, so adding a
+ * row here cannot un-settle an account that already finished. Folding them in instead would
+ * bring the dock back for everyone who completed it, and the documented remedy for that
+ * (bumping `ONBOARDING_VERSION`) is worse still: it also clears the protection on everyone who
+ * dismissed. A version bump means "the tour changed, ask again". This is not that.
+ *
+ * They still live in the same `steps` record, so they persist, merge, and dismiss through
+ * exactly the machinery the tour uses — see `ALL_STEP_IDS`.
+ */
+export type OnboardingCustomizeId = 'reminders' | 'appearance' | 'import';
 
 /** Display order, and the set `shouldShowOnboarding` counts against. */
 export const ONBOARDING_STEP_IDS: readonly OnboardingStepId[] = [
@@ -35,7 +62,32 @@ export const ONBOARDING_STEP_IDS: readonly OnboardingStepId[] = [
   'recall',
 ];
 
-const STEP_ID_SET = new Set<string>(ONBOARDING_STEP_IDS);
+/** Display order of the "Make it yours" section, beneath the tour. */
+export const CUSTOMIZE_STEP_IDS: readonly OnboardingCustomizeId[] = [
+  'reminders',
+  'appearance',
+  'import',
+];
+
+/**
+ * Every id the `steps` record holds.
+ *
+ * Only the shape-level operations use this — creating the record, narrowing keys off storage,
+ * and merging. Everything that decides what the dock *does* uses `ONBOARDING_STEP_IDS`.
+ */
+export const ALL_STEP_IDS: readonly OnboardingStepId[] = [
+  ...ONBOARDING_STEP_IDS,
+  ...CUSTOMIZE_STEP_IDS,
+];
+
+const STEP_ID_SET = new Set<string>(ALL_STEP_IDS);
+
+const CUSTOMIZE_ID_SET = new Set<string>(CUSTOMIZE_STEP_IDS);
+
+/** Narrow a string back to one of the customization rows. */
+export function isOnboardingCustomizeId(value: string): value is OnboardingCustomizeId {
+  return CUSTOMIZE_ID_SET.has(value);
+}
 
 /** Narrow a string that came from storage or a URL back to a step id. */
 export function isOnboardingStepId(value: string): value is OnboardingStepId {
@@ -93,7 +145,7 @@ export interface OnboardingSignals {
 
 function emptySteps(): Record<OnboardingStepId, OnboardingStepState> {
   const steps = {} as Record<OnboardingStepId, OnboardingStepState>;
-  for (const id of ONBOARDING_STEP_IDS) steps[id] = { done: false, dismissed: false };
+  for (const id of ALL_STEP_IDS) steps[id] = { done: false, dismissed: false };
   return steps;
 }
 
@@ -188,8 +240,12 @@ function mergeStep(a: OnboardingStepState, b: OnboardingStepState): OnboardingSt
  * changes the result, which is the whole reason the sync layer can merge in both directions.
  */
 export function mergeOnboardingStates(a: OnboardingState, b: OnboardingState): OnboardingState {
+  /* Every id, not just the tour: a client that predates the customization rows drops those
+     keys on parse, so its copy reads as `{done:false,dismissed:false}` there and loses the
+     `||` against whatever the account really holds. That is what makes shipping a new row
+     safe without coordinating a client rollout. */
   const steps = {} as Record<OnboardingStepId, OnboardingStepState>;
-  for (const id of ONBOARDING_STEP_IDS) steps[id] = mergeStep(a.steps[id], b.steps[id]);
+  for (const id of ALL_STEP_IDS) steps[id] = mergeStep(a.steps[id], b.steps[id]);
   return {
     version: Math.max(a.version, b.version),
     dismissedVersion: Math.max(a.dismissedVersion, b.dismissedVersion),


### PR DESCRIPTION
The getting-started dock gains a **Make it yours** section holding three customization offers: reminders, appearance, and import.

Two of them already existed but were scattered — a reminders card on Home, an import row inside Activity's `Suggested` list — and both remembered a "no" only in device-local `localStorage`, so a dismissal on the laptop never reached the phone. Appearance had no pointer at all.

Church connect is deliberately **not** here. There is no connect flow to put in a checklist: picking a church in Settings saves Here's My Church directory fields, `connectedChurchId` is then derived silently by `server/utils/church-connection.ts`, and only if an admin already provisioned that church. `ChurchMemberships` has zero readers and zero writers. The prerequisite is a user-visible connected state, not a row.

## The design decision worth reviewing

The customize ids are **not** part of `ONBOARDING_STEP_IDS`. That set is the tour — the six things that teach the app, and the set every lifecycle decision is defined over (`shouldShowOnboarding`, `withCompletion`, `onboardingProgress`, `canRestoreOnboarding`, the auto-complete seed).

Folding three more ids into it would have un-settled every account that had already finished, bringing the dock back for them. The documented remedy for that — bumping `ONBOARDING_VERSION` — is worse still, since it also clears the protection on everyone who dismissed. A version bump means "the tour changed, ask again"; this is not that.

Keeping them apart means **no migration exists to get wrong**, and the count stays `n/6` so the finish line does not recede because someone has not picked a background. The ids still live in the same `steps` record, so they persist, merge and dismiss through the machinery the tour already uses. A client that predates these rows drops the keys on parse, so its copy cannot vote "no" on a row it has never heard of — no coordinated rollout needed.

## Who owns each offer

One rule (`onboardingOwnsOffer`): while the dock lists a row, the standing surface stands down; when the tour retires, it takes the offer back.

Nothing is narrowed. Activity's import row was aimed at every account on purpose — the likeliest importer has years of notes elsewhere, not a first session — and that reader still meets it exactly where they did before.

## Reminders

The only row whose availability is a fact about the device rather than the account, so `remindersRowApplies` answers it: shown on `default` and `needs-home-screen`, hidden on `granted`, `denied` and `unsupported`.

The `needs-home-screen` case closes a real gap — `PrototypeRemindersCard` renders on `default` alone, so **an iPhone in a Safari tab has never been offered reminders outside Settings**. That is arguably the most user-visible thing in this PR.

The permission prompt is still only ever raised straight off a tap, and the row calls `enablePushReminders` in place rather than navigating: a browser denial is permanent, and iOS will not treat a deferred call as a gesture. The module is preloaded when the row renders so the dynamic import has already settled by the time anyone can press it.

Appearance and import latch on the real thing — a preset actually picked, an import that actually landed notes — never on arriving at the page.

## Verification

- **4129 tests pass** (370 files), including 18 new: the merge against a client predating these rows, all five push-support values, every offer-ownership branch, and `shouldShowOnboarding` staying false for both a completed and a dismissed pre-existing account
- **No new type errors** (126 pre-existing at HEAD, 125 after)
- **`perf:check` passes**, no regressions; baseline untouched
- **In the browser on a real established account:** count stayed `0/6`; dismissing the last customize row removed the heading *and* brought Activity's import row back — the handoff working live in both directions. That account's stored state (`completedAt` set, all six done, `dismissedVersion: 0`, no customize keys) is exactly the shape the rejected approach would have broken, and it correctly shows no dock.

**Not verified:** end-to-end push delivery. The only database reachable from this machine is production and the reminders schema was never applied there. `npm run push:schema:apply` must run **before** any deploy touching `UserMetadata`, or `get-profile`, `navigation/data` and `update-onboarding` 500 for every signed-in user.

**Note:** `release-notes/2026-09-06.md` is still an auto-generated draft — it files this under "Visual polish" (wrong; it is a feature) with `TODO` placeholders. Wants a marketing pass before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
