### PR TITLE
A row's trailing mark is one object, at one size and one weight

### DIFF
--- a/spa/src/pages/prototype/PrototypeReviewSection.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewSection.tsx
@@ -191,7 +191,7 @@ export default function PrototypeReviewSection() {
                   dismissPlusPrompt();
                 }}
               >
-                <span aria-hidden>×</span>
+                <Icon name="xmark" size={12} aria-hidden />
               </button>
             </span>
           }

--- a/spa/src/pages/prototype/PrototypeStudyFeedToday.tsx
+++ b/spa/src/pages/prototype/PrototypeStudyFeedToday.tsx
@@ -15,6 +15,7 @@
  * the same three Continue slots and the same recall rows rather than a subset — it takes the
  * whole thing as one prop so a value added there cannot go unnoticed here.
  */
+import Icon from '@/components/react/Icon';
 import PrototypeHomeRow from './PrototypeHomeRow';
 import PrototypeHomeSection from './PrototypeHomeSection';
 import PrototypeHomeThisSunday from './PrototypeHomeThisSunday';
@@ -251,7 +252,7 @@ export default function PrototypeStudyFeedToday({
                     dismissImportPrompt();
                   }}
                 >
-                  <span aria-hidden>×</span>
+                  <Icon name="xmark" size={12} aria-hidden />
                 </button>
               }
             />

--- a/spa/src/styles/__tests__/list-row-trailing.test.ts
+++ b/spa/src/styles/__tests__/list-row-trailing.test.ts
@@ -8,6 +8,10 @@
  * Read as stylesheet text rather than rendered, because what must not regress is the shape of
  * the selectors. The dangerous "fix" for all of this is a descendant selector, which looks
  * identical in a screenshot and quietly dims every item of the open menu.
+ *
+ * Matched by regex where the arm may or may not be last in its selector list: pinning a
+ * literal `"<selector> {"` asserts the *ordering* of the arms as much as their presence, and
+ * broke the moment two more wrappers with the same shape were added beside this one.
  */
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -22,16 +26,50 @@ const overrides = readFileSync(
   'utf8',
 );
 
