### PR TITLE
fix(design): give empty-state copy a measure, and even its lines

### DIFF
--- a/Changelog/3.7.3.md
+++ b/Changelog/3.7.3.md
@@ -1,0 +1,7 @@
+# Version 3.7.3
+
+**Release Date**: September 7, 2026
+
+## Fixes
+
+- Empty-state text wraps into even lines instead of one long one

--- a/Changelog/3.7.4.md
+++ b/Changelog/3.7.4.md
@@ -1,0 +1,7 @@
+# Version 3.7.4
+
+**Release Date**: September 7, 2026
+
+## Fixes
+
+- An answered review option stays readable when you point at it

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.7.3
+**Version:** 3.7.4
 **Status:** Official 1.0 Released January 8, 2026

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.7.2
+**Version:** 3.7.3
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-7-2';
+const CACHE_NAME = 'harvous-cache-v3-7-3';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-7-3';
+const CACHE_NAME = 'harvous-cache-v3-7-4';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/release-notes/2026-09-07.md
+++ b/release-notes/2026-09-07.md
@@ -3,65 +3,22 @@
 **Release Date:** September 7, 2026
 **Versions:** v3.6.1–v3.7.4
 
-Small corrections to the app's frame. The search chip sits where it looks like it should on a phone, a chapter now narrows the way a note does, and the what's-new row stops sending you back to a welcome you have already read.
+Home now arrives as one page instead of filling in around you. Review explains itself before it has anything to ask, the daily sample for free accounts is finally daily, and live sync between your devices is talking again.
 
 ---
 
 ## Updates in This Release
 
-### Search sits in the middle of the row on a phone
+### Home opens as one page
 
 **What changed:**
-- The Search chip is now centred on the toolbar itself rather than in whatever space the buttons on either side happened to leave.
-- Because those two groups are not the same width, the chip had been sitting noticeably right of centre on a narrow screen.
-- When the row genuinely runs out of room the chip shortens instead of sliding under the buttons beside it.
+- Opening Home used to show a couple of things straight away and then visibly grow, a section at a time, as the rest arrived.
+- Underneath that, the page could never finish settling properly for most accounts, so every cold open waited a fixed two and a half seconds and then still arrived incomplete.
+- It now waits for what it needs and shows the whole page at once.
 
 **How it helps you:**
-- The one control in the middle of the toolbar looks like it is in the middle.
-
-### A chapter narrows the way a note does
-
-**What changed:**
-- The Bible reader had two width steps where the note editor has three, so on a narrow phone a chapter kept padding the editor had already given up.
-- Reading size shrinks by a proportion rather than a fixed number, and never past the smallest size the S/M/L control itself offers.
-
-**How it helps you:**
-- The same passage reads the same whether you opened it in the reader or met it inside a note.
-- If you have chosen a larger reading size, a narrow screen no longer quietly overrules you.
-
-### The what's-new row stops sending you back to the welcome
-
-**What changed:**
-- Opening what's new reopened the Harvous 3 welcome sheet each time. It now stays out of the way until 4.0.
-
-**How it helps you:**
-- The row takes you to what is actually new, not to an introduction you have already read.
-
-### What's New opens the welcome again
-
-**What changed:**
-- The What's New row had a small eye icon tucked beside its dismiss cross that opened the release notes page instead of the Harvous 3 welcome. It was easy to hit by accident and gave no hint it went somewhere different.
-- That icon is gone. The row opens the welcome, and the welcome still offers the release notes as a button that says so.
-- The welcome stays reachable for the whole of Harvous 3, and retires on its own at 4.0.
-
-**How it helps you:**
-- Pressing the row gets you the explanation of what moved and why, every time.
-
-### What's New links to the right page again
-
-**What changed:**
-- The What's New row checks with harvous.com which versions have a written page, so it can take you straight to the one you are on. That check was being refused, so it quietly sent everyone to the index instead.
-
-**How it helps you:**
-- The row takes you to the notes for your version, not to the top of the list.
-
-### Your devices are talking to each other again
-
-**What changed:**
-- Live sync between your devices had stopped connecting. Nothing said so — a note written on your phone simply took longer to appear on your laptop than it should have.
-
-**How it helps you:**
-- What you write in one place shows up in the other without waiting for a reload.
+- Nothing shifts under you while you are already reading it.
+- Opening the app lands somewhere finished rather than somewhere still assembling.
 
 ### Review says what it is waiting for
 
@@ -84,13 +41,51 @@ Small corrections to the app's frame. The search chip sits where it looks like i
 - The one question you can try is worth trying again tomorrow.
 - If you would rather not be asked at all, saying so once is enough.
 
