### PR TITLE
perf(home): re-land the settle work, with the fix it needed

### DIFF
--- a/server/routes/navigation.ts
+++ b/server/routes/navigation.ts
@@ -34,6 +34,13 @@ route.get('/api/navigation/data', async (c) => {
 
     // Ensure user cache exists before reading thread list.
     await getCachedUserData(userId);
+    /*
+     * Serial, and it has to be. The purge deletes notes, `ensurePersonalHomeSpace` backfills the
+     * ones that are left, and the junction repair reads what both of them have settled on — run
+     * together they race over the same rows, and the repair can create a junction for a note the
+     * purge is deleting. ~400ms of the request lives here; taking it off the critical path means
+     * changing how often these heal, which is a different change from making them faster.
+     */
     await purgeOnboardingContentForUser(userId);
     await ensurePersonalHomeSpace(userId);
     // Classic thread lists use NoteThreads junction; heal desynced threadId rows on nav load.

--- a/server/routes/review.ts
+++ b/server/routes/review.ts
@@ -35,6 +35,8 @@ import {
   chapterTruthFor,
   gradeAnswerFor,
   verseTruthFor,
+  buildReviewItemSummaries,
+  filterAskableReviewRows,
   buildReviewItemViews,
   buildReviewReveal,
   createReviewItem,
@@ -78,7 +80,7 @@ route.get('/api/review/inbox', requireAuth, rateLimit('read'), requireFeature('r
     await refillReviewQueue(auth.userId, now);
 
     /*
-     * Fetch, then drop, then cut — in that order.
+     * Fetch, then drop, then cut — in that order, and only then build.
      *
      * A note item the resolver can ask nothing about is dropped while views are built, so cutting
      * to three rows first means a dropped item costs a slot. It showed one question with three
@@ -86,14 +88,27 @@ route.get('/api/review/inbox', requireAuth, rateLimit('read'), requireFeature('r
      * same trick `review-opportunities.ts` uses when the floor turns a candidate away.
      *
      * One extra row beyond the cut, purely to answer `hasMore` without a second count query.
+     *
+     * `filterAskableReviewRows` first, so the build is not handed rows already known to be
+     * unaskable — but the cut still happens *after* the build, and that ordering is not an
+     * oversight to optimise away later.
+     *
+     * It was optimised away once. Cutting to three before building looked equivalent, because
+     * the filter was believed to apply every drop rule the build applies. It applied two of
+     * three: a chapter whose text cannot be fetched is only discoverable once that text has been
+     * asked for. So a chapter in the top three was dropped during the build, the inbox came back
+     * short, short enough came back empty, and the Review section rendered nothing at all in
+     * production. The slack listed beyond the three rows exists precisely so a late drop costs a
+     * row from the tail rather than from what is shown, and cutting first threw that away.
      */
     const due = await listDueReviewItems(
       auth.userId,
       REVIEW_INBOX_MAX_ROWS + 1 + REVIEW_INBOX_UNASKABLE_SLACK,
       now,
     );
-    const askable = await buildReviewItemViews(auth.userId, due, { dropUnaskable: true });
-    const items = askable.slice(0, REVIEW_INBOX_MAX_ROWS);
+    const askable = await filterAskableReviewRows(auth.userId, due, { dropUnaskable: true });
+    const built = await buildReviewItemViews(auth.userId, askable, { dropUnaskable: true });
+    const items = built.slice(0, REVIEW_INBOX_MAX_ROWS);
 
     /*
      * Why there is nothing, when there is nothing.
@@ -109,7 +124,9 @@ route.get('/api/review/inbox', requireAuth, rateLimit('read'), requireFeature('r
     return c.json({
       success: true,
       items,
-      hasMore: askable.length > REVIEW_INBOX_MAX_ROWS,
+      /* `built`, not `askable`: the build applies one drop rule the filter cannot, so the count
+         that answers "is there more" has to be the built one. See the note above the cut. */
+      hasMore: built.length > REVIEW_INBOX_MAX_ROWS,
       coldStart: coldStart
         ? { ready: coldStart.ready, needed: coldStart.needed, opensAt: coldStart.opensAt?.toISOString() ?? null }
         : null,
@@ -124,7 +141,18 @@ route.get('/api/review/inbox', requireAuth, rateLimit('read'), requireFeature('r
   }
 });
 
-/** The manage list: everything, or one status. Used by the Review page, not the inbox. */
+/**
+ * The manage list: everything, or one status. Used by the Review page, not the inbox.
+ *
+ * `view=summary` returns the same rows without building a question for any of them — see
+ * `ReviewItemSummary`. Home asks for that on every load, because it reads this list for the
+ * suggestion handoff and for two fold counts and renders none of it; the full build was
+ * assembling eighteen questions to show at most two, on the critical path of the first paint.
+ * The full shape is fetched when a reader actually opens a fold, which is a press that can carry
+ * its own wait.
+ *
+ * Additive: no parameter means the old payload, so every existing consumer is untouched.
+ */
 route.get('/api/review/items', requireAuth, rateLimit('read'), requireFeature('review'), async (c) => {
   try {
     const auth = getAuthenticatedAuth(c);
@@ -132,10 +160,20 @@ route.get('/api/review/items', requireAuth, rateLimit('read'), requireFeature('r
     if (statusParam && !isReviewItemStatus(statusParam)) {
       return c.json({ error: 'Unknown status', code: 'REVIEW_STATUS_INVALID' }, 400);
     }
+    // Rejected rather than ignored, the same way an unknown status is: a typo that silently
+    // returned the expensive shape would be a performance regression nobody could see.
+    const viewParam = c.req.query('view');
+    if (viewParam && viewParam !== 'summary') {
+      return c.json({ error: 'Unknown view', code: 'REVIEW_VIEW_INVALID' }, 400);
+    }
     const rows = await listReviewItems(
       auth.userId,
       statusParam && isReviewItemStatus(statusParam) ? statusParam : undefined,
     );
+    if (viewParam === 'summary') {
+      const items = await buildReviewItemSummaries(auth.userId, rows, { dropUnaskable: true });
+      return c.json({ success: true, items });
+    }
     const items = await buildReviewItemViews(auth.userId, rows, { dropUnaskable: true });
     return c.json({ success: true, items });
   } catch (error) {

--- a/server/utils/__tests__/review-askable-rules-parity.test.ts
+++ b/server/utils/__tests__/review-askable-rules-parity.test.ts
@@ -1,0 +1,71 @@
+/**
+ * `filterAskableReviewRows` and `buildReviewItemViews` must drop the same rows.
+ *
+ * They are two answers to one question — which stored rows become rows a reader can be asked
+ * about — and they exist separately only so counting a queue does not cost what building one
+ * does. When they disagree, the queue lies: a fold says "12 more" and opens onto eleven, or the
+ * inbox reports three and returns two.
+ *
+ * This is not hypothetical. The filter shipped with two of the build's three drop rules, missing
+ * the one that needs a chapter's text — and because the inbox had been changed to cut to three
+ * rows *before* building, a single unfetchable chapter in the top three took the whole Review
+ * section off Home in production.
+ *
+ * Read from the source because both sides are database calls end to end; there is no seam to
+ * unit test without standing one up. What it can still do is fail the moment the two counts
+ * diverge, which is the only warning that would have helped.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const source = readFileSync(join(process.cwd(), 'server/utils/review-service.ts'), 'utf8');
+
+function bodyOf(signature: string): string {
+  const start = source.indexOf(signature);
+  expect(start, `${signature} not found`).toBeGreaterThan(-1);
+  // Both functions end at the next top-level declaration.
+  const rest = source.slice(start + signature.length);
+  const end = rest.search(/\n(?:export )?(?:async )?function |\n\/\*\*/);
+  return rest.slice(0, end === -1 ? undefined : end);
+}
+
+const buildBody = bodyOf('export async function buildReviewItemViews');
+const filterBody = bodyOf('export async function filterAskableReviewRows');
+
+describe('askable-row rules stay in step', () => {
+  it('the build drops rows in exactly three places', () => {
+    /*
+     * A guard on the number, not the wording. If a fourth `continue` appears in the build loop,
+     * this fails — and the fix is to teach `filterAskableReviewRows` the same rule, not to bump
+     * the number. Counting anything the reader can still be asked about as askable is the whole
+     * contract between these two.
+     */
+    const drops = buildBody.match(/\bcontinue;/g) ?? [];
+    expect(drops).toHaveLength(3);
+  });
+
+  it('the filter rejects rows in the same three places', () => {
+    const rejects = filterBody.match(/\breturn false;/g) ?? [];
+    expect(rejects).toHaveLength(3);
+  });
+
+  it('both know the kind rule', () => {
+    expect(buildBody).toContain('isReviewAskableKind');
+    expect(filterBody).toContain('isReviewAskableKind');
+  });
+
+  it('both know the unaskable-note rule', () => {
+    expect(buildBody).toContain('noteRungFor');
+    expect(filterBody).toContain('noteRungFor');
+  });
+
+  it('both know the chapter-without-text rule', () => {
+    // The one that was missing. The build reads it off loaded chapter material; the filter asks
+    // the cheaper question — are there verses at all — but it must ask it.
+    expect(buildBody).toContain("kind === 'chapter'");
+    expect(buildBody).toContain('verses.length');
+    expect(filterBody).toContain("kind === 'chapter'");
+    expect(filterBody).toContain('splitChapterHtmlIntoVerses');
+  });
+});

--- a/server/utils/__tests__/thread-junction-repair.test.ts
+++ b/server/utils/__tests__/thread-junction-repair.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The four conditions that decide which junctions get healed.
+ *
+ * Read from the source rather than executed, because the whole function is now one query — there
+ * is no seam left to unit test without standing up a database, and the repo's other server-util
+ * tests are pure functions over injected rows. What this guards is a later edit quietly dropping
+ * a clause while the query still compiles and still looks right.
+ *
+ * Two of the four are not performance details. `Threads.userId` and `Notes.userId` are what keep
+ * a heal inside one account: without the thread-side check a note pointing at someone else's
+ * thread id would have a junction created into it. The other two keep the repair create-only and
+ * off the unorganized bucket.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const source = readFileSync(
+  join(process.cwd(), 'server/utils/thread-junction-repair.ts'),
+  'utf8',
+);
+const query = source.slice(source.indexOf('const missing'), source.indexOf('let created'));
+
+describe('repairMissingNoteThreadJunctionsForUser', () => {
+  it('only ever heals notes belonging to the user it was asked about', () => {
+    expect(query).toContain('eq(Notes.userId, userId)');
+  });
+
+  it('only links threads belonging to that same user', () => {
+    // The inner join is the ownership check. Losing it lets a stale `Notes.threadId` pointing at
+    // another account's thread create a junction into it.
+    expect(query).toContain('eq(Threads.userId, userId)');
+    expect(query).toContain('innerJoin(Threads');
+  });
+
+  it('leaves the unorganized bucket alone', () => {
+    expect(query).toContain("ne(Notes.threadId, 'thread_unorganized')");
+  });
+
+  it('stays create-only: it selects the pairs that have no junction yet', () => {
+    expect(query).toContain('leftJoin(');
+    expect(query).toContain('isNull(NoteThreads.noteId)');
+  });
+
+  it('asks the database which rows need repairing rather than diffing whole tables', () => {
+    // The shape this replaced read every note, every thread and every junction for the account
+    // on each `/api/navigation/data` load — a full scan to discover there was nothing to do.
+    expect(source).not.toContain('noteThreadPairs');
+    expect(source.match(/await db\s*\n?\s*\.select/g) ?? []).toHaveLength(1);
+  });
+});

--- a/server/utils/review-service.ts
+++ b/server/utils/review-service.ts
@@ -265,6 +265,33 @@ export interface ReviewItemView {
 }
 
 /**
+ * The same queue, without building a question for any of it.
+ *
+ * Home reads the active list on every load and renders none of it: the suggestion handoff wants
+ * `kind` and `scriptureReference` so a passage already in Review is not also offered as a nudge,
+ * and the Review section wants counts — how many are due, how many are coming back. The rows a
+ * reader actually sees when the section is closed come from `/api/review/inbox`, which is a
+ * different request capped at three.
+ *
+ * So the full build was assembling eighteen questions — cue text, cross-reference openings,
+ * curated knowledge, a database round trip apiece — to render at most two, on the critical path
+ * of Home's first paint. Measured at 3.4s against 750ms for this.
+ *
+ * Membership is identical to {@link buildReviewItemViews}: same askable-kind rule, same
+ * unaskable-note drop, via the same `noteRungFor`. A count from one and a list from the other is
+ * how a "12 more" fold opens onto eleven rows.
+ */
+export interface ReviewItemSummary {
+  id: string;
+  kind: ReviewItemKind;
+  status: ReviewItemStatus;
+  recallState: RecallState;
+  dueAt: string;
+  scriptureReference: string | null;
+  noteId: string | null;
+}
+
+/**
  * How much stored body to fetch for one line of context. The same `left()` cap the note list
  * uses, trimmed hard: this becomes ~64 characters on screen.
  */
@@ -617,6 +644,114 @@ async function threadTitleFor(userId: string, repNoteId: string): Promise<string
   return displayTitle(rep.studyThreadTitle) ?? displayTitle(rep.title);
 }
 
+/**
+ * The rung a note item can actually answer, or null when there is nothing to ask about it.
+ *
+ * The stored step is nominal — a note with no links skips past "what did you link this to?"
+ * rather than showing a question with no possible answer, and a note with none of the three is
+ * dropped from the queue entirely. Shared with {@link buildReviewItemSummaries} so the full list
+ * and the counts can never disagree about which rows exist.
+ */
+function noteRungFor(row: ReviewItemRow, material: Map<string, NoteMaterial>) {
+  if (row.kind !== 'note' || !row.noteId) return null;
+  return resolveNoteRung(row.ladderStep, material.get(row.noteId) ?? EMPTY_NOTE_MATERIAL);
+}
+
+/**
+ * Which stored rows are rows a reader can actually be asked about, in order.
+ *
+ * The queue's visibility rules on their own, with no question built for any of them: a kind
+ * Review no longer asks about is dropped, and so is a note the resolver can say nothing about.
+ * Costs one `loadNoteMaterial` — eight batched queries — and only when the list holds notes.
+ *
+ * Extracted because three callers need the same answer at three different prices. The summary
+ * shape below wants it and nothing else; `/api/review/inbox` wants to know *which* rows are
+ * askable before it pays to build any, so it can build the three it will show instead of the
+ * eight it listed; and {@link buildReviewItemViews} applies the same rules while building.
+ */
+export async function filterAskableReviewRows(
+  userId: string,
+  rows: ReviewItemRow[],
+  options: { dropUnaskable?: boolean } = {},
+): Promise<ReviewItemRow[]> {
+  const noteIds = rows
+    .filter((r) => r.kind === 'note')
+    .map((r) => r.noteId)
+    .filter((id): id is string => Boolean(id));
+  const material =
+    options.dropUnaskable && noteIds.length
+      ? await loadNoteMaterial(userId, noteIds)
+      : new Map<string, NoteMaterial>();
+
+  /*
+   * Chapters need their text before we can say whether they are askable, because every rung of a
+   * chapter is built out of its verses — one that could not be fetched is a prompt above nothing.
+   *
+   * This rule was missed when these three were first pulled out of the build loop, and it broke
+   * Review in production: the inbox cut to three rows *before* building, so a chapter that the
+   * build then dropped left the section short, and short enough became empty and the whole
+   * section rendered nothing. The slack the inbox lists beyond its three rows exists for exactly
+   * this and cutting first defeated it.
+   *
+   * `fetchVerseText` rather than `loadChapterMaterial`: the question here is only whether there
+   * are verses at all, which is one cached read per distinct chapter, where the full material
+   * load is five concurrent queries for facts only a built prompt needs.
+   */
+  const chapterRefs = options.dropUnaskable
+    ? [
+        ...new Set(
+          rows
+            .filter((r) => r.kind === 'chapter' && r.scriptureReference)
+            .map((r) => `${r.scriptureReference}|${r.translation ?? 'NET'}`),
+        ),
+      ]
+    : [];
+  const chapterHasVerses = new Map<string, boolean>();
+  await Promise.all(
+    chapterRefs.map(async (key) => {
+      const [reference, translation] = key.split('|');
+      const parts = chapterKeyPartsFromReference(reference);
+      const html = parts
+        ? await fetchVerseText(chapterReferenceLabel(parts), translation).catch(() => '')
+        : '';
+      chapterHasVerses.set(key, Boolean(html) && splitChapterHtmlIntoVerses(html).length > 0);
+    }),
+  );
+
+  return rows.filter((row) => {
+    const kind = row.kind as ReviewItemKind;
+    if (!isReviewAskableKind(kind)) return false;
+    if (kind === 'note' && options.dropUnaskable && !noteRungFor(row, material)) return false;
+    if (kind === 'chapter' && options.dropUnaskable) {
+      const key = `${row.scriptureReference}|${row.translation ?? 'NET'}`;
+      if (!chapterHasVerses.get(key)) return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Counts and routing keys for a queue, with no question built for any row.
+ *
+ * See {@link ReviewItemSummary} for why this exists.
+ */
+export async function buildReviewItemSummaries(
+  userId: string,
+  rows: ReviewItemRow[],
+  options: { dropUnaskable?: boolean } = {},
+): Promise<ReviewItemSummary[]> {
+  const askable = await filterAskableReviewRows(userId, rows, options);
+  return askable.map((row) => ({
+    id: row.id,
+    kind: row.kind as ReviewItemKind,
+    status: row.status as ReviewItemStatus,
+    recallState: row.recallState as RecallState,
+    dueAt: row.dueAt.toISOString(),
+    scriptureReference: row.scriptureReference,
+    noteId: row.noteId,
+  }));
+}
+
 export async function buildReviewItemViews(
   userId: string,
   rows: ReviewItemRow[],
@@ -765,10 +900,7 @@ export async function buildReviewItemViews(
      * is nominal; a note with no links skips past "what did you link this to?" rather than
      * showing a question with no possible answer.
      */
-    const noteRung =
-      kind === 'note' && row.noteId
-        ? resolveNoteRung(row.ladderStep, material.get(row.noteId) ?? EMPTY_NOTE_MATERIAL)
-        : null;
+    const noteRung = noteRungFor(row, material);
 
     /*
      * A note the resolver can ask nothing about is not shown at all.
@@ -1627,12 +1759,25 @@ async function loadVerseMaterial(
   const targets = (knowledge?.crossReferences ?? [])
     .filter((c) => c.chapterStart === c.chapterEnd)
     .slice(0, CROSSREF_TEXT_FETCHES);
-  const crossRefs: { reference: string; text: string }[] = [];
-  for (const c of targets) {
-    const targetRef = `${c.book} ${c.chapterStart}:${c.verseStart}`;
-    const html = await fetchVerseText(targetRef, translation);
-    if (html) crossRefs.push({ reference: targetRef, text: stripHtml(html) });
-  }
+  /*
+   * The three cross-reference openings, fetched together rather than one after another.
+   *
+   * `fetchVerseText` is a database round trip (a `VerseTextCache` read, then `BibleVerses`, then
+   * a cache write) — not an in-memory lookup — so awaiting them in a loop cost three serial trips
+   * per verse item. A queue of eighteen paid that eighteen times over, and it was the largest
+   * single component of a `/api/review/items` response that Home's first paint waits on.
+   *
+   * `Promise.all` preserves order, and the falsy-`html` rows are dropped after rather than never
+   * pushed, so the list this returns is identical to the one the loop built.
+   */
+  const crossRefTargets = targets.map((c) => `${c.book} ${c.chapterStart}:${c.verseStart}`);
+  const crossRefHtml = await Promise.all(
+    crossRefTargets.map((targetRef) => fetchVerseText(targetRef, translation)),
+  );
+  const crossRefs = crossRefTargets
+    .map((reference, i) => ({ reference, html: crossRefHtml[i] }))
+    .filter((entry) => Boolean(entry.html))
+    .map((entry) => ({ reference: entry.reference, text: stripHtml(entry.html) }));
 
   return {
     reference: ref,

--- a/server/utils/thread-junction-repair.ts
+++ b/server/utils/thread-junction-repair.ts
@@ -1,34 +1,44 @@
 /**
  * Create-only repair for Classic thread visibility: insert missing NoteThreads rows
  * when Notes.threadId already points at a real thread. Does not delete orphans.
+ *
+ * Runs on every `/api/navigation/data` load, which is what makes its shape matter. It used to
+ * read three whole tables for the account — every note, every thread, every junction — and diff
+ * them in JavaScript to find the rows to insert. On a healthy account that is a full scan to
+ * discover there is nothing to do, and it grows with the library while navigation is on the
+ * critical path of every space-scoped query on Home. Measured at 243ms for thirty notes.
+ *
+ * The join below asks the database the question directly and gets back only the rows that need
+ * repairing, which is almost always none. Same four conditions as the old diff, in the same
+ * order of meaning: the note belongs to this reader, it points at a thread, that thread is not
+ * the unorganized bucket, that thread is really theirs (the inner join), and no junction for the
+ * pair exists yet (the left join's null).
  */
 
-import { db, Notes, Threads, NoteThreads, eq } from '../db';
+import { db, Notes, Threads, NoteThreads, and, eq, isNotNull, isNull, ne } from '../db';
 import { nowISO } from '../db/dates';
 
 export async function repairMissingNoteThreadJunctionsForUser(userId: string): Promise<number> {
-  const userNotes = await db
+  const missing = await db
     .select({ id: Notes.id, threadId: Notes.threadId })
     .from(Notes)
-    .where(eq(Notes.userId, userId));
-
-  const userThreads = await db.select({ id: Threads.id }).from(Threads).where(eq(Threads.userId, userId));
-  const threadIdSet = new Set(userThreads.map((t) => t.id));
-
-  const allNoteThreads = await db
-    .select({ noteId: NoteThreads.noteId, threadId: NoteThreads.threadId })
-    .from(NoteThreads)
-    .innerJoin(Notes, eq(Notes.id, NoteThreads.noteId))
-    .where(eq(Notes.userId, userId));
-
-  const noteThreadPairs = new Set(allNoteThreads.map((nt) => `${nt.noteId}::${nt.threadId}`));
+    .innerJoin(Threads, and(eq(Threads.id, Notes.threadId), eq(Threads.userId, userId)))
+    .leftJoin(
+      NoteThreads,
+      and(eq(NoteThreads.noteId, Notes.id), eq(NoteThreads.threadId, Notes.threadId)),
+    )
+    .where(
+      and(
+        eq(Notes.userId, userId),
+        isNotNull(Notes.threadId),
+        ne(Notes.threadId, 'thread_unorganized'),
+        isNull(NoteThreads.noteId),
+      ),
+    );
 
   let created = 0;
-  for (const note of userNotes) {
-    if (!note.threadId || note.threadId === 'thread_unorganized' || !threadIdSet.has(note.threadId)) continue;
-    const key = `${note.id}::${note.threadId}`;
-    if (noteThreadPairs.has(key)) continue;
-
+  for (const note of missing) {
+    if (!note.threadId) continue;
     const id = `nt-heal-${note.id}-${note.threadId}-${Date.now()}`;
     try {
       await db.insert(NoteThreads).values({
@@ -37,7 +47,6 @@ export async function repairMissingNoteThreadJunctionsForUser(userId: string): P
         threadId: note.threadId,
         createdAt: nowISO(),
       });
-      noteThreadPairs.add(key);
       created++;
     } catch {
       // unique constraint = already exists, skip

--- a/spa/src/hooks/__tests__/warm-default-translation-pack.test.tsx
+++ b/spa/src/hooks/__tests__/warm-default-translation-pack.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * The offline pack downloads the whole canon a book at a time, and it must not do that while the
+ * first screen is still asking for its own data.
+ *
+ * Over HTTP/1.1 the opening burst is already queueing against a six-connection cap, so 66 book
+ * requests starting the moment `profile` landed were competing with the page the reader is
+ * looking at. Nothing about the pack is urgent — it resumes where it left off and exists for a
+ * signal outage that has not happened yet.
+ *
+ * The other half is the one worth a test: a gate that never opens would silently stop offline
+ * packs from ever downloading, and nobody would find out until they lost signal.
+ */
+const profile = { data: { defaultTranslation: 'NET' } as { defaultTranslation: string } | undefined };
+vi.mock('../queries/useProfile', () => ({ useProfile: () => profile }));
+vi.mock('../../lib/api', () => ({ api: { get: vi.fn(async () => ({})) } }));
+
+const downloadPack = vi.fn(async () => ({ booksSaved: 66, booksTotal: 66, aborted: false }));
+vi.mock('@/utils/bible-pack-store', () => ({
+  listPacks: async () => [],
+  canAddPack: () => true,
+  downloadPack: (...args: unknown[]) => downloadPack(...(args as [])),
+}));
+
+import { useWarmDefaultTranslationPack } from '../useWarmDefaultTranslationPack';
+
+let client: QueryClient;
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={client}>{children}</QueryClientProvider>
+);
+
+/** A query that stays in flight until the test lets it finish. */
+function startBusyQuery(key: string) {
+  let release!: () => void;
+  const done = new Promise<string>((resolve) => {
+    release = () => resolve('ok');
+  });
+  void client.fetchQuery({ queryKey: [key], queryFn: () => done });
+  return release;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  downloadPack.mockClear();
+  profile.data = { defaultTranslation: 'NET' };
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useWarmDefaultTranslationPack', () => {
+  it('does not start while the app still has requests in flight', async () => {
+    startBusyQuery('busy');
+    renderHook(() => useWarmDefaultTranslationPack(), { wrapper });
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(downloadPack).not.toHaveBeenCalled();
+  });
+
+  it('starts once the app has been quiet for a moment', async () => {
+    const release = startBusyQuery('busy');
+    renderHook(() => useWarmDefaultTranslationPack(), { wrapper });
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(downloadPack).not.toHaveBeenCalled();
+
+    release();
+    await vi.advanceTimersByTimeAsync(1200);
+    expect(downloadPack).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts anyway when the app never goes quiet', async () => {
+    // A surface that polls would otherwise hold the pack off for the whole session. A pack that
+    // never downloads because someone left a dashboard open is worse than one that shares.
+    startBusyQuery('forever');
+    renderHook(() => useWarmDefaultTranslationPack(), { wrapper });
+
+    await vi.advanceTimersByTimeAsync(16_000);
+    expect(downloadPack).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for a profile before doing anything at all', async () => {
+    profile.data = undefined;
+    renderHook(() => useWarmDefaultTranslationPack(), { wrapper });
+
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(downloadPack).not.toHaveBeenCalled();
+  });
+});

--- a/spa/src/hooks/queries/__tests__/church-sermons-settled.test.tsx
+++ b/spa/src/hooks/queries/__tests__/church-sermons-settled.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * The flag that made Home's presentation gate inert for anyone without a church.
+ *
+ * `useChurchSermons` is `enabled: … && connected`, and a disabled query keeps `status: 'pending'`
+ * forever in React Query v5 — so a settled check written as `!isPending || hasData` answered
+ * "still loading" for a query that was never going to load. ANDed into
+ * `isPrototypeHomePresentationReady`, that made `presentationReady` permanently false: every cold
+ * load reached `contentReady` through the 2.5s deadline instead, painting with whatever had
+ * arrived and growing the rest a section at a time.
+ *
+ * Tested through the real hook rather than through `isQuerySettled` alone, because the fix leans
+ * on `isEnabled` being a field React Query actually publishes on the result. If a version bump
+ * ever dropped it the argument would arrive as `undefined`, the default would take over, and this
+ * would quietly go back to waiting forever on a query that never runs — with nothing failing.
+ */
+const profile = {
+  data: undefined as undefined | { connectedOrgId: string | null },
+  isPending: false,
+  isPlaceholderData: false,
+};
+
+vi.mock('@clerk/clerk-react', () => ({
+  useAuth: () => ({ userId: 'user_derek', isLoaded: true, isSignedIn: true, getToken: async () => 'jwt' }),
+}));
+vi.mock('../../useAuthReady', () => ({ useAuthReady: () => true }));
+vi.mock('../useProfile', () => ({ useProfile: () => profile }));
+vi.mock('../../../lib/api', () => ({ api: { get: vi.fn(async () => ({ connected: true, services: [] })) } }));
+
+import { api } from '../../../lib/api';
+import { useChurchSermons } from '../useChurchSermons';
+
+let client: QueryClient;
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={client}>{children}</QueryClientProvider>
+);
+
+beforeEach(() => {
+  vi.mocked(api.get).mockClear();
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  profile.data = { connectedOrgId: null };
+  profile.isPending = false;
+  profile.isPlaceholderData = false;
+});
+
+describe('useChurchSermons settled reporting', () => {
+  it('publishes isEnabled, which the whole fix rests on', () => {
+    const { result } = renderHook(() => useChurchSermons(), { wrapper });
+    expect(typeof result.current.isEnabled).toBe('boolean');
+  });
+
+  it('is settled for an account with no church — it will never run', () => {
+    const { result } = renderHook(() => useChurchSermons(), { wrapper });
+    expect(result.current.isEnabled).toBe(false);
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.isSettled).toBe(true);
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  /*
+   * The trap in the fix, and the reason the precondition lives in this hook rather than at the
+   * gate. `connected` is read off profile data, so before that lands the query is disabled
+   * *transiently* — calling it settled there would let Home paint and then pop "This Sunday" in
+   * afterwards for exactly the accounts that have one.
+   */
+  it('is not settled while the profile that decides it is still loading', () => {
+    profile.data = undefined;
+    profile.isPending = true;
+    const { result } = renderHook(() => useChurchSermons(), { wrapper });
+    expect(result.current.isSettled).toBe(false);
+  });
+
+  it('is not settled on a profile placeholder, which can be missing connectedOrgId', () => {
+    // The sessionStorage snapshot carries only the fields the build that wrote it knew about,
+    // and `connectedOrgId` is the one field this reads. See the placeholder note in useProfile.
+    profile.data = {} as { connectedOrgId: string | null };
+    profile.isPlaceholderData = true;
+    const { result } = renderHook(() => useChurchSermons(), { wrapper });
+    expect(result.current.isSettled).toBe(false);
+  });
+
+  it('waits for the answer when there is a church to ask about', async () => {
+    profile.data = { connectedOrgId: 'org_1' };
+    const { result } = renderHook(() => useChurchSermons(), { wrapper });
+    expect(result.current.isEnabled).toBe(true);
+    expect(result.current.isSettled).toBe(false);
+    await waitFor(() => expect(result.current.isSettled).toBe(true));
+    expect(api.get).toHaveBeenCalledWith('/api/church/services');
+  });
+});

--- a/spa/src/hooks/queries/useChallenges.ts
+++ b/spa/src/hooks/queries/useChallenges.ts
@@ -6,6 +6,7 @@ import { api } from '../../lib/api';
 import { useAuthReady } from '../useAuthReady';
 import { useHasFeature } from '../useHasFeature';
 import { useHarvousIdentity } from '../useHarvousIdentity';
+import { isQuerySettled } from '@/utils/prototype-home-ready';
 import type { ChallengeStatus, ChallengeTemplateKey } from '@/utils/review-item-kinds';
 import type { ChallengeStep } from '@/utils/challenge-templates';
 import type { VerseCloze } from '@/utils/verse-cloze';
@@ -86,12 +87,20 @@ export function useChallengesEnabled(): boolean {
   return authReady && access;
 }
 
+/** True once we know whether Challenges runs for this account. See `useReviewAccessSettled`. */
+export function useChallengeAccessSettled(): boolean {
+  const { ready } = useHasFeature('challenges');
+  const { isGuest } = useHarvousIdentity();
+  return isGuest || ready;
+}
+
 export function useChallenges(status?: ChallengeStatus | readonly ChallengeStatus[]) {
   const authReady = useAuthReady();
   const access = useChallengeAccess();
+  const accessSettled = useChallengeAccessSettled();
   const enabled = authReady && access;
   const statusParam = challengeStatusParam(status);
-  return useQuery({
+  const query = useQuery({
     queryKey: challengeListQueryKey(status),
     enabled,
     queryFn: () =>
@@ -100,6 +109,12 @@ export function useChallenges(status?: ChallengeStatus | readonly ChallengeStatu
       ),
     staleTime: 60_000,
   });
+  return {
+    ...query,
+    /** Settled once we know whether it should run — and then only once it has. */
+    isSettled:
+      accessSettled && isQuerySettled(query.isPending, query.data != null, query.isEnabled),
+  };
 }
 
 /** The shared Home list. See {@link HOME_CHALLENGE_STATUSES}. */

--- a/spa/src/hooks/queries/useChurchSermons.ts
+++ b/spa/src/hooks/queries/useChurchSermons.ts
@@ -3,6 +3,7 @@ import { useAuth } from '@clerk/clerk-react';
 import { api } from '../../lib/api';
 import { useAuthReady } from '../useAuthReady';
 import { useProfile } from './useProfile';
+import { isQuerySettled } from '@/utils/prototype-home-ready';
 import type { ChurchClock, ChurchSermon } from '../../lib/church-services';
 
 export type ChurchSermonsResponse = {
@@ -32,13 +33,38 @@ export function churchSermonsQueryKey(userId: string | null | undefined) {
 export function useChurchSermons(options?: { enabled?: boolean }) {
   const { userId } = useAuth();
   const authReady = useAuthReady();
-  const { data: profile } = useProfile();
-  const connected = Boolean(profile?.connectedOrgId);
+  const profileQuery = useProfile();
+  const connected = Boolean(profileQuery.data?.connectedOrgId);
 
-  return useQuery({
+  const query = useQuery({
     queryKey: churchSermonsQueryKey(userId),
     enabled: authReady && !!userId && connected && options?.enabled !== false,
     queryFn: () => api.get<ChurchSermonsResponse>('/api/church/services'),
     staleTime: 60_000,
   });
+
+  /*
+   * Whether this query has finished having anything to say — which, for a query that may never
+   * run at all, is not what `isPending` answers.
+   *
+   * Home's presentation gate ANDs a settled flag per query and paints once. This one is disabled
+   * for every account without a church, and a disabled query keeps `status: 'pending'` forever in
+   * React Query v5, so the flag was permanently false and the gate could never fire: Home reached
+   * `contentReady` only via its 2.5s deadline, on every cold load, painting with whatever had
+   * arrived by then and growing the rest a section at a time.
+   *
+   * The profile half is what keeps the cure from becoming the disease. `connected` is read off
+   * profile data, so before that lands this query is disabled *transiently* — reporting settled
+   * there would let the gate fire early and pop "This Sunday" in late for the accounts that
+   * actually have a church. `isPlaceholderData` is part of it rather than pedantry: the profile's
+   * sessionStorage snapshot can be missing `connectedOrgId` (see the placeholder note in
+   * `useProfile`), which is the one field this reads.
+   */
+  const profileSettled = !profileQuery.isPending && !profileQuery.isPlaceholderData;
+
+  return {
+    ...query,
+    isSettled:
+      profileSettled && isQuerySettled(query.isPending, query.data != null, query.isEnabled),
+  };
 }

--- a/spa/src/hooks/queries/useReview.ts
+++ b/spa/src/hooks/queries/useReview.ts
@@ -13,6 +13,7 @@ import { api } from '../../lib/api';
 import { useAuthReady } from '../useAuthReady';
 import { useHasFeature } from '../useHasFeature';
 import { useHarvousIdentity } from '../useHarvousIdentity';
+import { isQuerySettled } from '@/utils/prototype-home-ready';
 import type {
   RecallState,
   ReviewItemKind,
@@ -49,6 +50,23 @@ export interface ReviewItemView {
   /** Why this row is here, in the reader's words. Null on items they added themselves. */
   sourceLabel: string | null;
   sourceAt: string | null;
+}
+
+/**
+ * The same queue, without a question built for any row — see `useReviewItemsSummary`.
+ *
+ * Everything here is a column on the stored item, so the server can answer with one list query
+ * (plus one batched read to drop notes it can ask nothing about, which is what keeps this list's
+ * membership identical to the full one's).
+ */
+export interface ReviewItemSummary {
+  id: string;
+  kind: ReviewItemKind;
+  status: ReviewItemStatus;
+  recallState: RecallState;
+  dueAt: string;
+  scriptureReference: string | null;
+  noteId: string | null;
 }
 
 export interface ReviewInboxResponse {
@@ -114,8 +132,8 @@ export interface ReviewRevealResponse {
 export const reviewQueryKey = ['review'] as const;
 export const reviewInboxQueryKey = ['review', 'inbox'] as const;
 export const reviewSessionQueryKey = ['review', 'session'] as const;
-export const reviewItemsQueryKey = (status?: ReviewItemStatus) =>
-  ['review', 'items', status ?? 'all'] as const;
+export const reviewItemsQueryKey = (status?: ReviewItemStatus, view: 'full' | 'summary' = 'full') =>
+  ['review', 'items', status ?? 'all', view] as const;
 
 /*
  * Called unconditionally, then combined — never `authReady && useAccess()`.
@@ -149,23 +167,50 @@ export function useReviewEnabled(): boolean {
   return authReady && access;
 }
 
+/**
+ * True once we know whether Review runs for this account — not whether it does.
+ *
+ * The distinction is what Home's presentation gate needs. Every query below is disabled without
+ * the entitlement, and a disabled query keeps `status: 'pending'` forever in React Query v5, so
+ * "is it still loading" cannot tell a free account (never will load) from a subscriber whose
+ * entitlement has not answered yet (about to). Gating on the first and not the second is what
+ * lets Home paint once *and* paint with Review already in it.
+ *
+ * A guest is settled immediately: they have no account to hold a key, so the answer is a
+ * structural no rather than a pending one, and `useHasFeature` would leave `ready` false forever
+ * for them because the subscription query never runs at all.
+ */
+export function useReviewAccessSettled(): boolean {
+  const { ready } = useHasFeature('review');
+  const { isGuest } = useHarvousIdentity();
+  return isGuest || ready;
+}
+
 export function useReviewInbox() {
   const authReady = useAuthReady();
   const access = useReviewAccess();
+  const accessSettled = useReviewAccessSettled();
   const enabled = authReady && access;
-  return useQuery({
+  const query = useQuery({
     queryKey: reviewInboxQueryKey,
     enabled,
     queryFn: () => api.get<ReviewInboxResponse>('/api/review/inbox'),
     staleTime: 60_000,
   });
+  return {
+    ...query,
+    /** Settled once we know whether it should run — and then only once it has. */
+    isSettled:
+      accessSettled && isQuerySettled(query.isPending, query.data != null, query.isEnabled),
+  };
 }
 
 export function useReviewItems(status?: ReviewItemStatus, options?: { enabled?: boolean }) {
   const authReady = useAuthReady();
   const access = useReviewAccess();
+  const accessSettled = useReviewAccessSettled();
   const enabled = authReady && access;
-  return useQuery({
+  const query = useQuery({
     queryKey: reviewItemsQueryKey(status),
     // The caller's `enabled` narrows, never widens: the dock only wants this list when the
     // session cannot answer, and no caller may bypass the auth/entitlement gate.
@@ -176,6 +221,54 @@ export function useReviewItems(status?: ReviewItemStatus, options?: { enabled?: 
       ),
     staleTime: 30_000,
   });
+  return {
+    ...query,
+    /*
+     * See `useReviewAccessSettled`. This one matters to Home beyond its own rows: the `active`
+     * list is what the suggestion handoff reads to step Home's resurfacing cards aside for a
+     * passage Review has already taken up, so arriving late does not add a section — it *removes*
+     * cards from a deck someone is already reading.
+     */
+    isSettled:
+      accessSettled && isQuerySettled(query.isPending, query.data != null, query.isEnabled),
+  };
+}
+
+/**
+ * The same queue, counted rather than built.
+ *
+ * Home reads the active list on every load and renders none of it — the suggestion handoff wants
+ * kinds and references, the Review section wants counts, and the rows it shows come from
+ * `useReviewInbox`. Asking for the full shape meant the server assembled a question per item, at
+ * 3.4s for eighteen of them, on the critical path of Home's first paint.
+ *
+ * A hook of its own rather than an option on `useReviewItems`, because the payload is a different
+ * type and a union return would push that choice out to every call site. Its own query key too,
+ * so the two shapes cannot overwrite each other in the cache; both still sit under the `review`
+ * prefix every mutation invalidates.
+ */
+export function useReviewItemsSummary(status?: ReviewItemStatus, options?: { enabled?: boolean }) {
+  const authReady = useAuthReady();
+  const access = useReviewAccess();
+  const accessSettled = useReviewAccessSettled();
+  const enabled = authReady && access;
+  const query = useQuery({
+    queryKey: reviewItemsQueryKey(status, 'summary'),
+    enabled: enabled && options?.enabled !== false,
+    queryFn: () =>
+      api.get<{ items: ReviewItemSummary[] }>(
+        status
+          ? `/api/review/items?status=${encodeURIComponent(status)}&view=summary`
+          : '/api/review/items?view=summary',
+      ),
+    staleTime: 30_000,
+  });
+  return {
+    ...query,
+    /** See `useReviewAccessSettled`. This is the flag Home's presentation gate waits on. */
+    isSettled:
+      accessSettled && isQuerySettled(query.isPending, query.data != null, query.isEnabled),
+  };
 }
 
 /**

--- a/spa/src/hooks/useWarmDefaultTranslationPack.ts
+++ b/spa/src/hooks/useWarmDefaultTranslationPack.ts
@@ -1,7 +1,19 @@
 import { useEffect, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useProfile } from './queries/useProfile';
 import { api } from '../lib/api';
 import { canAddPack, downloadPack, listPacks } from '@/utils/bible-pack-store';
+
+/**
+ * How long the app has to stay quiet before the pack is allowed to start, and how long we wait
+ * for that quiet before giving up on it.
+ *
+ * A second of no fetches means the first screen has what it asked for. The ceiling is there
+ * because a surface that polls would otherwise never be quiet, and a pack that never downloads
+ * because someone left a dashboard open is worse than one that shares the pipe for a while.
+ */
+const QUIET_MS = 1000;
+const QUIET_DEADLINE_MS = 15_000;
 
 /**
  * Silently completes the account's default translation's offline pack once per app session, so
@@ -21,24 +33,71 @@ import { canAddPack, downloadPack, listPacks } from '@/utils/bible-pack-store';
  * closed sheet must be able to cancel; see `useBiblePacks.ts`), this is meant to keep completing
  * in the background for the life of the session even through an incidental remount of whatever
  * mounts it.
+ *
+ * **It waits for the app to go quiet first.** `downloadPack` walks the canon a book at a time, so
+ * on a browser whose pack is incomplete this is up to 66 requests — and it used to start the
+ * moment `profile` landed, which is in the middle of the first screen's own burst. Over HTTP/1.1
+ * that burst is already queueing against a six-connection cap, so the pack was competing with the
+ * page the reader is looking at. Nothing here is urgent: the pack has no deadline, resumes where
+ * it left off, and is for a signal outage that has not happened yet.
+ *
+ * Quiet is read from the query cache rather than from a timer, because the thing worth waiting
+ * for is the *network* going idle, not the main thread — `requestIdleCallback` fires happily
+ * while twenty requests are in flight, since waiting on a socket leaves the CPU free.
  */
 export function useWarmDefaultTranslationPack(): void {
   const { data: profile } = useProfile();
+  const queryClient = useQueryClient();
   const startedRef = useRef(false);
 
   useEffect(() => {
     if (!profile || startedRef.current) return;
-    startedRef.current = true;
     const translationId = profile.defaultTranslation || 'NET';
-    void (async () => {
-      const packs = await listPacks();
-      const existing = packs.find((p) => p.translationId === translationId);
-      if (existing?.complete) return;
-      if (!canAddPack(packs, translationId)) return;
-      await downloadPack(translationId, async (book) => {
-        const params = new URLSearchParams({ book, translation: translationId });
-        return api.get(`/api/scripture/book?${params.toString()}`);
-      });
-    })();
-  }, [profile]);
+
+    const start = () => {
+      if (startedRef.current) return;
+      startedRef.current = true;
+      void (async () => {
+        const packs = await listPacks();
+        const existing = packs.find((p) => p.translationId === translationId);
+        if (existing?.complete) return;
+        if (!canAddPack(packs, translationId)) return;
+        await downloadPack(translationId, async (book) => {
+          const params = new URLSearchParams({ book, translation: translationId });
+          return api.get(`/api/scripture/book?${params.toString()}`);
+        });
+      })();
+    };
+
+    /*
+     * Armed whenever nothing is in flight and disarmed the moment something is, so the pack
+     * starts after a full second of quiet rather than in the first gap between two waves of the
+     * opening burst.
+     */
+    let quiet: number | undefined;
+    const disarm = () => {
+      if (quiet !== undefined) {
+        window.clearTimeout(quiet);
+        quiet = undefined;
+      }
+    };
+    const check = () => {
+      if (startedRef.current) return;
+      if (queryClient.isFetching() > 0) {
+        disarm();
+        return;
+      }
+      if (quiet === undefined) quiet = window.setTimeout(start, QUIET_MS);
+    };
+
+    const unsubscribe = queryClient.getQueryCache().subscribe(check);
+    const deadline = window.setTimeout(start, QUIET_DEADLINE_MS);
+    check();
+
+    return () => {
+      unsubscribe();
+      disarm();
+      window.clearTimeout(deadline);
+    };
+  }, [profile, queryClient]);
 }

--- a/spa/src/pages/prototype/PrototypeChurchHub.tsx
+++ b/spa/src/pages/prototype/PrototypeChurchHub.tsx
@@ -409,6 +409,12 @@ export default function PrototypeChurchHub() {
    * It only counts when it is actually enabled: a disabled query stays
    * `isPending` forever in React Query v5, so requiring it for a congregant
    * (who never sees the row) would strand the animation permanently.
+   *
+   * Spelled as `!billingEnabled || …` rather than by handing `isQuerySettled`
+   * the query's own `isEnabled`, which would look tidier and be wrong: that flag
+   * is also false while auth is still resolving and before an `orgId` is known,
+   * and treating either of those as settled would fire this gate on an empty
+   * hub. `billingEnabled` is the one condition here that can be a permanent no.
    */
   const contentReady =
     isQuerySettled(navQuery.isPending, nav != null) &&

--- a/spa/src/pages/prototype/PrototypeReviewSection.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewSection.tsx
@@ -38,6 +38,7 @@ import {
   reviewSampleDayKey,
   useReviewInbox,
   useReviewItems,
+  useReviewItemsSummary,
   useReviewSample,
   type ReviewItemView,
 } from '../../hooks/queries/useReview';
@@ -109,26 +110,35 @@ export default function PrototypeReviewSection() {
   /* The question's own dismissal, distinct from the upsell's — see the hook's docblock. */
   const { dismissed: sampleDismissed, dismiss: dismissSample } = useDismissibleReviewSample();
 
+  /* Declared above the queries because two of them are enabled by these — a fold that is open
+     is the only reason to build the rows behind it. */
   const [expanded, setExpanded] = useState(false);
-  const inboxQuery = useReviewInbox();
   const [setAsideOpen, setSetAsideOpen] = useState(false);
   const [comingBackOpen, setComingBackOpen] = useState(false);
+  const inboxQuery = useReviewInbox();
   /*
-   * The active list, on the key Home already fetches — so this costs nothing.
+   * The active list twice over: counted always, built only when a fold is open.
    *
-   * `use-home-surface-data` reads `useReviewItems('active')` on every Activity load for the
-   * suggestion handoff, so asking for the same key here shares that one request rather than
-   * adding a second. Asking for *every* status instead, as this briefly did, was a whole extra
-   * round trip on any load with an empty queue.
+   * `use-home-surface-data` reads the summary on every Activity load for the suggestion handoff,
+   * so asking for the same key here shares that one request rather than adding a second — the
+   * same trick this already used, now on the cheap shape. Asking for *every* status instead, as
+   * this briefly did, was a whole extra round trip on any load with an empty queue.
+   *
+   * The split is the point. This section shows at most two rows when closed and takes them from
+   * `useReviewInbox`; everything it wanted from the active list was counts — how many are due,
+   * how many are coming back — and the server was building a question per item to supply them.
+   * Measured at 3.4s for eighteen items, on the critical path of the first paint. The built shape
+   * is fetched when a reader opens a fold, which is a press that can carry its own wait.
    */
-  const activeQuery = useReviewItems('active');
+  const activeSummaryQuery = useReviewItemsSummary('active');
+  const activeBuiltQuery = useReviewItems('active', { enabled: expanded || comingBackOpen });
   /*
    * Every status, for the drawer of things put aside. Fetched only when the reader opens a fold
    * — or when there is nothing active at all, which is the one case where something they put
    * down is the only thing left and no fold exists to open.
    */
   const nothingActive =
-    activeQuery.isFetched && (activeQuery.data?.items?.length ?? 0) === 0;
+    activeSummaryQuery.isFetched && (activeSummaryQuery.data?.items?.length ?? 0) === 0;
   const allQuery = useReviewItems(undefined, {
     enabled: expanded || setAsideOpen || nothingActive,
   });
@@ -215,7 +225,6 @@ export default function PrototypeReviewSection() {
 
   const inboxItems = inboxQuery.data?.items ?? [];
   const everyItem = allQuery.data?.items ?? null;
-  const activeItems = activeQuery.data?.items ?? null;
   /*
    * Due, and not due yet — two different things that the fold used to show as one.
    *
@@ -224,13 +233,28 @@ export default function PrototypeReviewSection() {
    * hides when nothing is due, so an account with a full schedule and an empty morning showed
    * no Review at all and no way to reach any of it — the page that used to list them under
    * "Coming back later" is gone.
+   *
+   * Split twice over, because the two answers are wanted at different moments. The counts decide
+   * whether this section appears at all and what its folds are labelled, and they come off the
+   * summary, which every load already has. The rows are only ever rendered inside an open fold,
+   * so they come off the built list, which is only fetched once one is open. `dueAt` is a column
+   * on the stored item, so both lists can be bucketed the same way.
    */
   const nowMs = Date.now();
-  const dueActive = activeItems
-    ? activeItems.filter((item) => Date.parse(item.dueAt) <= nowMs)
+  const summaryItems = activeSummaryQuery.data?.items ?? null;
+  const dueActiveCount = summaryItems
+    ? summaryItems.filter((item) => Date.parse(item.dueAt) <= nowMs).length
     : null;
-  const comingBack = activeItems
-    ? activeItems.filter((item) => Date.parse(item.dueAt) > nowMs)
+  const comingBackCount = summaryItems
+    ? summaryItems.filter((item) => Date.parse(item.dueAt) > nowMs).length
+    : 0;
+
+  const builtItems = activeBuiltQuery.data?.items ?? null;
+  const dueActive = builtItems
+    ? builtItems.filter((item) => Date.parse(item.dueAt) <= nowMs)
+    : null;
+  const comingBack = builtItems
+    ? builtItems.filter((item) => Date.parse(item.dueAt) > nowMs)
     : [];
   /*
    * Paused, and put down. The one place either can be picked back up.
@@ -268,10 +292,12 @@ export default function PrototypeReviewSection() {
    * full list has been fetched once, the count behind the fold is genuinely unknown, and the
    * label says "See all" rather than guessing. Guessing printed "1 more" over two items.
    */
-  const fullList = dueActive;
+  /* The summary's count, not the built list's — this is known on every load, where the built
+     list only exists once a fold is open. It is also why the label can say "12 more" straight
+     away instead of "See all" until someone presses it. */
   const folded =
-    fullList !== null
-      ? Math.max(0, fullList.length - reviewRows.length)
+    dueActiveCount !== null
+      ? Math.max(0, dueActiveCount - reviewRows.length)
       : inboxQuery.data?.hasMore
         ? null
         : Math.max(0, items.length - reviewRows.length);
@@ -283,7 +309,9 @@ export default function PrototypeReviewSection() {
    * put down is something to do.
    */
   const hasRows =
-    reviewRows.length > 0 || Boolean(challengeRow) || comingBack.length > 0 || setAside.length > 0;
+    /* `comingBackCount` from the summary, not the built list — the built one is only fetched
+       once a fold is open, so counting it here would hide the section on every closed load. */
+    reviewRows.length > 0 || Boolean(challengeRow) || comingBackCount > 0 || setAside.length > 0;
 
   /*
    * Three absences, and only one of them is worth a word.
@@ -397,14 +425,14 @@ export default function PrototypeReviewSection() {
         * with nothing due this is the entire Review section, and it is the only way back to a
         * queue that is otherwise invisible until its dates come round.
         */}
-      {comingBack.length > 0 ? (
+      {comingBackCount > 0 ? (
         <>
           <button
             type="button"
             className="proto-feed-part__more"
             onClick={() => setComingBackOpen((open) => !open)}
           >
-            <span>{reviewComingBackCopy(comingBack.length)}</span>
+            <span>{reviewComingBackCopy(comingBackCount)}</span>
             <Icon name={comingBackOpen ? 'caret-up' : 'caret-down'} size={10} />
           </button>
           {comingBackOpen

--- a/spa/src/pages/prototype/__tests__/home-settle-trace-opt-in.test.ts
+++ b/spa/src/pages/prototype/__tests__/home-settle-trace-opt-in.test.ts
@@ -1,0 +1,62 @@
+/**
+ * The switch that lets production answer the question dev cannot.
+ *
+ * Home's gate exists to beat a 2.5s deadline against real latency, and the trace that reports
+ * whether it did was `import.meta.env.DEV`-only — so the one environment whose answer matters
+ * could never be asked. `?debug=home` arms it for the tab.
+ *
+ * The three cases below are the whole contract, and the middle one is the reason this is a pure
+ * function: the trace reports on the *first* settle of a load, so checking it means reloading,
+ * and a flag that only lived as long as the URL would be useless for the job it exists to do.
+ */
+import { describe, expect, it } from 'vitest';
+import { homeSettleTraceDecision } from '../useHomeSettleTrace';
+
+describe('homeSettleTraceDecision', () => {
+  it('is off by default, and asks for nothing to be written', () => {
+    expect(homeSettleTraceDecision('', false)).toEqual({
+      enabled: false,
+      arm: false,
+      disarm: false,
+    });
+  });
+
+  it('turns on and arms the tab when asked', () => {
+    expect(homeSettleTraceDecision('?debug=home', false)).toEqual({
+      enabled: true,
+      arm: true,
+      disarm: false,
+    });
+  });
+
+  it('stays on across a reload that has dropped the parameter', () => {
+    // The point of arming. A reload is how you compare a cold load with a warm one.
+    expect(homeSettleTraceDecision('', true)).toEqual({
+      enabled: true,
+      arm: false,
+      disarm: false,
+    });
+  });
+
+  it('turns off on request, and clears the arming with it', () => {
+    expect(homeSettleTraceDecision('?debug=off', true)).toEqual({
+      enabled: false,
+      arm: false,
+      disarm: true,
+    });
+  });
+
+  it('ignores a debug parameter meant for something else', () => {
+    expect(homeSettleTraceDecision('?debug=reader', false).enabled).toBe(false);
+    // And does not disturb an arming that is already there.
+    expect(homeSettleTraceDecision('?debug=reader', true)).toEqual({
+      enabled: true,
+      arm: false,
+      disarm: false,
+    });
+  });
+
+  it('reads the parameter alongside others', () => {
+    expect(homeSettleTraceDecision('?space=space_1&debug=home', false).enabled).toBe(true);
+  });
+});

--- a/spa/src/pages/prototype/__tests__/review-section-rows.test.tsx
+++ b/spa/src/pages/prototype/__tests__/review-section-rows.test.tsx
@@ -46,10 +46,20 @@ vi.mock('../../../hooks/useHasFeature', () => ({
   useHasFeature: (key: string) => features[key] ?? { has: false, ready: true },
 }));
 const allItems = { data: undefined as undefined | { items: unknown[] } };
+/*
+ * The counted shape, fetched on every load — where the built one below is not.
+ *
+ * This is the split that took `/api/review/items` off Home's first paint: the section reads
+ * counts from here and only asks the server to build questions when a fold is opened. The two
+ * lists have identical membership by construction (same drop rules, server side), so a test can
+ * hand them the same rows.
+ */
+const summaryItems = { data: undefined as undefined | { items: unknown[] } };
 vi.mock('../../../hooks/queries/useReview', () => ({
   useReviewInbox: () => inbox,
   // Fetched only once the reader unfolds the section.
   useReviewItems: () => allItems,
+  useReviewItemsSummary: () => summaryItems,
   // The sample is for an account without the feature; these rows all have it.
   useReviewSample: (opts: { enabled: boolean }) => ({
     data: opts?.enabled === false ? undefined : sample.data,
@@ -128,6 +138,7 @@ beforeEach(() => {
   features.challenges = { has: true, ready: true };
   inbox.data = { items: [], hasMore: false };
   allItems.data = undefined;
+  summaryItems.data = undefined;
   challenges.data = { challenges: [] };
   sample.data = undefined;
   try { window.localStorage.clear(); } catch { /* ignore */ }
@@ -253,9 +264,16 @@ describe('what it shows a subscriber', () => {
     expect(screen.queryByText(/\d+ more/)).not.toBeInTheDocument();
   });
 
-  it('counts them once the full list is in hand', () => {
+  /*
+   * The count comes off the summary, which every load already has — so the label can say how
+   * many rather than "See all" without anyone pressing anything first. It used to need the
+   * built list, which is only fetched on expand, so the honest label before that was "See all".
+   */
+  it('counts them from the summary, without waiting for the built list', () => {
+    // `allItems` stays undefined here (reset in beforeEach): nothing is expanded, so the server
+    // was never asked to build a question, and the count is right anyway.
     inbox.data = { items: ['a', 'b'].map((id) => reviewItem(id, `Question ${id}`)), hasMore: false };
-    allItems.data = { items: ['a', 'b', 'c'].map((id) => reviewItem(id, `Question ${id}`)) };
+    summaryItems.data = { items: ['a', 'b', 'c'].map((id) => reviewItem(id, `Question ${id}`)) };
     render(<PrototypeReviewSection />);
     expect(screen.getByText('2 more')).toBeInTheDocument();
   });

--- a/spa/src/pages/prototype/use-home-surface-data.ts
+++ b/spa/src/pages/prototype/use-home-surface-data.ts
@@ -48,7 +48,14 @@ import { PROTOTYPE_NOTE_LIST_NAV_SEARCH } from '@/utils/prototype-sidebar-highli
 import type { SpaceNoteRow } from '../../hooks/queries/useSpace';
 import type { ScriptureIndexBook } from '../../hooks/queries/usePrototypeSpaceScriptureIndex';
 import { useTagsList } from '../../hooks/queries/useTagsList';
-import { useReviewItems } from '../../hooks/queries/useReview';
+import {
+  useReviewAccessSettled,
+  useReviewInbox,
+  useReviewItemsSummary,
+} from '../../hooks/queries/useReview';
+import { useHomeChallenges } from '../../hooks/queries/useChallenges';
+import { useReadingPlans } from '../../hooks/queries/useReadingPlans';
+import { useAuthReady } from '../../hooks/useAuthReady';
 import { usePrototypeStudyThreads } from '../../hooks/queries/usePrototypeStudyThreads';
 import {
   usePrototypeSpaceStudyThreadHighlights,
@@ -296,6 +303,36 @@ export function useHomeSurfaceData({
   const connectSuggestionsQuery = useConnectSuggestions();
   const churchSermonsQuery = useChurchSermons();
   const churchFeedQuery = useChurchFeed({ limit: HOME_FEED_LIMIT });
+  /*
+   * The precondition that makes every `isEnabled` below meaningful — see the flag's docblock in
+   * `prototype-home-ready.ts`. Nearly every query here is `enabled: authReady && …`, so until
+   * this is true they are all disabled, and "disabled" must not read as "settled" there.
+   */
+  const authReady = useAuthReady();
+  /*
+   * Review, challenges, reading plans and the checklist store — all four render rows inside the
+   * gate's own tree and none of them used to be in it, so each landed after Home had painted and
+   * inserted a row. Review was the one you could watch: it was deliberately made to start at t=0
+   * (a per-tab entitlement snapshot, see `useSubscriptionStatus`) and so became the *only*
+   * populated section on a page that was still waiting for everything else.
+   *
+   * `activeReviewItems` is the sharpest of them. It is read far below for the suggestion handoff,
+   * and it does not add a section — it *removes* recall cards, for passages Review has already
+   * taken up. Declared up here with the rest because the gate is computed a few lines down and
+   * has to be able to see it.
+   */
+  const reviewAccessSettled = useReviewAccessSettled();
+  const reviewInboxQuery = useReviewInbox();
+  /*
+   * The summary shape, not the built one. Everything below reads `kind` and
+   * `scriptureReference` off this list and renders none of it, so asking the server to assemble
+   * a question per item — cue text, cross-references, curated knowledge, a round trip apiece —
+   * was 3.4s of Home's first paint spent on work nothing displayed.
+   */
+  const activeReviewItems = useReviewItemsSummary('active');
+  const challengesQuery = useHomeChallenges();
+  const readingPlansQuery = useReadingPlans();
+  const { hydrated: onboardingHydrated } = useOnboardingState();
   const {
     meaningWeightById,
     fingerprintsById,
@@ -331,50 +368,117 @@ export function useHomeSurfaceData({
     [closeDrawer, isMobileSidebar, openLibraryPanel],
   );
 
-  const tagsSettled = isQuerySettled(tagsQuery.isPending, tagsQuery.data != null);
-  const threadsSettled = isQuerySettled(threadsQuery.isPending, threadsQuery.data != null);
-  const highlightsSettled = isQuerySettled(highlightsQuery.isPending, highlightsQuery.data != null);
+  /*
+   * Every flag passes its query's `isEnabled`, including the ones that are always on.
+   *
+   * Not decoration. A *disabled* query keeps `status: 'pending'` forever in React Query v5, so a
+   * two-argument `isQuerySettled` reads "still loading" for a query that will never load — and
+   * one such flag ANDed into the gate below makes it permanently false. That is not a
+   * hypothetical: `churchSermonsSettled` was exactly this for every account without a church, so
+   * `presentationReady` never fired and Home reached `contentReady` only through its 2.5s
+   * deadline, on every cold load, painting with whatever had arrived and growing the rest a
+   * section at a time. Passing it everywhere means the next conditionally-enabled query cannot
+   * quietly do it again.
+   */
+  const tagsSettled = isQuerySettled(
+    tagsQuery.isPending,
+    tagsQuery.data != null,
+    tagsQuery.isEnabled,
+  );
+  const threadsSettled = isQuerySettled(
+    threadsQuery.isPending,
+    threadsQuery.data != null,
+    threadsQuery.isEnabled,
+  );
+  const highlightsSettled = isQuerySettled(
+    highlightsQuery.isPending,
+    highlightsQuery.data != null,
+    highlightsQuery.isEnabled,
+  );
+  /*
+   * Deliberately still the two-argument form — the one query here that must not pass `isEnabled`.
+   *
+   * VOTD is disabled only while `homeSpaceId` is unresolved, which is a wait rather than a never:
+   * the moment the space lands the query runs. Reporting it settled during that window would let
+   * the gate fire before the passage pill exists and then pop it in, which is the bug rather than
+   * the fix. Every other precondition here belongs to a query that can be permanently off; this
+   * one always resolves, and the 2.5s deadline covers the pathological case where it does not.
+   */
   const votdSettled =
     isQuerySettled(votdQuery.isPending, votdQuery.data != null) || Boolean(votdQuery.isError);
   const fingerprintsSettled = isQuerySettled(
     fingerprintsQuery.isPending,
     fingerprintsQuery.data != null,
+    fingerprintsQuery.isEnabled,
   );
   const studyBibleSettled =
-    isQuerySettled(studyBibleNodesQuery.isPending, studyBibleNodesQuery.data != null) ||
-    Boolean(studyBibleNodesQuery.isError);
+    isQuerySettled(
+      studyBibleNodesQuery.isPending,
+      studyBibleNodesQuery.data != null,
+      studyBibleNodesQuery.isEnabled,
+    ) || Boolean(studyBibleNodesQuery.isError);
   const connectionsSettled =
-    isQuerySettled(crossRefConnectionsQuery.isPending, crossRefConnectionsQuery.data != null) &&
+    isQuerySettled(
+      crossRefConnectionsQuery.isPending,
+      crossRefConnectionsQuery.data != null,
+      crossRefConnectionsQuery.isEnabled,
+    ) &&
     isQuerySettled(
       referenceWordConnectionsQuery.isPending,
       referenceWordConnectionsQuery.data != null,
+      referenceWordConnectionsQuery.isEnabled,
     );
   const searchEventsSettled = isQuerySettled(
     searchEventsQuery.isPending,
     searchEventsQuery.data != null,
+    searchEventsQuery.isEnabled,
   );
   const crossRefGapsSettled = isQuerySettled(
     crossRefGapsQuery.isPending,
     crossRefGapsQuery.data != null,
+    crossRefGapsQuery.isEnabled,
   );
   const connectSuggestionsSettled = isQuerySettled(
     connectSuggestionsQuery.isPending,
     connectSuggestionsQuery.data != null,
+    connectSuggestionsQuery.isEnabled,
   );
   const recallHistorySettled = isQuerySettled(
     recallHistoryQuery.isPending,
     recallHistoryQuery.data != null,
+    recallHistoryQuery.isEnabled,
   );
   // Read here purely to gate on. PrototypeHomeThisSunday and PrototypeHomeChurchFeed each call
   // these themselves and return null until they resolve — "This Sunday" sits *above* the daily
   // passage, so it arriving late pushes the passage pill, the continue card and the whole recall
   // deck down. React Query dedupes by key, so subscribing again here costs one cache read, not a
   // second request.
-  const churchSermonsSettled = isQuerySettled(
-    churchSermonsQuery.isPending,
-    churchSermonsQuery.data != null,
+  //
+  // `isSettled` rather than a flag built here: this query is disabled until the *profile* says
+  // whether there is a church to ask about, so "will it ever run" is a question only the hook can
+  // answer. See `useChurchSermons`.
+  const churchSermonsSettled = churchSermonsQuery.isSettled;
+  const churchFeedSettled = isQuerySettled(
+    churchFeedQuery.isPending,
+    churchFeedQuery.data != null,
+    churchFeedQuery.isEnabled,
   );
-  const churchFeedSettled = isQuerySettled(churchFeedQuery.isPending, churchFeedQuery.data != null);
+  /*
+   * The four that used to sit outside the gate entirely, and the reason Review looked like it
+   * loaded before the rest of the page rather than with it.
+   *
+   * Review and challenges carry their own `isSettled` for the same reason the church query does:
+   * both are disabled without the paid key, and "disabled because this account will never have
+   * it" has to be told apart from "disabled because the entitlement has not answered yet".
+   */
+  const entitlementSettled = reviewAccessSettled;
+  const reviewSettled = reviewInboxQuery.isSettled && activeReviewItems.isSettled;
+  const challengesSettled = challengesQuery.isSettled;
+  const readingPlansSettled = isQuerySettled(
+    readingPlansQuery.isPending,
+    readingPlansQuery.data != null,
+    readingPlansQuery.isEnabled,
+  );
   /*
    * `data != null` will not do here: "no bookmark" is a legitimate answer and arrives as
    * `null`, so waiting for data would hold Home forever for anyone who has not read yet.
@@ -391,6 +495,7 @@ export function useHomeSurfaceData({
   // excess-property check that catches a flag added here and never declared there — the
   // exact mistake that let five queries sit outside the gate for months.
   const presentationInput: PrototypeHomePresentationReadyInput = {
+    authReady,
     notesReady: isPrototypeHomeContentReady(notesListPhase),
     clerkLoaded,
     fingerprintsSettled,
@@ -408,12 +513,29 @@ export function useHomeSurfaceData({
     churchFeedSettled,
     readingPositionSettled,
     studyBibleSettled,
+    entitlementSettled,
+    reviewSettled,
+    challengesSettled,
+    readingPlansSettled,
+    onboardingHydrated,
   };
   const presentationReady = isPrototypeHomePresentationReady(presentationInput);
 
-  // Backstop: a disabled query stays `isPending` forever in React Query v5, so without a
-  // deadline one misconfigured auxiliary would strand Home on loading dots. Trading a
-  // little jitter for a blank Home would be a worse bug than the one being fixed.
+  /*
+   * Backstop: if a query never settles, Home must still paint rather than sit on dots forever.
+   *
+   * The window restarts when `authReady` flips, which is the difference between a backstop and a
+   * timer nobody can beat. Nearly every query here is gated on a usable session JWT, so none of
+   * them can even be *sent* until that lands — and measured from mount the deadline was mostly
+   * spent waiting for Clerk. Measured on a cold dev load: auth at 1666ms, leaving the fifteen
+   * remaining queries about 800ms of a 2500ms budget to finish in. They did not, so the deadline
+   * won every time and Home painted half-assembled — which is the bug, arriving by a second road
+   * after the first one (`churchSermonsSettled` never settling at all) was closed.
+   *
+   * Restarting rather than gating on `authReady` keeps the guarantee for the case the backstop is
+   * actually for: a session that never authenticates still paints at 2500ms, because that first
+   * timer is never cleared.
+   */
   const [presentationDeadlinePassed, setPresentationDeadlinePassed] = useState(false);
   useEffect(() => {
     if (presentationReady) return;
@@ -422,7 +544,7 @@ export function useHomeSurfaceData({
       HOME_PRESENTATION_DEADLINE_MS,
     );
     return () => window.clearTimeout(id);
-  }, [presentationReady]);
+  }, [presentationReady, authReady]);
 
   const contentReady = presentationReady || presentationDeadlinePassed;
 
@@ -1232,11 +1354,13 @@ export function useHomeSurfaceData({
 
   /*
    * Passages Review has already taken up, so Home's two resurfacing cards can step aside for
-   * them (`review-suggestion-handoff.ts` has the rule). The query gates itself on auth and on
-   * the entitlement, so a free account fires nothing and this is empty — which is the same
-   * answer as "nothing active", and needs no branch here.
+   * them (`review-suggestion-handoff.ts` has the rule). `activeReviewItems` is declared with the
+   * other queries at the top, because the presentation gate has to wait on it: these two sets
+   * *remove* cards, so a late arrival takes rows out of a deck someone is already reading.
+   *
+   * The query gates itself on auth and on the entitlement, so a free account fires nothing and
+   * this is empty — the same answer as "nothing active", and it needs no branch here.
    */
-  const activeReviewItems = useReviewItems('active');
   /**
    * Chapters Review has taken up, as `${book}|${chapter}`.
    *
@@ -1603,8 +1727,6 @@ export function useHomeSurfaceData({
   );
 
   // ─── Getting-started checklist ─────────────────────────────────────────────
-
-  const { hydrated: onboardingHydrated } = useOnboardingState();
 
   /*
    * Tell the checklist what this account's own data already answers.

--- a/spa/src/pages/prototype/useHomeSettleTrace.ts
+++ b/spa/src/pages/prototype/useHomeSettleTrace.ts
@@ -1,8 +1,51 @@
 import { useEffect, useRef } from 'react';
 import type { PrototypeHomePresentationReadyInput } from '@/utils/prototype-home-ready';
 
+/** Where the opt-in is remembered. Session-scoped on purpose — see `resolveHomeSettleTrace`. */
+export const HOME_SETTLE_TRACE_KEY = 'harvous-debug-home-settle';
+
 /**
- * DEV-only: how long Home waited, and what it was waiting on.
+ * What `?debug=home` should do, given the URL and whether the trace is already armed.
+ *
+ * Split out as a pure function because the interesting part is the three-way decision, and the
+ * rest is `window` plumbing that a test would only be mocking.
+ */
+export function homeSettleTraceDecision(
+  search: string,
+  armed: boolean,
+): { enabled: boolean; arm: boolean; disarm: boolean } {
+  const param = new URLSearchParams(search).get('debug');
+  if (param === 'off') return { enabled: false, arm: false, disarm: true };
+  if (param === 'home') return { enabled: true, arm: true, disarm: false };
+  return { enabled: armed, arm: false, disarm: false };
+}
+
+/**
+ * Whether to trace this load: always in dev, and in production once asked.
+ *
+ * Armed in `sessionStorage` rather than `localStorage`, which is the whole design of the opt-in.
+ * The trace reports on the *first* settle of a load, so checking it means reloading a few times —
+ * a flag that died with the URL would be useless, and one that outlived the tab would be a
+ * diagnostic left switched on in someone's browser forever. A tab's lifetime is exactly the
+ * length of the question.
+ */
+export function resolveHomeSettleTrace(): boolean {
+  if (import.meta.env.DEV) return true;
+  if (typeof window === 'undefined') return false;
+  try {
+    const armed = window.sessionStorage.getItem(HOME_SETTLE_TRACE_KEY) === '1';
+    const { enabled, arm, disarm } = homeSettleTraceDecision(window.location.search, armed);
+    if (arm) window.sessionStorage.setItem(HOME_SETTLE_TRACE_KEY, '1');
+    if (disarm) window.sessionStorage.removeItem(HOME_SETTLE_TRACE_KEY);
+    return enabled;
+  } catch {
+    // Private windows and blocked site data throw on access. No trace is the right answer.
+    return false;
+  }
+}
+
+/**
+ * How long Home waited, and what it was waiting on.
  *
  * Home presents once, when every query it renders from has settled, with a 2.5s deadline
  * behind that as a backstop. Both halves fail quietly. If a flag never flips — a query
@@ -13,12 +56,24 @@ import type { PrototypeHomePresentationReadyInput } from '@/utils/prototype-home
  *
  * So the trace reports the number *and* the reason: `gate` means readiness fired, and
  * `deadline` names the flags that were still false when the backstop gave up.
+ *
+ * **Dev always, production on request.** It was dev-only, which meant the one environment whose
+ * answer actually matters could never be asked: the gate's whole job is to beat a 2.5s deadline
+ * against real latency, and a dev machine with its own database pool is not that. Load any page
+ * with `?debug=home` to arm it for the tab and `?debug=off` to stop. Flag names and millisecond
+ * counts only — nothing about what is being studied.
  */
 export function useHomeSettleTrace(
   input: PrototypeHomePresentationReadyInput,
   contentReady: boolean,
   presentationReady: boolean,
 ): void {
+  /* Resolved once per mount and held, so a client-side navigation that drops the query parameter
+     cannot switch the trace off halfway through the load it is reporting on. */
+  const enabledRef = useRef<boolean | null>(null);
+  if (enabledRef.current === null) enabledRef.current = resolveHomeSettleTrace();
+  const enabled = enabledRef.current;
+
   // The clock starts when the view first mounts, which is the first frame the reader sees dots.
   const startedAtRef = useRef<number | null>(null);
   const reportedRef = useRef(false);
@@ -29,12 +84,12 @@ export function useHomeSettleTrace(
   const inputRef = useRef(input);
   inputRef.current = input;
 
-  if (import.meta.env.DEV && startedAtRef.current === null) {
+  if (enabled && startedAtRef.current === null) {
     startedAtRef.current = performance.now();
   }
 
   useEffect(() => {
-    if (!import.meta.env.DEV) return;
+    if (!enabled) return;
     const now = performance.now();
     for (const [flag, settled] of Object.entries(inputRef.current)) {
       if (settled && !settledAtRef.current.has(flag)) settledAtRef.current.set(flag, now);
@@ -42,7 +97,7 @@ export function useHomeSettleTrace(
   });
 
   useEffect(() => {
-    if (!import.meta.env.DEV) return;
+    if (!enabled) return;
     if (!contentReady || reportedRef.current) return;
     reportedRef.current = true;
 
@@ -57,12 +112,15 @@ export function useHomeSettleTrace(
       .slice(-4)
       .join(', ');
 
+    /* Only outside dev, where the reader asked for this and needs to know how to stop. */
+    const off = import.meta.env.DEV ? '' : ' — ?debug=off to stop';
+
     if (presentationReady) {
-      console.info(`[home] settled via gate in ${elapsed}ms — last to land: ${slowest}`);
+      console.info(`[home] settled via gate in ${elapsed}ms — last to land: ${slowest}${off}`);
     } else {
       console.warn(
-        `[home] settled via DEADLINE in ${elapsed}ms — still waiting on: ${unsettled.join(', ') || '(none)'} — last to land: ${slowest}`,
+        `[home] settled via DEADLINE in ${elapsed}ms — still waiting on: ${unsettled.join(', ') || '(none)'} — last to land: ${slowest}${off}`,
       );
     }
-  }, [contentReady, presentationReady]);
+  }, [contentReady, presentationReady, enabled]);
 }

--- a/src/utils/__tests__/prototype-home-ready.test.ts
+++ b/src/utils/__tests__/prototype-home-ready.test.ts
@@ -35,10 +35,33 @@ describe('isQuerySettled', () => {
   it('returns false when pending with no data', () => {
     expect(isQuerySettled(true, false)).toBe(false);
   });
+
+  /*
+   * The regression this guards is the one that made Home's whole gate inert. A disabled query
+   * keeps `status: 'pending'` in React Query v5, so without the third argument a query that will
+   * never run reads as forever-loading — and one of those ANDed into the presentation gate meant
+   * `presentationReady` was never true for any account without a church.
+   */
+  it('treats a disabled query as settled — it will never answer', () => {
+    expect(isQuerySettled(true, false, false)).toBe(true);
+  });
+
+  it('still waits on an enabled query that is pending', () => {
+    expect(isQuerySettled(true, false, true)).toBe(false);
+  });
+
+  it('defaults to enabled, so a two-argument call is unchanged', () => {
+    expect(isQuerySettled(true, false)).toBe(isQuerySettled(true, false, true));
+  });
+
+  it('prefers data over both — a disabled query holding cache is settled with its data', () => {
+    expect(isQuerySettled(true, true, false)).toBe(true);
+  });
 });
 
 describe('isPrototypeHomePresentationReady', () => {
   const readyBase = {
+    authReady: true,
     notesReady: true,
     clerkLoaded: true,
     fingerprintsSettled: true,
@@ -56,6 +79,11 @@ describe('isPrototypeHomePresentationReady', () => {
     churchFeedSettled: true,
     readingPositionSettled: true,
     studyBibleSettled: true,
+    entitlementSettled: true,
+    reviewSettled: true,
+    challengesSettled: true,
+    readingPlansSettled: true,
+    onboardingHydrated: true,
   };
 
   it('returns true when all presentation deps are settled', () => {
@@ -95,10 +123,39 @@ describe('isPrototypeHomePresentationReady', () => {
   ] as const)('returns false while %s is still loading', (flag) => {
     expect(isPrototypeHomePresentationReady({ ...readyBase, [flag]: false })).toBe(false);
   });
+
+  /**
+   * The five that sat outside the gate until Review started arriving first.
+   *
+   * Review's absence was a deliberate call when it was the slowest thing on the page. Then it was
+   * made to start at t=0 and became one of the fastest, so it was the only populated section on a
+   * page still waiting for the rest — the same pop-in, inverted. `reviewSettled` also covers the
+   * `active` list, which *removes* recall cards rather than adding a section.
+   */
+  it.each([
+    ['entitlementSettled'],
+    ['reviewSettled'],
+    ['challengesSettled'],
+    ['readingPlansSettled'],
+    ['onboardingHydrated'],
+  ] as const)('returns false while %s is still loading', (flag) => {
+    expect(isPrototypeHomePresentationReady({ ...readyBase, [flag]: false })).toBe(false);
+  });
+
+  /*
+   * `authReady` is what keeps the disabled-is-settled rule from eating itself. Nearly every query
+   * behind these flags is `enabled: authReady && …`, so before a session JWT exists they are all
+   * disabled and every flag reads settled at once. Without this precondition the gate would fire
+   * on the first frames and Home would paint empty — a worse bug than the one being fixed.
+   */
+  it('is never ready before auth, however settled everything else looks', () => {
+    expect(isPrototypeHomePresentationReady({ ...readyBase, authReady: false })).toBe(false);
+  });
 });
 
 describe('home readiness composition', () => {
   const ready = {
+    authReady: true,
     notesReady: true,
     clerkLoaded: true,
     fingerprintsSettled: true,
@@ -116,6 +173,11 @@ describe('home readiness composition', () => {
     churchFeedSettled: true,
     readingPositionSettled: true,
     studyBibleSettled: true,
+    entitlementSettled: true,
+    reviewSettled: true,
+    challengesSettled: true,
+    readingPlansSettled: true,
+    onboardingHydrated: true,
   };
 
   it('is not ready on notes alone', () => {

--- a/src/utils/prototype-home-ready.ts
+++ b/src/utils/prototype-home-ready.ts
@@ -18,12 +18,43 @@ export function isPrototypeHomeContentReady(notesListPhase: PrototypeNotesListPh
   return notesListPhase === 'list' || notesListPhase === 'empty';
 }
 
-/** React Query helper: settled when not pending or cached data exists. */
-export function isQuerySettled(isPending: boolean, hasData: boolean): boolean {
-  return !isPending || hasData;
+/**
+ * React Query helper: settled when it has an answer, or when it will never have one.
+ *
+ * `isEnabled` is the third argument because a *disabled* query keeps `status: 'pending'` in
+ * React Query v5, so the two-argument form reads "still loading" for a query that is never
+ * going to load. One such flag ANDed into the presentation gate is enough to make
+ * {@link isPrototypeHomePresentationReady} permanently false — which is exactly what
+ * `churchSermonsSettled` did for every account without a church, so Home reached `contentReady`
+ * only through its 2.5s deadline and painted with whatever had arrived by then. Waiting on a
+ * query that will never run is waiting forever.
+ *
+ * **"Disabled" only means "never" once the thing that disabled it has settled.** A query gated
+ * on another query's data is disabled *transiently* while that data is in flight, and calling it
+ * settled there would let the gate fire early — the same pop-in, just for the accounts that do
+ * have the feature. Compose the precondition where it is known (see `useChurchSermons.isSettled`)
+ * rather than passing a bare `isEnabled` for those.
+ *
+ * Defaults to `true` so a call about an unconditionally-enabled query stays a two-argument call.
+ */
+export function isQuerySettled(isPending: boolean, hasData: boolean, isEnabled = true): boolean {
+  if (hasData) return true;
+  if (!isPending) return true;
+  return !isEnabled;
 }
 
 export interface PrototypeHomePresentationReadyInput {
+  /**
+   * `useAuthReady()` — a usable session JWT, not merely a signed-in user.
+   *
+   * A hard precondition, and the one that makes every `isEnabled` below safe to trust. Nearly
+   * every query here is `enabled: authReady && …`, so before auth settles they are all disabled
+   * — and `isQuerySettled` reads a disabled query as settled, because a query that will never
+   * run is not something to wait for. Without this line that reasoning inverts on itself: on the
+   * first frames *everything* would look settled at once and Home would paint empty. With it,
+   * `isEnabled === false` can only mean the query's own condition said no.
+   */
+  authReady: boolean;
   /** Notes list/empty. */
   notesReady: boolean;
   /** Clerk `useUser().isLoaded` — enough for the hello first name. */
@@ -54,6 +85,22 @@ export interface PrototypeHomePresentationReadyInput {
   churchFeedSettled: boolean;
   /** Reading bookmark — *replaces* the continue-book card, so its arrival reorders the deck. */
   readingPositionSettled: boolean;
+  /**
+   * The paid-feature answer, which decides whether Review exists on this page at all — and, for
+   * an account without it, whether the sample and the Plus row do.
+   */
+  entitlementSettled: boolean;
+  /**
+   * Review's own rows. Also *removes* recall cards: the suggestion handoff steps Home's
+   * resurfacing cards aside for any passage Review has already taken up.
+   */
+  reviewSettled: boolean;
+  /** Challenges — the Review section reads them, and so does the strengthen-a-Thread row. */
+  challengesSettled: boolean;
+  /** Personal reading plans — a row inside Following. */
+  readingPlansSettled: boolean;
+  /** The getting-started checklist's own store, whose dock inserts at the *top* of the sheet. */
+  onboardingHydrated: boolean;
 }
 
 /**
@@ -70,13 +117,20 @@ export interface PrototypeHomePresentationReadyInput {
  * `null` until their own query resolves — and "This Sunday" sits above the daily passage, so
  * its arrival pushes everything below it down.
  *
+ * Five more joined later — the entitlement, Review, challenges, reading plans and the
+ * onboarding store. Review's absence was deliberate at the time: it was the slowest thing on the
+ * page, so gating on it would have made everyone wait for it. Then it was made to start at t=0
+ * (a per-tab entitlement snapshot, see `useSubscriptionStatus`) and became one of the fastest,
+ * which is precisely why it was the section a reader saw sitting alone while the rest arrived.
+ * The reasoning inverted with the measurement.
+ *
  * When adding a flag, add it to {@link PrototypeHomePresentationReadyInput} as well. This
  * function has already been bitten once by exactly that: the call site passed five flags the
  * parameter type didn't declare and all five were silently dropped, so Home painted early
  * anyway. `npm run typecheck:ratchet` now catches it.
  */
 export function isPrototypeHomePresentationReady(input: PrototypeHomePresentationReadyInput): boolean {
-  if (!input.notesReady || !input.clerkLoaded) return false;
+  if (!input.authReady || !input.notesReady || !input.clerkLoaded) return false;
   return (
     input.fingerprintsSettled &&
     input.tagsSettled &&
@@ -92,6 +146,11 @@ export function isPrototypeHomePresentationReady(input: PrototypeHomePresentatio
     input.churchSermonsSettled &&
     input.churchFeedSettled &&
     input.readingPositionSettled &&
-    input.studyBibleSettled
+    input.studyBibleSettled &&
+    input.entitlementSettled &&
+    input.reviewSettled &&
+    input.challengesSettled &&
+    input.readingPlansSettled &&
+    input.onboardingHydrated
   );
 }


### PR DESCRIPTION
Restores what was reverted this afternoon, merged with the Review work that landed while it was out.

**The revert was right at the time and turned out to be unnecessary.** Production had a Review section that had vanished and no diagnosis, so backing out was the correct call. But Review was empty because the engine's cold start had never cleared for that account — nothing in here touches that. The revert changed nothing about the symptom, and everything it removed was measured and tested.

## The bug that is live on main right now

`useChurchSermons` is disabled for an account with no church. A disabled query keeps `status: 'pending'` in React Query v5, so `isQuerySettled` read it as "still loading" — `presentationReady` was permanently false, and **every cold load reaches `contentReady` through the 2.5s deadline** and paints with whatever happened to arrive. This is the only change that fixes it.

## What else comes back

- `authReady` as a hard precondition — what stops the disabled-is-settled rule eating itself on the first frames
- Five row-rendering queries that were inside the gate's tree and never in the gate
- The deadline restarting when auth lands, so its budget goes on queries rather than on Clerk
- `?view=summary`, so Home stops assembling a question per review item to render none of them
- `/api/review/inbox` building the three rows it shows rather than the eight it lists
- `repairMissingNoteThreadJunctionsForUser` asking which rows need repair instead of reading three whole tables to find out
- The offline Bible pack waiting for the network to go quiet rather than racing the first screen

## The one thing that is new

`review-askable-rules-parity.test.ts`. The bug that made this look dangerous was a drop rule the filter did not know about — the chapter whose text cannot be fetched — and it took Review off Home in production. That test **fails on the code that shipped it**, and fails again if a fourth drop rule appears in the build without the filter learning it.

## Merged, not replayed

`PrototypeReviewSection` and the inbox route both carry work that landed while this was reverted: the cold-start empty state and its `coldStart` payload. Resolved so all of it survives — `hasMore` reads the built count, `hasRows` reads the summary's `comingBackCount`, and the empty state sits above the row rendering.

## Measured against the merged tree, not trusted from before

```
/api/review/items?status=active&view=summary    715ms  n=21
/api/review/items?status=active               3769ms  n=21
/api/review/inbox                             2194ms  n=3  hasMore=true
```

The two lists agreeing at 21 is the parity claim that was wrong the first time round. Home renders correctly with Review and both its folds.

5866 tests, typecheck ratchet 125, auth-gated-queries, perf:check.

## Verifying after it deploys

`?debug=home` on production Home. `[home] settled via gate` means the gate fires and this did its job; `settled via DEADLINE … still waiting on: X` names what is left. Every number in this PR is from dev with `DB_POOL_MAX=4`, where the page is bounded by database work over four connections — production is the measurement that settles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)