### PR TITLE
fix(discover): take jsdom out of the API bundle

### DIFF
--- a/Changelog/3.6.2.md
+++ b/Changelog/3.6.2.md
@@ -1,0 +1,34 @@
+# Version 3.6.2
+
+**Release Date**: September 7, 2026
+
+## Features
+
+- Topic-derived colour, sanitized previews, and reviewer provenance
+- Carry each kind's body, colour and image to the catalog
+- A quiet way out of every list that has a counterpart
+- Out to Discover from Everything's empty corner
+- Reachable from the library panel and from composing
+- A curated catalog of study people have shared
+
+## Fixes
+
+- Take jsdom out of the API bundle
+- Topics stay switchable, and rows carry their colour
+- Centre the panel's loading and empty states
+- Don't let a browser cache the catalog, and space the excerpt
+
+## Improvements
+
+- Call them Templates, Notes and Threads
+- An expand control, not a row in the kind menu
+- The catalog is the website's; in the app it is a tool
+
+## Other Changes
+
+- Catch up two source-contract tests to earlier refactors
+- Drop today's generated release-notes draft
+- Strip the Discover lines from the generated draft
+- Drop the account-menu entry too
+- No Discover control in the library panel
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.6.1
+**Version:** 3.6.2
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-6-1';
+const CACHE_NAME = 'harvous-cache-v3-6-2';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/server/__tests__/discover-bundle.test.ts
+++ b/server/__tests__/discover-bundle.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The API bundle must not contain jsdom.
+ *
+ * `build:fly` bundles the whole server into one `dist-server/api.cjs` and the
+ * image copies that file and nothing else. jsdom reads its own
+ * `default-stylesheet.css` off disk at require time, so bundling it produces a
+ * binary that builds, pushes, starts, and then dies before serving a request:
+ *
+ *     fatal startup error: ENOENT ... open '/browser/default-stylesheet.css'
+ *
+ * That is exactly what shipping Discover's server-side `safeRenderHtml` did.
+ * Nothing in the failure is visible to `tsc`, to `vitest`, or to the Docker
+ * build — only to production — which is why it is asserted here instead.
+ *
+ * Asserted against the source rather than a built artifact so it runs in the
+ * ordinary suite: any server file importing the DOM-dependent renderer is the
+ * thing that drags jsdom in.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const SERVER_DIR = resolve(process.cwd(), 'server');
+
+function serverSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue;
+      out.push(...serverSourceFiles(full));
+    } else if (entry.endsWith('.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('the API bundle stays free of jsdom', () => {
+  const files = serverSourceFiles(SERVER_DIR);
+
+  it('finds server sources to check', () => {
+    expect(files.length).toBeGreaterThan(20);
+  });
+
+  it('imports neither jsdom nor a module that needs one', () => {
+    const offenders = files.filter((file) => {
+      const text = readFileSync(file, 'utf8');
+      return (
+        /from ['"]jsdom['"]/.test(text) ||
+        /from ['"]isomorphic-dompurify['"]/.test(text) ||
+        // The app's own renderer is DOMPurify underneath; it belongs to the
+        // browser and to Astro's build, never to this process.
+        /from ['"]@\/utils\/content-renderer['"]/.test(text)
+      );
+    });
+    expect(offenders.map((f) => f.replace(`${process.cwd()}/`, ''))).toEqual([]);
+  });
+});

--- a/server/routes/__tests__/discover-routes.test.ts
+++ b/server/routes/__tests__/discover-routes.test.ts
@@ -91,7 +91,7 @@ describe('discover routes', () => {
 
       What did not change: `payload` carries `sourceId` and `sourceVersionId`
       provenance no reader needs, so it stays out. The body travels in
-      `preview.bodyHtml`, sanitized on write and again on read.
+      `preview.bodyHtml`, as authored — the renderer sanitizes it.
     */
     for (const marker of PUBLIC_HANDLERS) {
       const body = handlerBody(routes(), marker);
@@ -101,23 +101,33 @@ describe('discover routes', () => {
     }
   });
 
-  it('sanitizes the public body on the way out as well as the way in', () => {
-    // Two passes, one dependency. The write pass cannot cover a row written
-    // before it existed, and harvous.com renders this string with `set:html`
-    // and no sanitizer of its own.
+  it('does not reach for a DOM sanitizer on the server', () => {
+    /*
+     * This route sanitized with DOMPurify once, which pulls jsdom, which cannot
+     * be bundled into the API image — jsdom reads its own stylesheet off disk
+     * and `build:fly` ships one file. It built, pushed, started, and died
+     * before serving a request. See `server/__tests__/discover-bundle.test.ts`
+     * for the mechanical guard; this asserts the intent at the call site.
+     *
+     * Sanitizing moved to the one thing that renders the field as HTML:
+     * harvous.com, with `sanitize-html`, immediately before `set:html`.
+     */
     const text = routes();
-    expect(text).toContain('function sanitizePreviewBody');
-    expect(text).toContain('safeRenderHtml(body)');
+    // The import and the call, not the bare word — both files explain in prose
+    // why the sanitizer is gone, and a docblock is not a dependency.
+    expect(text).not.toContain("from '@/utils/content-renderer'");
+    expect(text).not.toContain('safeRenderHtml(');
     const start = text.indexOf('function serializePublic');
     const publicSerializer = text.slice(start, text.indexOf('\nfunction ', start + 1));
-    expect(publicSerializer, 'serializePublic emits an unsanitized preview').toContain(
-      'sanitizePreviewBody(parsePreview(row.preview))',
+    expect(publicSerializer, 'serializePublic stopped emitting the body').toContain(
+      'parsePreview(row.preview)',
     );
   });
 
-  it('sanitizes and caps the body at snapshot time', () => {
+  it('caps the body at snapshot time', () => {
     const text = snapshot();
-    expect(text).toContain('safeRenderHtml(cut)');
+    expect(text).not.toContain("from '@/utils/content-renderer'");
+    expect(text).not.toContain('safeRenderHtml(');
     expect(text).toContain('BODY_HTML_MAX_LENGTH');
     // Every kind that has a body carries one; a resource has none to carry.
     expect(text).toContain('bodyHtml: bodyHtmlOf(template.content)');

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -49,7 +49,6 @@ import {
 } from '../db';
 import { handleAPIError } from '@/utils/error-handling';
 import { rateLimit } from '@/utils/rate-limit';
-import { safeRenderHtml } from '@/utils/content-renderer';
 import { isUniqueViolationError } from '../utils/db-errors';
 import { requireHarvousAdmin, getHarvousSystemUserId } from '../utils/harvous-admin';
 import { DISCOVER_CATEGORIES, isDiscoverCategory } from '@/data/discover-categories';
@@ -136,23 +135,6 @@ function parsePreview(preview: string | null): unknown {
 }
 
 /**
- * The second sanitize pass, on the way out.
- *
- * `bodyHtmlOf` already cleaned this at submit. Doing it again here costs one
- * function call and covers the cases a write-time pass cannot: a row written
- * before the sanitizer existed, and a future writer that forgets. It is also
- * what lets harvous.com render the string with `set:html` without taking a
- * DOMPurify dependency of its own — the static site has no user input, so the
- * only untrusted bytes it ever sees are these.
- */
-function sanitizePreviewBody(preview: unknown): unknown {
-  if (!preview || typeof preview !== 'object') return preview;
-  const body = (preview as { bodyHtml?: unknown }).bodyHtml;
-  if (typeof body !== 'string' || !body) return preview;
-  return { ...(preview as Record<string, unknown>), bodyHtml: safeRenderHtml(body) };
-}
-
-/**
  * The only serializer an unauthenticated route may use.
  *
  * Deliberately does not spread the row. `submittedByUserId`, `reviewedByUserId`,
@@ -166,6 +148,13 @@ function sanitizePreviewBody(preview: unknown): unknown {
  * static site — a catalog of things people chose to publish, on pages meant to
  * rank. `payload` stays private regardless: it carries `sourceId` and
  * `sourceVersionId` provenance that no reader needs.
+ *
+ * **`bodyHtml` leaves here as authored.** This route used to sanitize it with
+ * DOMPurify, which reaches for jsdom, which cannot be bundled into the API
+ * image — it crashed production at startup the first time it shipped. The
+ * consumer sanitizes instead: harvous.com runs `sanitize-html` at build time
+ * immediately before `set:html`, and it is the only thing that renders this as
+ * HTML. Treat every reader of this field as responsible for its own output.
  */
 function serializePublic(row: ListingRow) {
   return {
@@ -175,7 +164,7 @@ function serializePublic(row: ListingRow) {
     description: row.description,
     category: row.category,
     authorDisplayName: row.authorDisplayName,
-    preview: sanitizePreviewBody(parsePreview(row.preview)),
+    preview: parsePreview(row.preview),
     installCount: row.installCount,
     listedAt: row.listedAt,
   };

--- a/server/scripts/discover-clear-demo-listings.ts
+++ b/server/scripts/discover-clear-demo-listings.ts
@@ -1,0 +1,74 @@
+/**
+ * Empty the catalog before it is reachable by anyone real.
+ *
+ * Every row in it was written during the feature's own build, to click through
+ * each kind and each treatment before anything had been submitted for real.
+ * Five carry invented authors ("Sam W.", "Ada K.", "Jo M.", "Tom B.",
+ * "Naomi R.") under sentinel `user_demo_*` ids; the rest are honestly
+ * attributed to the account that made them but are placeholders all the same.
+ * None of it came from a submit → review → approve flow with an actual
+ * stranger, which is the only thing the catalog is for.
+ *
+ * That was fine while Discover was reachable only from a dev session. It stops
+ * being fine the moment the app's Library-panel entry point ships to
+ * production, because then a real signed-in person can browse this and install
+ * somebody who does not exist.
+ *
+ * Deletes `DiscoverInstalls` first (the dependent side) and `DiscoverListings`
+ * second. **Installed copies are not touched** — a template someone already
+ * took is theirs, and lives in `NoteTemplates`, not here; that is the same
+ * guarantee delisting has always made. Dry by default; `--apply` writes, and
+ * `--production` on top of it when the target is the live database.
+ */
+import 'dotenv/config';
+import { db, DiscoverListings, DiscoverInstalls } from '../db';
+import { requireDbTarget } from '../utils/require-db-target';
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const apply = argv.includes('--apply');
+  requireDbTarget({ scriptName: 'discover:clear', writes: apply, argv, env: process.env });
+
+  const rows = await db
+    .select({
+      id: DiscoverListings.id,
+      slug: DiscoverListings.slug,
+      kind: DiscoverListings.kind,
+      title: DiscoverListings.title,
+      authorDisplayName: DiscoverListings.authorDisplayName,
+      status: DiscoverListings.status,
+    })
+    .from(DiscoverListings);
+
+  const installs = await db.select({ id: DiscoverInstalls.id }).from(DiscoverInstalls);
+
+  if (rows.length === 0 && installs.length === 0) {
+    console.log('Catalog is already empty. Nothing to do.');
+    return;
+  }
+
+  for (const row of rows) {
+    console.log(
+      `  ${apply ? 'DELETE' : 'would delete'}  ${String(row.kind).padEnd(9)} ` +
+        `${String(row.slug ?? row.id).padEnd(30)} ${String(row.status).padEnd(10)} ` +
+        `"${row.title}" — ${row.authorDisplayName}`,
+    );
+  }
+
+  console.log(
+    `\n${rows.length} listing(s) and ${installs.length} install row(s)` +
+      (apply ? ' deleted.' : ' would be deleted. Dry run: pass --apply to write.'),
+  );
+
+  if (apply) {
+    await db.delete(DiscoverInstalls);
+    await db.delete(DiscoverListings);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/server/utils/discover-snapshot.ts
+++ b/server/utils/discover-snapshot.ts
@@ -35,7 +35,6 @@ import {
   first,
 } from '../db';
 import { stripHtmlForPreview } from '@/utils/html-stripper';
-import { safeRenderHtml } from '@/utils/content-renderer';
 import { resolveNoteTemplateIconColor } from '@/utils/note-template-icon';
 import { findPersonalLibrary } from './ensure-personal-library';
 
@@ -163,19 +162,28 @@ export function excerptOf(html: string): string {
 export const BODY_HTML_MAX_LENGTH = 4000;
 
 /**
- * The body a public page renders, sanitized.
+ * The body a public page renders, capped. **Stored as authored, not sanitized
+ * here — the renderer sanitizes.**
  *
- * This is the one place a listing's actual writing becomes public, so it is
- * sanitized on the way in — `safeRenderHtml` is DOMPurify (isomorphic, so it
- * runs here), which strips scripts, event handlers and `javascript:` URLs while
- * keeping the `data-*` attributes scripture pills depend on. `serializePublic`
- * sanitizes again on the way out; two passes cost one dependency and mean the
- * website needs no sanitizer of its own.
+ * This used to call `safeRenderHtml`, which is DOMPurify via
+ * `isomorphic-dompurify` → jsdom. That works in a browser and in a test, and it
+ * took the production API down the first time it shipped: `build:fly` bundles
+ * the server into a single `api.cjs` and the image copies nothing else, so
+ * jsdom's `readFileSync` of its own `default-stylesheet.css` had no file to
+ * find and the process died at startup, before serving a request. There is no
+ * DOM on this side and nothing here should reach for one.
+ *
+ * So the boundary moved to the only thing that renders this as HTML:
+ * harvous.com sanitizes with `sanitize-html` (htmlparser2, no DOM) at build
+ * time, immediately before `set:html`. The app's own public listing page never
+ * renders it — it is the install action and nothing else — and the export is
+ * consumed by that one build. Anything new that renders `bodyHtml` sanitizes
+ * it first; `discover-bundle.test.ts` guards the half of that which is
+ * mechanical.
  */
 export function bodyHtmlOf(html: string): string {
   if (!html) return '';
-  const cut = html.length > BODY_HTML_MAX_LENGTH ? html.slice(0, BODY_HTML_MAX_LENGTH) : html;
-  return safeRenderHtml(cut);
+  return html.length > BODY_HTML_MAX_LENGTH ? html.slice(0, BODY_HTML_MAX_LENGTH) : html;
 }
 
 function tooBig(payload: string): boolean {


### PR DESCRIPTION
**Production hotfix.** The API crash-looped on startup after #85 merged, and the Fly deploy for `08873904b` failed:

```
fatal startup error: ENOENT: no such file or directory, open '/browser/default-stylesheet.css'
  at node_modules/isomorphic-dompurify/node_modules/jsdom/lib/jsdom/living/helpers/style-rules.js
```

## What happened

Discover was the **first server-side caller of `safeRenderHtml`**, which is DOMPurify → `isomorphic-dompurify` → jsdom. `build:fly` bundles the server into a single `dist-server/api.cjs` and the image copies that file and nothing else, so jsdom's own `default-stylesheet.css` — which it reads off disk at require time — had nothing to find. The image built, pushed, and started; the process died before serving a request.

Nothing upstream could see it. `tsc` passes, all 5825 tests pass, the Docker build succeeds. It is only observable as a running container.

## The fix

Sanitizing moves to the one thing that renders these bytes as HTML: **harvous.com, with `sanitize-html`** (htmlparser2, no DOM), immediately before `set:html`. Pairs with harvouscom/harvous.com#14.

- The app's own `/discover/$slug` page is the install action and never renders the body.
- The export is consumed by that one static build.
- The server stores the snapshot as authored.

Verified the sanitizer keeps what the content needs and drops what it must:

| input | output |
|---|---|
| `<h2>Hi</h2><script>alert(1)</script><p>after</p>` | `<h2>Hi</h2><p>after</p>` |
| `<p onclick="steal()">click</p><img src=x onerror=alert(1)>` | `<p>click</p>` |
| `<a href="javascript:alert(1)">go</a>` | `<a rel="noopener noreferrer nofollow">go</a>` |
| `<iframe src="…"></iframe><p>kept</p>` | `<p>kept</p>` |
| scripture pill with `class` + `data-*` | preserved exactly |
| headings, lists, blockquote | preserved |

## Guard

`server/__tests__/discover-bundle.test.ts` fails if any server source imports `jsdom`, `isomorphic-dompurify`, or the DOM-dependent `@/utils/content-renderer`. This class of failure is invisible to every other check we run, so the next person to reach for a DOM on the server finds out in CI.

## Verification

- `npm run build:fly` → bundle is 17.2 MB, **0 occurrences** of `jsdom` or `default-stylesheet`
- Ran the built `api.cjs` directly: reaches `[fly] Hono API listening` instead of dying at require
- 545 test files / 5825 tests passing
- No new type errors

Also carries `discover-clear-demo-listings.ts`, the script that emptied the seeded demo catalog (11 listings, 1 install row) before the entry point became reachable in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)