+### Your devices are talking to each other again
+
+**What changed:**
+- Live sync between your devices had stopped connecting. Nothing said so. A note written on your phone simply took longer to reach your laptop than it should have.
+
+**How it helps you:**
+- What you write in one place shows up in the other without waiting for a reload.
+
+### What's new takes you to what is new
+
+**What changed:**
+- The row opens the Harvous 3 welcome, which is the explanation of what moved and why. It stays reachable for the whole of Harvous 3 and retires on its own at 4.0.
+- A small eye icon had been sitting beside the row's dismiss cross that opened the release notes page instead. It was easy to hit by accident and gave no sign it went somewhere different, so it is gone. The welcome still offers the release notes as a button that says so.
+- The link through to your own version's notes was being refused and quietly sending everyone to the top of the list instead. It reaches the right page again.
+
+**How it helps you:**
+- One row, one destination, and the destination is the thing you were looking for.
+
+### Search sits in the middle of the row on a phone
+
+**What changed:**
+- The Search chip is now centred on the toolbar itself rather than in whatever space the buttons on either side happened to leave.
+- Because those two groups are not the same width, the chip had been sitting noticeably right of centre on a narrow screen.
+- When the row genuinely runs out of room the chip shortens instead of sliding under the buttons beside it.
+
+**How it helps you:**
+- The one control in the middle of the toolbar looks like it is in the middle.
+
+### A chapter narrows the way a note does
+
+**What changed:**
+- The Bible reader had two width steps where the note editor has three, so on a narrow phone a chapter kept padding the editor had already given up.
+- Reading size shrinks by a proportion rather than a fixed number, and never past the smallest size the S/M/L control itself offers.
+
+**How it helps you:**
+- The same passage reads the same whether you opened it in the reader or met it inside a note.
+- If you have chosen a larger reading size, a narrow screen no longer quietly overrules you.
+
 ### Smaller changes
 
 **What changed:**
-- Text under an empty state now wraps into even lines rather than running the full width of the panel and leaving a word or two stranded underneath.
+- Text under an empty state wraps into even lines rather than running the full width of the panel and leaving a word or two stranded underneath.
 - Pointing at a review option you have already answered no longer washes it out and hides its words.
-- The reminders settings page no longer offers to send you a test notification. Checking that notifications arrive is something we do while building them; your schedule already says what will arrive and when.
 - Added to the home screen on Android, the app opens as its own window again rather than inside a browser tab.
+- The reminders settings page no longer offers to send you a test notification. Checking that notifications arrive is something we do while building them, and your schedule already says what will arrive and when.
 
 **How it helps you:**
-- One less control in Settings that was never meant for you.
+- Fewer small things to look past, and one less control in Settings that was never meant for you.

--- a/release-notes/2026-09-07.md
+++ b/release-notes/2026-09-07.md
@@ -1,7 +1,7 @@
 # What's New in Harvous — September 7, 2026
 
 **Release Date:** September 7, 2026
-**Versions:** v3.6.1–v3.7.3
+**Versions:** v3.6.1–v3.7.4
 
 Small corrections to the app's frame. The search chip sits where it looks like it should on a phone, a chapter now narrows the way a note does, and the what's-new row stops sending you back to a welcome you have already read.
 
@@ -88,6 +88,7 @@ Small corrections to the app's frame. The search chip sits where it looks like i
 
 **What changed:**
 - Text under an empty state now wraps into even lines rather than running the full width of the panel and leaving a word or two stranded underneath.
+- Pointing at a review option you have already answered no longer washes it out and hides its words.
 - The reminders settings page no longer offers to send you a test notification. Checking that notifications arrive is something we do while building them; your schedule already says what will arrive and when.
 - Added to the home screen on Android, the app opens as its own window again rather than inside a browser tab.
 

--- a/release-notes/2026-09-07.md
+++ b/release-notes/2026-09-07.md
@@ -1,7 +1,7 @@
 # What's New in Harvous — September 7, 2026
 
 **Release Date:** September 7, 2026
-**Versions:** v3.6.1–v3.7.2
+**Versions:** v3.6.1–v3.7.3
 
 Small corrections to the app's frame. The search chip sits where it looks like it should on a phone, a chapter now narrows the way a note does, and the what's-new row stops sending you back to a welcome you have already read.
 
@@ -87,6 +87,7 @@ Small corrections to the app's frame. The search chip sits where it looks like i
 ### Smaller changes
 
 **What changed:**
