### PR TITLE
fix(review): the Review section could vanish from Home

### DIFF
--- a/Changelog/3.6.2.md
+++ b/Changelog/3.6.2.md
@@ -1,0 +1,17 @@
+# Version 3.6.2
+
+**Release Date**: September 7, 2026
+
+## Fixes
+
+- The Review section could vanish from Home
+
+## Performance
+
+- Activity arrives once, not a section at a time (#92)
+
+## Other Changes
+
+- Re-enable CSRF protection, in observe mode (#64)
+- A row's trailing mark is one object, at one size and one weight (#91)
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.6.1
+**Version:** 3.6.2
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-6-1';
+const CACHE_NAME = 'harvous-cache-v3-6-2';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/release-notes/2026-09-07.md
+++ b/release-notes/2026-09-07.md
@@ -1,9 +1,9 @@
 # What's New in Harvous — September 7, 2026
 
 **Release Date:** September 7, 2026
-**Versions:** v3.6.1
+**Versions:** v3.6.1–v3.6.2
 
-Small corrections to the app's frame. The search chip sits where it looks like it should on a phone, a chapter now narrows the way a note does, and the what's-new row stops sending you back to a welcome you have already read.
+Small corrections to the app's frame, and Home now loads as one page instead of growing in front of you. The search chip sits where it looks like it should on a phone, a chapter now narrows the way a note does, and the what's-new row stops sending you back to a welcome you have already read.
 
 ---
 
@@ -36,6 +36,24 @@ Small corrections to the app's frame. The search chip sits where it looks like i
 
 **How it helps you:**
 - The row takes you to what is actually new, not to an introduction you have already read.
+
+### Home loads once, not a section at a time
+
+**What changed:**
+- Opening Home used to show a couple of things right away and then fill in the rest as each one arrived, so the page visibly grew for a moment after it first appeared.
+- It now waits for everything it needs and shows the whole page at once.
+
+**How it helps you:**
+- Nothing shifts under you while you are reading it.
+
+### A rare case where Review could go missing
+
+**What changed:**
+- The change above had a gap: on a visit where one of the items due for review was a chapter, the whole Review section could fail to appear at all.
+- Fixed the same day it was found.
+
+**How it helps you:**
+- Review shows up reliably again, every time there is something in it.
 
 ### Smaller changes
 

--- a/server/routes/review.ts
+++ b/server/routes/review.ts
@@ -89,11 +89,17 @@ route.get('/api/review/inbox', requireAuth, rateLimit('read'), requireFeature('r
      *
      * One extra row beyond the cut, purely to answer `hasMore` without a second count query.
      *
-     * Building came last only recently. Dropping used to be a side effect of building, so this
-     * assembled a full question for all eight candidates — cue text, cross-reference openings,
-     * curated knowledge, a database round trip apiece — and then threw five of them away. Since
-     * the drop rules are their own function, the same eight can be filtered for one batched read
-     * and only the three that will be shown are built. Same rows, same `hasMore`.
+     * `filterAskableReviewRows` first, so the build is not handed rows already known to be
+     * unaskable — but the cut still happens *after* the build, and that ordering is not an
+     * oversight to optimise away later.
+     *
+     * It was optimised away once. Cutting to three before building looked equivalent, because
+     * the filter was believed to apply every drop rule the build applies. It applied two of
+     * three: a chapter whose text cannot be fetched is only discoverable once that text has been
+     * asked for. So a chapter in the top three was dropped during the build, the inbox came back
+     * short, short enough came back empty, and the Review section rendered nothing at all in
+     * production. The slack listed beyond the three rows exists precisely so a late drop costs a
+     * row from the tail rather than from what is shown, and cutting first threw that away.
      */
     const due = await listDueReviewItems(
       auth.userId,
@@ -101,13 +107,10 @@ route.get('/api/review/inbox', requireAuth, rateLimit('read'), requireFeature('r
       now,
     );
     const askable = await filterAskableReviewRows(auth.userId, due, { dropUnaskable: true });
-    const items = await buildReviewItemViews(
-      auth.userId,
-      askable.slice(0, REVIEW_INBOX_MAX_ROWS),
-      { dropUnaskable: true },
-    );
+    const built = await buildReviewItemViews(auth.userId, askable, { dropUnaskable: true });
+    const items = built.slice(0, REVIEW_INBOX_MAX_ROWS);
 
-    return c.json({ success: true, items, hasMore: askable.length > REVIEW_INBOX_MAX_ROWS });
+    return c.json({ success: true, items, hasMore: built.length > REVIEW_INBOX_MAX_ROWS });
   } catch (error) {
     // A database without the tables yet is an empty inbox, not a broken Activity page.
     if (isReviewTableMissing(error)) {

--- a/server/utils/__tests__/review-askable-rules-parity.test.ts
+++ b/server/utils/__tests__/review-askable-rules-parity.test.ts
@@ -1,0 +1,71 @@
+/**
+ * `filterAskableReviewRows` and `buildReviewItemViews` must drop the same rows.
+ *
+ * They are two answers to one question — which stored rows become rows a reader can be asked
+ * about — and they exist separately only so counting a queue does not cost what building one
+ * does. When they disagree, the queue lies: a fold says "12 more" and opens onto eleven, or the
+ * inbox reports three and returns two.
+ *
+ * This is not hypothetical. The filter shipped with two of the build's three drop rules, missing
+ * the one that needs a chapter's text — and because the inbox had been changed to cut to three
+ * rows *before* building, a single unfetchable chapter in the top three took the whole Review
+ * section off Home in production.
+ *
+ * Read from the source because both sides are database calls end to end; there is no seam to
+ * unit test without standing one up. What it can still do is fail the moment the two counts
+ * diverge, which is the only warning that would have helped.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const source = readFileSync(join(process.cwd(), 'server/utils/review-service.ts'), 'utf8');
+
+function bodyOf(signature: string): string {
+  const start = source.indexOf(signature);
+  expect(start, `${signature} not found`).toBeGreaterThan(-1);
+  // Both functions end at the next top-level declaration.
+  const rest = source.slice(start + signature.length);
+  const end = rest.search(/\n(?:export )?(?:async )?function |\n\/\*\*/);
+  return rest.slice(0, end === -1 ? undefined : end);
+}
+
+const buildBody = bodyOf('export async function buildReviewItemViews');
+const filterBody = bodyOf('export async function filterAskableReviewRows');
+
+describe('askable-row rules stay in step', () => {
+  it('the build drops rows in exactly three places', () => {
+    /*
+     * A guard on the number, not the wording. If a fourth `continue` appears in the build loop,
+     * this fails — and the fix is to teach `filterAskableReviewRows` the same rule, not to bump
+     * the number. Counting anything the reader can still be asked about as askable is the whole
+     * contract between these two.
+     */
+    const drops = buildBody.match(/\bcontinue;/g) ?? [];
+    expect(drops).toHaveLength(3);
+  });
+
+  it('the filter rejects rows in the same three places', () => {
+    const rejects = filterBody.match(/\breturn false;/g) ?? [];
+    expect(rejects).toHaveLength(3);
+  });
+
+  it('both know the kind rule', () => {
+    expect(buildBody).toContain('isReviewAskableKind');
+    expect(filterBody).toContain('isReviewAskableKind');
+  });
+
+  it('both know the unaskable-note rule', () => {
+    expect(buildBody).toContain('noteRungFor');
+    expect(filterBody).toContain('noteRungFor');
+  });
+
+  it('both know the chapter-without-text rule', () => {
+    // The one that was missing. The build reads it off loaded chapter material; the filter asks
+    // the cheaper question — are there verses at all — but it must ask it.
+    expect(buildBody).toContain("kind === 'chapter'");
+    expect(buildBody).toContain('verses.length');
+    expect(filterBody).toContain("kind === 'chapter'");
+    expect(filterBody).toContain('splitChapterHtmlIntoVerses');
+  });
+});

--- a/server/utils/review-service.ts
+++ b/server/utils/review-service.ts
@@ -683,10 +683,49 @@ export async function filterAskableReviewRows(
       ? await loadNoteMaterial(userId, noteIds)
       : new Map<string, NoteMaterial>();
 
+  /*
+   * Chapters need their text before we can say whether they are askable, because every rung of a
+   * chapter is built out of its verses — one that could not be fetched is a prompt above nothing.
+   *
+   * This rule was missed when these three were first pulled out of the build loop, and it broke
+   * Review in production: the inbox cut to three rows *before* building, so a chapter that the
+   * build then dropped left the section short, and short enough became empty and the whole
+   * section rendered nothing. The slack the inbox lists beyond its three rows exists for exactly
+   * this and cutting first defeated it.
+   *
+   * `fetchVerseText` rather than `loadChapterMaterial`: the question here is only whether there
+   * are verses at all, which is one cached read per distinct chapter, where the full material
+   * load is five concurrent queries for facts only a built prompt needs.
+   */
+  const chapterRefs = options.dropUnaskable
+    ? [
+        ...new Set(
+          rows
+            .filter((r) => r.kind === 'chapter' && r.scriptureReference)
+            .map((r) => `${r.scriptureReference}|${r.translation ?? 'NET'}`),
+        ),
+      ]
+    : [];
+  const chapterHasVerses = new Map<string, boolean>();
+  await Promise.all(
+    chapterRefs.map(async (key) => {
+      const [reference, translation] = key.split('|');
+      const parts = chapterKeyPartsFromReference(reference);
+      const html = parts
+        ? await fetchVerseText(chapterReferenceLabel(parts), translation).catch(() => '')
+        : '';
+      chapterHasVerses.set(key, Boolean(html) && splitChapterHtmlIntoVerses(html).length > 0);
+    }),
+  );
+
   return rows.filter((row) => {
     const kind = row.kind as ReviewItemKind;
     if (!isReviewAskableKind(kind)) return false;
     if (kind === 'note' && options.dropUnaskable && !noteRungFor(row, material)) return false;
+    if (kind === 'chapter' && options.dropUnaskable) {
+      const key = `${row.scriptureReference}|${row.translation ?? 'NET'}`;
+      if (!chapterHasVerses.get(key)) return false;
+    }
     return true;
   });
 }


### PR DESCRIPTION
**Regression from #92, currently live.** Fixes Review disappearing from Home.

## What broke

The inbox lists eight candidates, drops the ones that can't be asked about, and cuts to three. I changed it to cut to three and *then* build, believing `filterAskableReviewRows` applied every rule the build applies.

**It applied two of three.** The third needs a chapter's text: every rung of a chapter is built from its verses, so one whose text can't be fetched has no exercise on any rung and the build drops it — and that's only discoverable after asking for the text.

Cutting first meant that drop came out of the three rows being shown rather than out of the tail. `REVIEW_INBOX_UNASKABLE_SLACK` exists precisely to absorb it, and cutting first threw the slack away. One unfetchable chapter in the top three left the inbox short; short enough left it empty; and with nothing due, nothing coming back and no challenge, `hasRows` went false and **the whole section rendered `null`.**

The summary shape had the same hole, so its counts could exceed what the built list would show — a fold saying "12 more" and opening onto eleven. That's the exact failure sharing these rules was supposed to make impossible, and my claim in #92 that membership was identical was wrong.

## The fix

**The filter learns the chapter rule.** It asks the cheaper question — are there verses at all — with one cached read per distinct chapter, rather than the five concurrent queries the full material load runs for facts only a built prompt needs.

**The inbox cuts after building again.** With all three rules in the filter that's now redundant — which is the point. It was redundant before too, right up until it wasn't. A drop rule only the build can evaluate should cost a row from the tail, not a row from the reader's screen.

**`review-askable-rules-parity.test.ts`** pins the two in step by counting drop points on both sides. It fails on the code this fixes. A fourth rule in the build fails it too, and the fix then is to teach the filter, not to bump the number.

## Verified

```
inbox    n=3  hasMore=true  kinds verse+chapter   ← was returning empty
summary  n=18                                     ← now matches built n=18
built    n=18
```

The membership claim is now true rather than nearly true. The chapter check costs the summary 505ms → 729ms, against 3454ms for the built shape — so #92's win is mostly kept and the correctness hole is closed.

5762 tests, typecheck ratchet 125, auth-gated-queries. Version bumped to 3.6.2 by the hook (`fix:`), changelog generated; release notes for 2026-09-07 were left alone and the new entry is listed for a `/marketing-agent` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)