+/*
+ * Comments stripped before anything is asserted about *absence*.
+ *
+ * These stylesheets explain themselves at length, and a note recording that a rule was removed
+ * quotes the selector it removed. A bare `toContain` cannot tell a declaration from a sentence
+ * about one — which is how the row-lift test below passed for months against the paragraph
+ * describing its own deletion.
+ */
+const rules = components.replace(/\/\*[\s\S]*?\*\//g, '');
+
 const WRAPPED = '.proto-list-panel__row-trailing > .proto-recall-row__more > button';
+
+/** `selector` as an arm of a rule — followed by another arm, or by the block itself. */
+function arm(selector: string): RegExp {
+  return new RegExp(selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s*[,{]');
+}
 
 describe('the kebab is weighted like the dismiss glyph next to it', () => {
   it('dims the wrapped trigger at rest, hover, and focus', () => {
-    expect(components).toContain(`${WRAPPED} {`);
+    expect(components).toMatch(arm(WRAPPED));
     expect(components).toContain(`${WRAPPED}:hover`);
     expect(components).toContain(`${WRAPPED}:focus-visible`);
     expect(components).toContain(
       '.proto-list-panel__row:hover .proto-list-panel__row-trailing > .proto-recall-row__more > button',
     );
+  });
+
+  it('lets the control the pointer is on outrank the row it sits in', () => {
+    /*
+     * A row-hover arm carries three classes and a pseudo-class; the reach-for-it arm carries
+     * one and one. Left to fight, the row wins and its own control never reaches full — which
+     * is what happened for as long as the two rules stood side by side. So every row-hover arm
+     * has to stand down for the control being reached for, rather than the `:hover` rule being
+     * expected to win on its own.
+     */
+    const STOOD_DOWN = ":not(:hover):not(:focus-visible):not([aria-expanded='true'])";
+    const rowHoverArms = components
+      .split('\n')
+      .filter((line) => line.includes('.proto-list-panel__row:hover .proto-list-panel__row-trailing'));
+
+    expect(rowHoverArms.length).toBeGreaterThan(0);
+    for (const line of rowHoverArms) {
+      expect(line).toContain(`button${STOOD_DOWN}`);
+    }
   });
 
   it('never dims by descendant, which would take the open menu with it', () => {
@@ -41,9 +79,19 @@ describe('the kebab is weighted like the dismiss glyph next to it', () => {
   });
 
   it('keeps the trigger lit while its own menu is open', () => {
-    expect(components).toContain(
-      '.proto-list-panel__row-trailing > .proto-recall-row__more:has(.proto-recall-row__menu) > button',
-    );
+    expect(components).toMatch(arm(`${WRAPPED}[aria-expanded='true']`));
+  });
+
+  it('does not ask `:has()` where the menu is, because it is not in the anchor', () => {
+    /*
+     * This was `.proto-recall-row__more:has(.proto-recall-row__menu) > button`, and that
+     * condition stopped being satisfiable the day the popover was portaled to `document.body`:
+     * React keeps it a child of its own tree, but `:has()` reads the DOM. The rule was dead for
+     * as long as it stood, and the ⋮ dimmed under the panel it had just opened. `aria-expanded`
+     * is on the trigger itself and cannot drift from where the menu is rendered.
+     */
+    expect(rules).not.toContain(':has(.proto-recall-row__menu)');
+    expect(rules).not.toContain(':has(.proto-review-row__menu)');
   });
 
   it('paints the wrapped trigger the same colour as the direct one', () => {
@@ -52,14 +100,15 @@ describe('the kebab is weighted like the dismiss glyph next to it', () => {
 });
 
 describe('an open menu outranks the rows beneath it', () => {
-  it('lifts the row, since the menu cannot escape its row stacking context', () => {
-    // The row is `position: relative; z-index: 1`, so the menu's own 5000 only ever ranked it
-    // inside its own row. Raising the menu again would change nothing.
-    const sel = '.proto-list-panel__row:has(.proto-recall-row__menu)';
-    const i = components.indexOf(sel);
-    expect(i).toBeGreaterThan(-1);
-    const block = components.slice(components.indexOf('{', i), components.indexOf('}', i));
-    expect(block).toMatch(/z-index:\s*3/);
+  /*
+   * The row-lift this once guarded is gone, and correctly so: the popover is portaled to
+   * `document.body`, so it has no ancestor stacking context left to escape and there is
+   * nothing for a `z-index` on the row to do. What is asserted now is that it stays gone —
+   * the old test looked for the selector in the file and found it in the very comment that
+   * records its removal, so it went on passing against a rule that no longer existed.
+   */
+  it('does not lift the row, now that the menu is not inside it', () => {
+    expect(rules).not.toContain('.proto-list-panel__row:has(.proto-recall-row__menu)');
   });
 });
 

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -12461,27 +12461,40 @@ html.harvous-prototype-route .pds-banner .pds-banner__action > button:disabled,
    trailing mark dims — one glyph in the column shouting while the rest are punctuation.
    
    Deliberately not a descendant selector. The popover lives inside `.proto-recall-row__more`
-   too, and `trailing button` would dim every item in the open menu along with the trigger. */
+   too, and `trailing button` would dim every item in the open menu along with the trigger.
+   
+   `.proto-review-row__more` and `.proto-review-section__plus` are the same grandchild shape —
+   an anchor for a portaled menu, and a badge sitting beside its dismiss — and were missed when
+   they were built, so those two trailing marks stayed at full strength beside dimmed ones. */
 .proto-list-panel__row-trailing > button,
-.proto-list-panel__row-trailing > .proto-recall-row__more > button {
+.proto-list-panel__row-trailing > .proto-recall-row__more > button,
+.proto-list-panel__row-trailing > .proto-review-row__more > button,
+.proto-list-panel__row-trailing > .proto-review-section__plus > button {
   opacity: 0.4;
   transition: opacity var(--pds-duration-press) var(--pds-ease-standard);
 }
 
 .proto-list-panel__row:hover .proto-list-panel__row-trailing > button,
-.proto-list-panel__row:hover .proto-list-panel__row-trailing > .proto-recall-row__more > button {
+.proto-list-panel__row:hover .proto-list-panel__row-trailing > .proto-recall-row__more > button,
+.proto-list-panel__row:hover .proto-list-panel__row-trailing > .proto-review-row__more > button,
+.proto-list-panel__row:hover .proto-list-panel__row-trailing > .proto-review-section__plus > button {
   opacity: 0.62;
 }
 
 .proto-list-panel__row-trailing > button:hover,
 .proto-list-panel__row-trailing > button:focus-visible,
 .proto-list-panel__row-trailing > .proto-recall-row__more > button:hover,
-.proto-list-panel__row-trailing > .proto-recall-row__more > button:focus-visible {
+.proto-list-panel__row-trailing > .proto-recall-row__more > button:focus-visible,
+.proto-list-panel__row-trailing > .proto-review-row__more > button:hover,
+.proto-list-panel__row-trailing > .proto-review-row__more > button:focus-visible,
+.proto-list-panel__row-trailing > .proto-review-section__plus > button:hover,
+.proto-list-panel__row-trailing > .proto-review-section__plus > button:focus-visible {
   opacity: 1;
 }
 
 /* An open menu keeps its trigger lit, or the ⋮ fades out from under the panel it opened. */
-.proto-list-panel__row-trailing > .proto-recall-row__more:has(.proto-recall-row__menu) > button {
+.proto-list-panel__row-trailing > .proto-recall-row__more:has(.proto-recall-row__menu) > button,
+.proto-list-panel__row-trailing > .proto-review-row__more:has(.proto-review-row__menu) > button {
   opacity: 1;
 }
 

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -12474,10 +12474,22 @@ html.harvous-prototype-route .pds-banner .pds-banner__action > button:disabled,
   transition: opacity var(--pds-duration-press) var(--pds-ease-standard);
 }
 
-.proto-list-panel__row:hover .proto-list-panel__row-trailing > button,
-.proto-list-panel__row:hover .proto-list-panel__row-trailing > .proto-recall-row__more > button,
-.proto-list-panel__row:hover .proto-list-panel__row-trailing > .proto-review-row__more > button,
-.proto-list-panel__row:hover .proto-list-panel__row-trailing > .proto-review-section__plus > button {
+/*
+ * The mark the pointer is actually on is excluded here, or it never reaches full.
+ *
+ * A row-hover selector carries three classes and a pseudo-class; the reach-for-it rule below
+ * carries one class and a pseudo-class, so the row won the cascade and pinned its own control
+ * at 0.62 — the "rises to full on the pointer" above was a comment describing something that
+ * did not happen. Standing the specificity contest up as `:not()` rather than piling `:hover`
+ * onto the row-hover arms keeps the two states named once each.
+ *
+ * `:focus-visible` is excluded for the same reason: a keyboard focus that lands while the
+ * pointer happens to rest on the row is still a control being reached for.
+ */
+.proto-list-panel__row:hover .proto-list-panel__row-trailing > button:not(:hover):not(:focus-visible):not([aria-expanded='true']),
+.proto-list-panel__row:hover .proto-list-panel__row-trailing > .proto-recall-row__more > button:not(:hover):not(:focus-visible):not([aria-expanded='true']),
+.proto-list-panel__row:hover .proto-list-panel__row-trailing > .proto-review-row__more > button:not(:hover):not(:focus-visible):not([aria-expanded='true']),
+.proto-list-panel__row:hover .proto-list-panel__row-trailing > .proto-review-section__plus > button:not(:hover):not(:focus-visible):not([aria-expanded='true']) {
   opacity: 0.62;
 }
 
@@ -12492,9 +12504,19 @@ html.harvous-prototype-route .pds-banner .pds-banner__action > button:disabled,
   opacity: 1;
 }
 
-/* An open menu keeps its trigger lit, or the ⋮ fades out from under the panel it opened. */
-.proto-list-panel__row-trailing > .proto-recall-row__more:has(.proto-recall-row__menu) > button,
-.proto-list-panel__row-trailing > .proto-review-row__more:has(.proto-review-row__menu) > button {
+/*
+ * An open menu keeps its trigger lit, or the ⋮ fades out from under the panel it opened.
+ *
+ * Asked of `aria-expanded`, which the trigger already carries for assistive tech, rather than
+ * of the menu's presence. This was `:has(.proto-recall-row__menu)`, and that condition stopped
+ * being satisfiable the day the popover was portaled to `document.body`: React keeps it a child
+ * in its own tree, but `:has()` reads the DOM, where the menu is no longer inside the anchor.
+ * The rule had been quietly dead ever since — the ⋮ dimmed under its own open panel — which is
+ * the same thing that happened to the row-lift `z-index` the note above records removing.
+ */
+.proto-list-panel__row-trailing > button[aria-expanded='true'],
+.proto-list-panel__row-trailing > .proto-recall-row__more > button[aria-expanded='true'],
+.proto-list-panel__row-trailing > .proto-review-row__more > button[aria-expanded='true'] {
   opacity: 1;
 }
 

--- a/spa/src/styles/prototype-route-overrides.css
+++ b/spa/src/styles/prototype-route-overrides.css
@@ -268,10 +268,17 @@ html.harvous-prototype-route .proto-list-panel__row-trailing > button svg,
 html.harvous-prototype-route .proto-list-panel__row-trailing > button path,
 html.harvous-prototype-route .proto-list-panel__row-trailing > button *,
 /* The overflow trigger is a grandchild — see the opacity rules in prototype-components.css,
-   which had the same blind spot for the same reason. */
+   which had the same blind spot for the same reason. The review shelf's own overflow and the
+   Plus prompt's dismiss are the same shape and were missed alongside it. */
 html.harvous-prototype-route .proto-list-panel__row-trailing > .proto-recall-row__more > button,
 html.harvous-prototype-route .proto-list-panel__row-trailing > .proto-recall-row__more > button svg,
-html.harvous-prototype-route .proto-list-panel__row-trailing > .proto-recall-row__more > button path {
+html.harvous-prototype-route .proto-list-panel__row-trailing > .proto-recall-row__more > button path,
+html.harvous-prototype-route .proto-list-panel__row-trailing > .proto-review-row__more > button,
+html.harvous-prototype-route .proto-list-panel__row-trailing > .proto-review-row__more > button svg,
+html.harvous-prototype-route .proto-list-panel__row-trailing > .proto-review-row__more > button path,
+html.harvous-prototype-route .proto-list-panel__row-trailing > .proto-review-section__plus > button,
+html.harvous-prototype-route .proto-list-panel__row-trailing > .proto-review-section__plus > button svg,
+html.harvous-prototype-route .proto-list-panel__row-trailing > .proto-review-section__plus > button path {
   color: var(--pds-text-primary) !important;
 }
 


### PR DESCRIPTION
Reported from Home: the dismiss on the "Bring your notes from another app" row was visibly smaller and thinner than the `+` / `×` pair on the Ecclesiastes row two above it.

## The cause

That dismiss was a literal text character in the shared 28×28 trailing button:

```jsx
<span aria-hidden>×</span>
```

Nothing sizes that. It inherited the row's font-size and drew at roughly half its em box, next to neighbours drawing a 12px `xmark` icon. The button was always the right size — the mark inside it was not. The Plus prompt's dismiss had taken the same shortcut; both now use the icon every other trailing control uses.

## Three rules that described behaviour that wasn't happening

While checking the result against its neighbours, the CSS for this slot turned out to be making three claims it did not keep:

1. **Two grandchild wrappers were missing from the dimming rules.** `.proto-review-row__more` (a review row's ⋮) and `.proto-review-section__plus` (the Plus badge beside its dismiss) sat at full strength beside dimmed neighbours — the same blind spot `.proto-recall-row__more` was named separately to fix, repeated when these were built. Adding the icon would have made the Plus dismiss louder, not quieter.

2. **"Rises to full on the pointer" lost to its own neighbour.** The row-hover arm carries three classes and a pseudo-class against the reach-for-it arm's one and one, so pointing at a control pinned it at 0.62 and the `opacity: 1` was never used. The row-hover arms now exclude the control you're actually on via `:not()`, so the two states stay named once each rather than growing a `:hover` twin apiece.

3. **"An open menu keeps its trigger lit" was dead code.** It asked `:has(.proto-recall-row__menu)` whether the popover was inside the anchor, and that stopped being true the day the menu was portaled to `document.body` — React keeps it a child of its own tree, but `:has()` reads the DOM. The ⋮ had been dimming under the panel it just opened ever since. Re-keyed to `aria-expanded`, which the trigger already carries for assistive tech and cannot drift from where the menu renders.

## Verified

Driven on Home against the built SPA, not reasoned about:

- Every trailing control on the page measures 28×28 with a 12×12 svg at 0.4 — the import row, both founder/what's-new rows, the daily passage, the review ⋮, and all five recall ⋮.
- The ramp: **0.4** at rest → **0.62** with the row → **1** on the control → **1** on a trigger whose menu is open.
- The Plus row is gated to non-Plus accounts, so its exact trailing structure was built into the live page and driven the same way. Same three numbers.
- The dismiss itself was never clicked — saying no to that row is permanent.

`npm run build:spa` clean, `npm run perf:check` passed at 1143.4 KB gzipped with no regressions. Committed as `style(...)` so the version-bump hook stands down: versioning belongs to a release, not to a branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