+- Text under an empty state now wraps into even lines rather than running the full width of the panel and leaving a word or two stranded underneath.
 - The reminders settings page no longer offers to send you a test notification. Checking that notifications arrive is something we do while building them; your schedule already says what will arrive and when.
 - Added to the home screen on Android, the app opens as its own window again rather than inside a browser tab.
 

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -23072,7 +23072,10 @@ button.proto-feed-sheet__stat:hover {
    * deep red of a warning, and this is an option that has been used, in the same family as the
    * blue one beside it that was right.
    */
-  background: linear-gradient(180deg, #f05252 0%, #d42828 55%, #be1f1f 100%);
+  /* Held in a variable so the hover rule below can restate it without a second copy of the
+     gradient — two literals is how the resting state and the hover state drift apart. */
+  --proto-verdict-bg: linear-gradient(180deg, #f05252 0%, #d42828 55%, #be1f1f 100%);
+  background: var(--proto-verdict-bg);
   box-shadow: var(--pds-shadow-destructive-button);
   color: var(--pds-on-accent) !important;
   opacity: 1;
@@ -23119,9 +23122,31 @@ button.proto-feed-sheet__stat:hover {
 }
 
 .proto-review-dock__choice[data-correct] {
-  background: var(--pds-bg-accent-button);
+  --proto-verdict-bg: var(--pds-bg-accent-button);
+  background: var(--proto-verdict-bg);
   box-shadow: var(--pds-shadow-accent-button);
   color: var(--pds-on-accent) !important;
+}
+
+/*
+ * A spent chip keeps its verdict under the pointer.
+ *
+ * `.proto-settings-btn--secondary:hover:not(:disabled)` is 0,3,0 and the verdict rules above are
+ * 0,2,0, so the neutral row-hover background won outright. The white the verdict paints its words
+ * with survives, because that is set with `!important` and again through
+ * `-webkit-text-fill-color` — so hovering an answered option left white text on pale grey and the
+ * words disappeared.
+ *
+ * Restated rather than fought with another `!important`: these chips are no longer offers, they
+ * are the answer being shown, so there is nothing for a hover to preview. `:focus-visible` gets
+ * the same treatment, since a keyboard reader would otherwise lose the words at the moment they
+ * arrived on them.
+ */
+.proto-review-dock__choice[data-correct]:hover:not(:disabled),
+.proto-review-dock__choice[data-correct]:focus-visible,
+.proto-review-dock__choice[data-missed]:hover:not(:disabled),
+.proto-review-dock__choice[data-missed]:focus-visible {
+  background: var(--proto-verdict-bg);
 }
 
 /* The gap's line carries its verdict, the same line that carries focus. */

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -6558,11 +6558,31 @@ html.harvous-prototype-route .proto-list-empty-state h2.proto-list-empty-state__
   font-weight: 400;
   line-height: 1.45;
   color: var(--pds-text-tertiary, var(--pds-text-secondary));
-  /* `pretty`, not `balance`. Balance equalises line lengths, which on a
-     three-sentence description means every line shrinks to the shortest one can
-     be — a tall narrow column in a pane that had width to spare. `pretty` keeps
-     the orphan control and lets the lines run full. */
-  text-wrap: pretty;
+  /*
+   * A measure and a balance, and the measure is what makes the balance safe.
+   *
+   * This was `pretty`, on the reasoning that `balance` "equalises line lengths, which on a
+   * three-sentence description means every line shrinks to the shortest one can be — a tall
+   * narrow column in a pane that had width to spare". That was written for a ~300px sidebar,
+   * where lines running full is also lines running short.
+   *
+   * The same empty state now appears on the Home canvas, where the card is wide enough to run
+   * body text past 130 characters — beyond any comfortable measure, and what left "up here."
+   * stranded alone under a line three times its length. So the width is capped first: a cap
+   * rather than a fixed width, so it only bites where there is width to spare and a sidebar,
+   * already narrower than this, is untouched.
+   *
+   * With the cap in place the old objection does not survive measurement. `balance` keeps the
+   * line *count* and only evens the widths, so it cannot produce the taller column it was
+   * rejected for. Measured at this cap, same string:
+   *
+   *   pretty   2 lines, 357px + 225px, 36px tall
+   *   balance  2 lines, 297px + 286px, 36px tall
+   *
+   * and on a longer one, 3 lines and 54px tall either way. Same height, evener lines.
+   */
+  max-width: 46ch;
+  text-wrap: balance;
 }
 
 /* Enough air that the action reads as a next step rather than a caption's


### PR DESCRIPTION
The Review empty state landed on Home and read badly: one line running the full width of the card, with "up here." stranded alone underneath it.

The description had no measure. On the canvas it ran past 130 characters — beyond anything comfortable to read, and long enough that whatever was left over could not fill a second line.

## Two changes, and the first is what makes the second safe

**A cap, at 46ch.** A cap rather than a width, so it only bites where there is width to spare. A sidebar is already narrower than this and nothing about it changes — which is the case the existing `pretty` was chosen for.

**Then `balance`,** which this file deliberately did not use. The stated reason:

> `pretty`, not `balance`. Balance equalises line lengths, which on a three-sentence description means every line shrinks to the shortest one can be — a tall narrow column in a pane that had width to spare.

That was written for a ~300px sidebar, where lines running full is also lines running short, and before there was any cap.

**With the cap in place the objection does not survive measurement.** `balance` keeps the line *count* and only evens the widths, so it cannot produce the taller column it was rejected for:

```
same string, at the cap
  pretty   2 lines, 357px + 225px, 36px tall
  balance  2 lines, 297px + 286px, 36px tall

a longer description
  pretty   3 lines, 357 + 384 + 239, 54px tall
  balance  3 lines, 313 + 321 + 346, 54px tall
```

Same height both times. Evener lines.

I corrected the old comment in place rather than deleting it, with the numbers, because its reasoning was right for the surface it was written about and wrong only once the component moved somewhere wider.

## Blast radius

`PrototypeListEmptyState` is shared, so this touches every empty state in the app. **The design-system gallery baseline for them is byte-identical after the change** — which is the evidence that the narrow cases really are untouched. The cap only ever engages where the copy had more room than it could use.

5866 tests, typecheck ratchet 125, perf:check, gallery baseline unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
