### PR TITLE
chore: bump version to 3.6.1

### DIFF
--- a/Changelog/3.6.1.md
+++ b/Changelog/3.6.1.md
@@ -1,0 +1,10 @@
+# Version 3.6.1
+
+**Release Date**: September 7, 2026
+
+## Fixes
+
+- Centre the Search chip on the toolbar row
+- Scale the Bible reader like a note on narrow screens
+- Stop the what's-new row reopening the Harvous 3 sheet
+- Keep the reminders test send to development

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.6.0
+**Version:** 3.6.1
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-6-0';
+const CACHE_NAME = 'harvous-cache-v3-6-1';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/release-notes/2026-09-07.md
+++ b/release-notes/2026-09-07.md
@@ -1,0 +1,46 @@
+# What's New in Harvous — September 7, 2026
+
+**Release Date:** September 7, 2026
+**Versions:** v3.6.1
+
+Small corrections to the app's frame. The search chip sits where it looks like it should on a phone, a chapter now narrows the way a note does, and the what's-new row stops sending you back to a welcome you have already read.
+
+---
+
+## Updates in This Release
+
+### Search sits in the middle of the row on a phone
+
+**What changed:**
+- The Search chip is now centred on the toolbar itself rather than in whatever space the buttons on either side happened to leave.
+- Because those two groups are not the same width, the chip had been sitting noticeably right of centre on a narrow screen.
+- When the row genuinely runs out of room the chip shortens instead of sliding under the buttons beside it.
+
+**How it helps you:**
+- The one control in the middle of the toolbar looks like it is in the middle.
+
+### A chapter narrows the way a note does
+
+**What changed:**
+- The Bible reader had two width steps where the note editor has three, so on a narrow phone a chapter kept padding the editor had already given up.
+- Reading size shrinks by a proportion rather than a fixed number, and never past the smallest size the S/M/L control itself offers.
+
+**How it helps you:**
+- The same passage reads the same whether you opened it in the reader or met it inside a note.
+- If you have chosen a larger reading size, a narrow screen no longer quietly overrules you.
+
+### The what's-new row stops sending you back to the welcome
+
+**What changed:**
+- Opening what's new reopened the Harvous 3 welcome sheet each time. It now stays out of the way until 4.0.
+
+**How it helps you:**
+- The row takes you to what is actually new, not to an introduction you have already read.
+
+### Smaller changes
+
+**What changed:**
+- The reminders settings page no longer offers to send you a test notification. Checking that notifications arrive is something we do while building them; your schedule already says what will arrive and when.
+
+**How it helps you:**
+- One less control in Settings that was never meant for you.


### PR DESCRIPTION
Versions the four user-visible fixes from #89, which landed on main unversioned.

**Why they were missed:** the version-bump hook is a *local* `post-commit` hook, so it never runs on a merge made through GitHub. #87 only carried a bump because that one was committed locally first. #89 was merged remotely, so main sat at 3.6.0 with four user-visible changes past it and no changelog or release note.

Changelog and release note are written by hand rather than generated, so they say what changed instead of restating commit subjects. September 7 is a new note — the September 6 one had its DRAFT banner removed, which correctly freezes it against the generator.

Covers: search centred on the toolbar row, the reader's narrow-screen tier, the what's-new row no longer reopening the Harvous 3 sheet, and the reminders test send becoming development-only.

Merging this publishes the note to the marketing site via the release-notes sync workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
