### PR TITLE
fix(prototype): land the stranded shell fixes, and keep Send a test to development

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -845,36 +845,6 @@ async function setPendingNavigation(url) {
  * fetch is simply killed with it. A failure genuinely is harmless — the next tick settles an
  * unreported delivery by attribution — but never being sent at all is not.
  */
-/**
- * Temporary instrumentation for the notification tap, which has now failed three times for
- * three different reasons and cost a device round trip to diagnose each time.
- *
- * Every detail goes in `message` on purpose: the server's sanitizer keeps only `statusCode`,
- * `apiPath` and `userAgentFamily` out of metadata and silently discards the rest, and drops
- * the whole payload if `anonymousSessionId` is missing — which a worker cannot read from
- * localStorage, so one is minted per event. `appVersion` carries CACHE_NAME because it says
- * which worker build ran, which is the question a stale install makes hard to answer.
- *
- * Remove once the paired `sw parked` / `client navigate` rows show up on every platform.
- */
-const PUSH_NAV_DIAGNOSTICS = true;
-
-function reportSwDiagnostic(message) {
-  if (!PUSH_NAV_DIAGNOSTICS) return Promise.resolve();
-  return fetch('/api/diagnostics/event', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      source: 'client_js',
-      severity: 'warning',
-      message: message,
-      platform: 'web',
-      appVersion: CACHE_NAME,
-      anonymousSessionId: 'sw-' + Math.random().toString(36).slice(2, 11),
-    }),
-  }).catch(() => {});
-}
-
 function reportNotificationEvent(deliveryId, event) {
   if (!deliveryId) return Promise.resolve();
   return fetch('/api/push/event', {
@@ -951,7 +921,6 @@ self.addEventListener('notificationclick', (event) => {
         }
       });
 
-      let handoff;
       if (sameOrigin) {
         await sameOrigin.focus();
         /*
@@ -963,11 +932,9 @@ self.addEventListener('notificationclick', (event) => {
          * nothing is listening yet, which on a cold launch is always.
          */
         sameOrigin.postMessage({ type: 'HARVOUS_NOTIFICATION_NAVIGATE', url: target });
-        handoff = 'focus-post';
       } else {
         // Navigates on its own, so this path never depended on the handoff.
         await self.clients.openWindow(target);
-        handoff = 'open-window';
       }
 
       /*
@@ -982,15 +949,6 @@ self.addEventListener('notificationclick', (event) => {
       await Promise.allSettled([
         navigator.clearAppBadge ? navigator.clearAppBadge() : Promise.resolve(),
         reportNotificationEvent(payload.deliveryId, 'click'),
-        reportSwDiagnostic(
-          // `target`, not payload.url — it is the resolved absolute URL actually parked, and
-          // it is defined even when the payload carried none.
-          '[push-nav] sw parked target=' + target + ' delivery=' + (payload.deliveryId || 'none')
-        ),
-        reportSwDiagnostic(
-          '[push-nav] sw handoff=' + handoff + ' clients=' + clientList.length +
-            ' delivery=' + (payload.deliveryId || 'none')
-        ),
       ]);
     })()
   );

--- a/server/__tests__/sw-push-handlers.test.ts
+++ b/server/__tests__/sw-push-handlers.test.ts
@@ -268,25 +268,6 @@ describe('service worker notificationclick', () => {
     expect(JSON.parse(harness.parked[0]!).url).toBe('https://app.harvous.com/read/today');
   });
 
-  it('emits instrumentation the sanitizer will actually store', async () => {
-    // The server drops any payload without anonymousSessionId, and keeps only three metadata
-    // keys — so the detail has to live in `message` or it vanishes without trace.
-    const harness = loadServiceWorker({ windows: [] });
-    const waits: Promise<unknown>[] = [];
-    harness.listeners.get('notificationclick')!(clickEvent(waits));
-    await Promise.all(waits);
-
-    const diagnostics = harness.fetches.filter((f) => f.url === '/api/diagnostics/event');
-    expect(diagnostics.length).toBeGreaterThanOrEqual(2);
-    for (const call of diagnostics) {
-      expect(call.body.source).toBe('client_js');
-      expect(call.body.severity).toBe('warning');
-      expect(String(call.body.anonymousSessionId)).toMatch(/^sw-/);
-      expect(String(call.body.message)).toContain('[push-nav]');
-    }
-    expect(diagnostics.map((d) => String(d.body.message)).join(' ')).toContain('handoff=open-window');
-  });
-
   it('parks the destination for an app that is still booting', async () => {
     // A message is delivered once, to whoever is listening at that instant. On a cold launch
     // that is nobody — which is the tap that matters most, the one that opens the app.

--- a/spa/src/lib/notification-navigation.ts
+++ b/spa/src/lib/notification-navigation.ts
@@ -19,10 +19,6 @@
  *   3. `addEventListener('message')` does not start the client message queue. Only assigning
  *      `onmessage` or calling `startMessages()` does, per spec.
  */
-import { reportDiagnosticEvent } from '@/utils/diagnostics-client';
-
-declare const __APP_VERSION__: string;
-
 export const NOTIFICATION_NAVIGATE_MESSAGE = 'HARVOUS_NOTIFICATION_NAVIGATE';
 
 /** Must match `PENDING_NAV_CACHE` / `PENDING_NAV_KEY` in public/sw.js. */
@@ -41,11 +37,6 @@ const PENDING_NAV_MAX_AGE_MS = 2 * 60_000;
 /** The message and the visibility peek can both resolve the same tap. Only act once. */
 const DUPLICATE_WINDOW_MS = 5_000;
 
-/** Temporary, paired with `PUSH_NAV_DIAGNOSTICS` in public/sw.js. */
-const PUSH_NAV_DIAGNOSTICS = true;
-
-type NavigationSource = 'message' | 'boot-peek' | 'visible-peek' | 'drain' | 'ready-recheck';
-
 interface NotificationNavigateMessage {
   type: typeof NOTIFICATION_NAVIGATE_MESSAGE;
   url: string;
@@ -59,23 +50,12 @@ interface NotificationNavigateMessage {
  */
 let routerReady = false;
 let queuedPath: string | null = null;
-let queuedAt = 0;
 let lastHandled: { path: string; at: number } | null = null;
 
 function isNavigateMessage(data: unknown): data is NotificationNavigateMessage {
   if (!data || typeof data !== 'object') return false;
   const { type, url } = data as Record<string, unknown>;
   return type === NOTIFICATION_NAVIGATE_MESSAGE && typeof url === 'string' && url.length > 0;
-}
-
-function log(message: string): void {
-  if (!PUSH_NAV_DIAGNOSTICS) return;
-  reportDiagnosticEvent({
-    source: 'client_js',
-    severity: 'warning',
-    message,
-    appVersion: typeof __APP_VERSION__ === 'string' ? __APP_VERSION__ : null,
-  });
 }
 
 /**
@@ -139,13 +119,11 @@ export async function consumePendingNavigation(): Promise<string | null> {
   return path;
 }
 
-function goTo(path: string, via: NavigationSource): void {
+function goTo(path: string): void {
   if (!routerReady) {
     // Held, not dropped, and deliberately not cleared — the parked copy is the only record
     // until something actually navigates.
     queuedPath = path;
-    queuedAt = Date.now();
-    log(`[push-nav] client queued path=${path} via=${via}`);
     return;
   }
 
@@ -160,14 +138,6 @@ function goTo(path: string, via: NavigationSource): void {
     return;
   }
   lastHandled = { path, at: now };
-
-  /*
-   * Logged here, at the call, and never on arrival: `/read/today` is itself a redirect page
-   * that loads a chunk and waits on the verse before it moves, so arrival is seconds later
-   * and says nothing about whether this fired.
-   */
-  const waited = queuedAt ? now - queuedAt : 0;
-  log(`[push-nav] client navigate path=${path} via=${via} waitedMs=${waited}`);
 
   /*
    * Imported here rather than at the top, to break a cycle.
@@ -186,9 +156,9 @@ function goTo(path: string, via: NavigationSource): void {
   void clearPendingNavigation();
 }
 
-function checkPending(via: NavigationSource): void {
+function checkPending(): void {
   void peekPendingNavigation().then((path) => {
-    if (path) goTo(path, via);
+    if (path) goTo(path);
   });
 }
 
@@ -205,11 +175,11 @@ export function markNotificationNavigationReady(): void {
     if (queuedPath) {
       const path = queuedPath;
       queuedPath = null;
-      goTo(path, 'drain');
+      goTo(path);
       return;
     }
     // Covers a destination parked between boot and readiness, which no listener saw.
-    checkPending('ready-recheck');
+    checkPending();
   }, 0);
 }
 
@@ -220,11 +190,11 @@ export function initNotificationNavigation(): () => void {
   const onMessage = (event: MessageEvent) => {
     if (!isNavigateMessage(event.data)) return;
     const path = resolveNotificationPath(event.data.url);
-    if (path) goTo(path, 'message');
+    if (path) goTo(path);
   };
 
   const onVisible = () => {
-    if (document.visibilityState === 'visible') checkPending('visible-peek');
+    if (document.visibilityState === 'visible') checkPending();
   };
 
   navigator.serviceWorker?.addEventListener('message', onMessage);
@@ -232,7 +202,7 @@ export function initNotificationNavigation(): () => void {
   // anything the worker posted before this listener existed.
   navigator.serviceWorker?.startMessages?.();
   document.addEventListener('visibilitychange', onVisible);
-  checkPending('boot-peek');
+  checkPending();
 
   return () => {
     navigator.serviceWorker?.removeEventListener('message', onMessage);
@@ -244,6 +214,5 @@ export function initNotificationNavigation(): () => void {
 export function resetNotificationNavigationForTests(): void {
   routerReady = false;
   queuedPath = null;
-  queuedAt = 0;
   lastHandled = null;
 }

--- a/spa/src/pages/prototype/PrototypeWhatsNewPill.tsx
+++ b/spa/src/pages/prototype/PrototypeWhatsNewPill.tsx
@@ -60,13 +60,11 @@ import Icon from '@/components/react/Icon';
 import PrototypeHomeRow from './PrototypeHomeRow';
 import { useReleaseNotesUrl } from '../../hooks/useReleaseNotesUrl';
 import {
-  PROTO_WELCOME_3_DISMISSED_KEY,
   PROTO_WHATS_NEW_DISMISSED_KEY,
   PROTO_WHATS_NEW_PREVIEW_KEY,
 } from '../../layouts/proto-session-keys';
 import { useDismissibleRelease } from './useDismissibleFlag';
 import { openWelcome3 } from './welcome3-bridge';
-import { readDismissFlag } from './useDismissibleFlag';
 
 /**
  * The major with a welcome sheet of its own.
@@ -77,10 +75,15 @@ import { readDismissFlag } from './useDismissibleFlag';
  * instead. `releaseMarkerFor` deliberately drops the patch; it does not drop the minor, and
  * the minor moves on any feature.
  *
- * The sheet's own dismissal is what retires this, not a version: once a reader has closed the
- * Harvous 3 welcome, the row goes back to being the release notes for them. So this stays
- * correct through 3.2 and 3.9 without anyone remembering to change it, and never re-opens a
- * launch announcement at someone who has already read it.
+ * Nothing retires it before 4. The sheet's own dismissal used to, on the reasoning that a
+ * launch announcement should not be re-opened at someone who has read it — but that made the
+ * row contradict the one job described above, of being the way back to a modal that otherwise
+ * shows itself once. Closing something is not the same as never wanting it again, and a
+ * reader who goes looking for "what's new" during 3.x is asking for the explanation of the
+ * rearrangement, whether or not they saw it on launch day.
+ *
+ * So this holds through 3.2 and 3.9 without anyone remembering to change it, and stops at 4.0
+ * on its own.
  */
 const WELCOME_SHEET_MAJOR = '3';
 
@@ -91,9 +94,8 @@ export default function PrototypeWhatsNewPill() {
     previewKey: PROTO_WHATS_NEW_PREVIEW_KEY,
   });
 
-  const welcomeSeen = readDismissFlag(PROTO_WELCOME_3_DISMISSED_KEY);
   const showsWelcomeSheet =
-    !welcomeSeen && (releaseMarkerFor(version) ?? '').split('.')[0] === WELCOME_SHEET_MAJOR;
+    (releaseMarkerFor(version) ?? '').split('.')[0] === WELCOME_SHEET_MAJOR;
 
   /* `releaseNotesUrl` belongs in the deps: it starts on the index and upgrades in place once
      the site answers, so a callback that captured only the first value would have pinned every

--- a/spa/src/pages/prototype/settings/PrototypeRemindersPage.tsx
+++ b/spa/src/pages/prototype/settings/PrototypeRemindersPage.tsx
@@ -463,7 +463,13 @@ export default function PrototypeRemindersPage() {
         </div>
       </SettingsGroup>
 
-      {support === 'granted' && deviceCount > 0 ? (
+      {/*
+        Development only. Sending yourself a notification is a way of checking the plumbing,
+        which is a thing to do while building reminders rather than a thing to offer someone
+        using them — the schedule above already says what will arrive and when. It shipped
+        ungated from the start; the gate is the correction.
+      */}
+      {import.meta.env.DEV && support === 'granted' && deviceCount > 0 ? (
         <SettingsGroup>
           <SettingsRow
             label="Send a test"

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -10332,6 +10332,12 @@ button.proto-appearance-hero__card {
   display: flex;
   flex-direction: row;
   align-items: stretch;
+  /*
+   * Wrap rather than squeeze. Side by side while both labels fit, stacked and centred when
+   * they do not — "See release notes" is the longer of the pair and was the one that lost.
+   */
+  flex-wrap: wrap;
+  justify-content: center;
   gap: var(--pds-space-2);
   width: 100%;
   max-width: 400px;
@@ -10341,8 +10347,14 @@ button.proto-appearance-hero__card {
 
 .proto-welcome3__cta,
 .proto-welcome3__secondary {
-  flex: 1 1 0;
-  min-width: 0;
+  flex: 1 1 auto;
+  /*
+   * Never narrower than its own label. With `min-width: 0` these shrank past their text, and
+   * because the text is `nowrap` it had nowhere to go and was clipped mid-word on a narrow
+   * phone. At `max-content` the button keeps its label and the row wraps instead, which is
+   * the honest thing for two buttons that cannot both fit.
+   */
+  min-width: max-content;
   min-height: 44px;
   padding: 0 var(--pds-space-3);
   border-radius: var(--pds-radius-button);

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -1234,26 +1234,42 @@ html[data-shift-hints='1'] .proto-toolbar-orb-group {
    */
 
   /*
-   * The chip takes its turn in the row instead of lying across it.
+   * A three-track grid, so the chip is centred on the row *and* bounded by it.
    *
-   * Centring it absolutely keeps it optically centred on the window, which is right when
-   * there is room — but it is centred on the *window*, not on the space actually left over,
-   * so it cannot know how wide the button groups beside it have grown. Each orb added to the
-   * left pushes that group further under a chip that has not moved, and the two overlap
-   * rather than the chip giving way. Measured at 375px: a 36px overlap, the chip sitting on
-   * top of the last orb.
+   * Two earlier attempts, each fixing the other's failure. Absolute centring is optically
+   * right — the chip sits on the middle of the window — but it is positioned against the
+   * window rather than the space left over, so it cannot know how wide the button groups
+   * beside it have grown. Each orb added to the left slid that group under a chip that had
+   * not moved: measured at 375px, a 36px overlap with the chip on top of the last orb. Making
+   * it an ordinary flex item fixed the overlap and lost the centring, because a flex item is
+   * centred in the gap its neighbours leave, and the two groups are not the same width — a
+   * 105px group on the left against 30px on the right pushes the chip visibly off-centre.
    *
-   * As a flex item it is bounded by its neighbours, so it truncates instead — which is what
-   * it was always built to do (`flex-shrink: 1`, `overflow: hidden`) and never got the chance
-   * to. Only here: above this width the absolute centring has room and looks better.
+   * `1fr auto 1fr` gives both. The middle track is centred on the full row because the side
+   * tracks are equal by construction, whatever they contain, and tracks cannot overlap — so
+   * when the row runs out of room the chip truncates, which is what it was always built to do
+   * (`flex-shrink: 1`, `overflow: hidden`).
    */
+  .proto-toolbar-inner {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+  }
+
+  .proto-toolbar-left {
+    justify-self: start;
+  }
+
+  .proto-toolbar-right {
+    justify-self: end;
+  }
+
   .proto-toolbar-center {
     position: static;
     transform: none;
-    flex: 1 1 auto;
-    max-width: none;
-    /* The row's own gap now does this work; without it the chip sits tight against the orbs. */
-    margin: 0 4px;
+    justify-self: center;
+    /* Lets the chip shrink inside its track rather than forcing the track wider. */
+    min-width: 0;
+    max-width: 100%;
   }
 
 }
@@ -18478,6 +18494,30 @@ html.harvous-prototype-route button[class*="proto-"].proto-settings-danger__btn:
        `--pds-reader-text-inset`, restated so it reads the narrow gutter above rather than
        the 28px default it would otherwise keep. */
     --pds-reader-text-inset: calc(var(--pds-reader-gutter) + var(--pds-space-1));
+    padding: var(--pds-editor-paper-padding-top-narrow) var(--pds-reader-paper-padding-x)
+      var(--pds-editor-paper-padding-bottom);
+  }
+}
+
+/*
+ * The step the reader was missing.
+ *
+ * The note editor has three: full padding, narrow at 640, and compact at 480 where it also
+ * drops its type. The reader stopped at 640, so a phone-width chapter kept a padding tier the
+ * editor had already left behind two breakpoints ago — the same document surface behaving
+ * differently depending on which of the two you happened to open.
+ *
+ * The gutter is deliberately not tightened again here. It reserves the margin-bar lane, three
+ * lanes at a 7px pitch, and the 20px above is already the floor that fits them; taking it
+ * further would put the bars back through the first words of the lines they mark, which is
+ * the failure the block above exists to record. What is left to give is the paper's own
+ * padding, which is what was asked for.
+ */
+@container pds-reader-scroll (max-width: 480px) {
+  .pds-reader__column {
+    --pds-reader-paper-padding-x: var(--pds-editor-paper-padding-x-compact);
+    /* Scales the reader's own S/M/L choice rather than replacing it — see `.pds-reader-text`. */
+    --pds-reader-font-scale: 0.9;
     padding: var(--pds-editor-paper-padding-top-narrow) var(--pds-reader-paper-padding-x)
       var(--pds-editor-paper-padding-bottom);
   }

--- a/spa/src/styles/prototype-tokens.css
+++ b/spa/src/styles/prototype-tokens.css
@@ -1597,7 +1597,16 @@ html.harvous-prototype-route [data-sonner-toast] [data-description] {
    re-sets one variable rather than swapping classes. */
 .pds-reader-text {
   font-family: var(--pds-font-reading);
-  font-size: var(--pds-reader-font-size);
+  /*
+   * The reader's chosen size, scaled — never replaced.
+   *
+   * Unlike the note editor, which drops to a flat 15px on a narrow pane, reading size here is
+   * a preference the reader set themselves (S/M/L writes `--pds-reader-font-size`). Hardcoding
+   * a size for narrow panes would quietly overrule that choice, so the responsive step is a
+   * multiplier instead, and the floor is the smallest size the control itself offers: a narrow
+   * pane may bring someone down toward their own minimum, never past it.
+   */
+  font-size: max(15px, calc(var(--pds-reader-font-size) * var(--pds-reader-font-scale, 1)));
   font-weight: 400;
   /* `none` would leave a static face with no bold at all; the optional reading faces are
      not variable, so let the browser synthesise weight where the family lacks it. */


### PR DESCRIPTION
Four commits. One is new; three are work that was written on 2026-09-05, never merged, and has been missing from production since.

## The stranded commits

`origin/claude/native-notifications-browser-pwa-20593e` still holds five commits that are not on `main` — reminders shipped from that branch, and these landed after that merge. The branch is 29 commits behind, which is why they went unnoticed. Three are substantive and all three are here:

- **`fix(reader, toolbar)` — centres Search on the row.** The chip was centred in the gap its neighbours left rather than on the row itself. Also gives the reader the 480px tier the note editor already had.
- **`fix(whats-new)`** — the row keeps opening the Harvous 3 sheet until 4.0.
- **`chore(reminders)` — removes the push-nav instrumentation.** This is the one worth noting: that debug logging is *live in production right now* (`public/sw.js`, `spa/src/lib/notification-navigation.ts`), and its author had already deleted it on the branch after it proved the tap end to end on a real iPhone.

The two version-bump commits are deliberately not cherry-picked.

## Send a test

`PrototypeRemindersPage` has always rendered "Send a test" to anyone with a live subscription, with no gate. Sending yourself a notification is a way of checking our own plumbing, not something to offer someone using reminders — the schedule above it already states what will arrive and when. Now `import.meta.env.DEV`, matching how the design galleries and the dev route error preview are gated, so it drops out of a production build rather than shipping dark.

## One conflict, resolved by re-measuring

`scripts/perf-budget.json` was the only conflict. Neither side's numbers were valid — main's baseline has moved since that branch measured, and the branch's numbers were *higher* than main's. Took main's tighter figures rather than either recorded value, then rebuilt: `perf:check` passes at 1143.3 KB with no regressions, so removing the instrumentation earns headroom rather than needing budget.

## Verification

- 4142 tests pass (370 files); typecheck 125 errors, one fewer than main's 126
- `perf:check` passes after `build:spa`
- **Search centring measured in the browser at 375px:** `display: grid`, side tracks 120.977px and 120.984px, chip 93px, **0px off centre** — against 37.5px off before

A note for whoever verifies this next: the service worker caches the dev server's CSS, so a CSS change will not appear until you unregister it and clear `caches`. It cost me a while — the rule was served correctly and simply was not in the CSSOM.

Not touched: `spa/src/lib/push-reminders.ts:182` still tags a genuine subscribe-failure diagnostic with a `[push-nav]` prefix. It is a real error report rather than instrumentation, and renaming it would change what shows up in diagnostics filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
