### PR TITLE
chore(dev): cap the reminders worktree's database pool

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -118,7 +118,7 @@
       "runtimeExecutable": "sh",
       "runtimeArgs": [
         "-c",
-        "API_PORT=3004 VITE_API_PROXY_TARGET=http://localhost:3004 npx concurrently --names api,spa -c green,yellow 'npm run dev:api' 'node scripts/wait-for-api.js && npm run dev:spa -- --port 4329 --strictPort'"
+        "API_PORT=3004 DB_POOL_MAX=4 VITE_API_PROXY_TARGET=http://localhost:3004 npx concurrently --names api,spa -c green,yellow 'npm run dev:api' 'node scripts/wait-for-api.js && npm run dev:spa -- --port 4329 --strictPort'"
       ],
       "port": 4329,
       "autoPort": false


### PR DESCRIPTION
One line in `.claude/launch.json`: `reminders-worktree` now sets `DB_POOL_MAX=4`.

It was the only API-spawning worktree config without one, so it asked for the default 10 while other dev servers were already holding connections. Supabase's session pooler caps the project at 15 clients across all of them.

Running it on 2026-09-06 produced exactly the failure `server/db/client.ts` warns about — `EMAXCONNSESSION` on `/api/navigation/data`, with the app rendering signed in and empty rather than looking like a connection problem. Five API processes were up at the time. Four is the same allowance `activity-search-worktree` already takes.

**Left alone deliberately:** `spa` and `spa-alt-ports` are the single-server case the default 10 was chosen for. `shared-spaces-worktree` runs `dev:all` beside the others and is the next one that likely wants a cap, but that is a separate call.

Dev tooling only — no application code, no runtime behavior change. Production reads `DB_POOL_MAX` from its own environment, not from this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
