### PR TITLE
feat(discover): publish the templates Harvous ships with

### DIFF
--- a/Changelog/3.7.0.md
+++ b/Changelog/3.7.0.md
@@ -1,17 +1,8 @@
 # Version 3.7.0
 
-**Release Date**: September 6, 2026
+**Release Date**: September 7, 2026
 
 ## Features
 
-- Out to Discover from Everything's empty corner
-
-## Improvements
-
-- An expand control, not a row in the kind menu
-
-## Other Changes
-
-- Drop the account-menu entry too
-- No Discover control in the library panel
+- Publish the templates Harvous ships with
 

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.6.2
+**Version:** 3.7.0
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-6-2';
+const CACHE_NAME = 'harvous-cache-v3-7-0';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/server/scripts/discover-seed-builtin-templates.ts
+++ b/server/scripts/discover-seed-builtin-templates.ts
@@ -1,0 +1,150 @@
+/**
+ * Publish the templates Harvous ships with into the catalog.
+ *
+ * A brand-new catalog is empty and honestly so — nothing has been submitted —
+ * but an empty page is a poor first impression of a feature whose whole point
+ * is "here is study you can start from", and harvous.com's `/discover/` pages
+ * exist to be found by people who do not have an account yet. The six built-in
+ * study methods are the obvious thing to open with: they are real, they are
+ * already what a new account gets, and they are ours to publish.
+ *
+ * **These do not go through submit → review.** That flow exists so a stranger's
+ * work is read before it is public; the publisher here *is* Harvous, so a
+ * round trip through a queue reviewing our own shipped content would be
+ * theatre. They are written straight to `status: 'listed'` with
+ * `preview.official`, which is what makes the card read "Included" rather than
+ * crediting a person.
+ *
+ * A built-in has no `NoteTemplates` row — it lives in code — so `sourceId`
+ * holds the built-in's own id (`soap`, `inductive`, …) rather than an `ntpl_`.
+ * That is also what `resolveNoteTemplateIconColor` keys on, so each one keeps
+ * the colour it wears in the app's own picker.
+ *
+ * Idempotent: matches on `sourceId`, updates in place rather than minting a
+ * second listing, so re-running after a template's copy changes republishes it
+ * instead of duplicating it. Dry by default; `--apply` writes, `--production`
+ * on top when the target is live.
+ */
+import 'dotenv/config';
+import { eq } from 'drizzle-orm';
+import { db, DiscoverListings } from '../db';
+import { requireDbTarget } from '../utils/require-db-target';
+import { getBuiltInTemplates } from '@/data/note-templates';
+import { resolveNoteTemplateIconColor } from '@/utils/note-template-icon';
+import { bodyHtmlOf, excerptOf, headingsOf } from '../utils/discover-snapshot';
+import { isDiscoverCategory } from '@/data/discover-categories';
+
+/** Where each shipped method belongs. Chosen once, here, rather than guessed
+ *  per run — the reviewer files everything else, and these have no reviewer. */
+const CATEGORY: Record<string, string> = {
+  soap: 'daily-journal',
+  text: 'daily-journal',
+  inductive: 'deep-study',
+  topical: 'topical-study',
+  'chapter-summary': 'book-study',
+  comparative: 'deep-study',
+};
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const apply = argv.includes('--apply');
+  requireDbTarget({ scriptName: 'discover:seed-builtins', writes: apply, argv, env: process.env });
+
+  const now = new Date();
+  let created = 0;
+  let updated = 0;
+
+  for (const template of getBuiltInTemplates()) {
+    const category = CATEGORY[template.id];
+    if (!category || !isDiscoverCategory(category)) {
+      console.log(`  SKIP  ${template.id} — no category mapped`);
+      continue;
+    }
+
+    const payload = JSON.stringify({
+      name: template.name,
+      title: template.titleTemplate || null,
+      content: template.content,
+      noteType: template.noteType,
+      iconColor: template.iconColor,
+    });
+
+    const preview = JSON.stringify({
+      titleTemplate: template.titleTemplate || null,
+      iconColor: resolveNoteTemplateIconColor(template.id, template.iconColor),
+      headings: headingsOf(template.content),
+      excerpt: excerptOf(template.content),
+      bodyHtml: bodyHtmlOf(template.content),
+      /* The whole reason these can skip the queue: they are the product's. */
+      official: true,
+    });
+
+    const existing = (
+      await db
+        .select({ id: DiscoverListings.id, slug: DiscoverListings.slug })
+        .from(DiscoverListings)
+        .where(eq(DiscoverListings.sourceId, template.id))
+        .limit(1)
+    )[0];
+
+    if (existing) {
+      updated += 1;
+      console.log(`  ${apply ? 'UPDATE' : 'would update'}  ${existing.slug} — ${template.name}`);
+      if (apply) {
+        await db
+          .update(DiscoverListings)
+          .set({ title: template.name, description: template.description, category, payload, preview, updatedAt: now })
+          .where(eq(DiscoverListings.id, existing.id));
+      }
+      continue;
+    }
+
+    created += 1;
+    const slug = slugify(template.name);
+    console.log(`  ${apply ? 'CREATE' : 'would create'}  ${slug.padEnd(20)} ${category.padEnd(15)} ${template.name}`);
+    if (apply) {
+      await db.insert(DiscoverListings).values({
+        id: `dsc_${crypto.randomUUID()}`,
+        kind: 'template',
+        sourceId: template.id,
+        submittedByUserId: process.env.HARVOUS_SYSTEM_USER_ID ?? 'harvous',
+        /* Null on purpose — the card reads "Included" from `preview.official`,
+           and a byline here would be a person who did not write it. */
+        authorDisplayName: null,
+        title: template.name,
+        description: template.description,
+        category,
+        slug,
+        payload,
+        preview,
+        status: 'listed',
+        installCount: 0,
+        listedAt: now,
+        staffReadAt: now,
+        reviewedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+  }
+
+  console.log(
+    `\n${created} to create, ${updated} to update` +
+      (apply ? ' — applied.' : '. Dry run: pass --apply to write.'),
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
The catalog was empty — honestly so, since nothing had been submitted, but a poor first impression of a feature whose point is "here is study you can start from", and harvous.com's `/discover/` pages exist to be found by people who do not have an account yet.

This publishes the six built-in study methods: **SOAP, TEXT, Inductive Study, Topical Study, Chapter Summary, Comparative Study.** They are real, they are already what every new account gets, and they are ours to publish.

## Why they skip submit → review

That flow exists so a stranger's work is read before it becomes public. The publisher here *is* Harvous, so queueing our own shipped content in order to approve it would be theatre. They are written straight to `status: 'listed'` with `preview.official`, which is what makes the card read **"Included"** rather than crediting a person who did not write it.

A built-in has no `NoteTemplates` row — it lives in code — so `sourceId` holds the built-in's own id (`soap`, `inductive`, …). That is also what `resolveNoteTemplateIconColor` keys on, so each listing keeps the colour it wears in the app's own picker: SOAP blue, TEXT purple, Inductive orange, Topical green, Chapter Summary pink, Comparative yellow.

## Applied to production

```
CREATE  soap                 daily-journal   SOAP
CREATE  text                 daily-journal   TEXT
CREATE  inductive-study      deep-study      Inductive Study
CREATE  topical-study        topical-study   Topical Study
CREATE  chapter-summary      book-study      Chapter Summary
CREATE  comparative-study    deep-study      Comparative Study
```

Export confirms six listings, `official: true` and `authorDisplayName: null` on every one, each carrying its own `bodyHtml`. Pairs with harvouscom/harvous.com#15, which commits the synced catalog file.

The script matches on `sourceId` and updates in place, so re-running after a template's copy changes republishes rather than duplicating. **Caveat:** I could not re-run the dry pass after applying to prove that empirically — the shared Supabase session pool (15 clients) was saturated by other dev servers and every retry returned `EMAXCONNSESSION`. The apply itself is verified by the export showing exactly six rows with six distinct slugs.

## The loop, walked live

Against production, with a throwaway template, removed afterwards:

| Step | Result |
|---|---|
| Submit | listing created (first attempt 500'd on the same pool exhaustion; fine on retry) |
| Before approval | **invisible** to the anonymous read |
| In the admin queue | present, with `official` and the author's `iconColor` intact |
| Approve with no category | refused, `BAD_CATEGORY` |
| Approve, marked Included | `listed`, slug assigned |
| Review a second time | refused, `ALREADY_REVIEWED` |
| Public list + detail | visible; headings and body present |
| Export | carries it |
| Self-install | refused, `SELF_INSTALL` |
| Delist | gone from list, detail 404s |
| Export after delist | 0 — once past its deliberate 300s cache |

Install-as-another-user and the double-install idempotency were **not** re-run: doing so needs a second identity, and the DB write to arrange one was declined here. `server/utils/discover-install.ts` is byte-identical to the commit whose live install walk is recorded in #85, and the only install-related diffs since are comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)