### PR TITLE
feat(review): reading counts toward unlocking Review

### DIFF
--- a/Changelog/3.8.0.md
+++ b/Changelog/3.8.0.md
@@ -1,8 +1,7 @@
 # Version 3.8.0
 
-**Release Date**: September 6, 2026
+**Release Date**: September 7, 2026
 
 ## Features
 
-- A quiet way out of every list that has a counterpart
-
+- Chapters you have read count toward starting Review

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.7.4
+**Version:** 3.8.0
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.7.4",
+  "version": "3.8.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-7-4';
+const CACHE_NAME = 'harvous-cache-v3-8-0';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/release-notes/2026-09-07.md
+++ b/release-notes/2026-09-07.md
@@ -1,7 +1,7 @@
 # What's New in Harvous — September 7, 2026
 
 **Release Date:** September 7, 2026
-**Versions:** v3.6.1–v3.7.4
+**Versions:** v3.6.1–v3.8.0
 
 Home now arrives as one page instead of filling in around you. Review explains itself before it has anything to ask, the daily sample for free accounts is finally daily, and live sync between your devices is talking again.
 
@@ -29,6 +29,15 @@ Home now arrives as one page instead of filling in around you. Review explains i
 
 **How it helps you:**
 - An empty Review reads as a feature getting ready rather than one that is not working.
+
+### Reading counts toward starting Review
+
+**What changed:**
+- Review waits for a few days of your own study before it begins. Chapters you had read were not counted toward that, only notes and passages you had cited, so someone who mostly reads could wait indefinitely without ever being told why.
+- Chapters now count, on the same terms as everything else: a chapter you have read or gone back to, or read and marked something in. A chapter you only opened still counts for nothing.
+
+**How it helps you:**
+- If reading is how you study, that is now how Review starts.
 
 ### The daily Review sample is actually daily
 

--- a/src/utils/__tests__/review-opportunity-scoring.test.ts
+++ b/src/utils/__tests__/review-opportunity-scoring.test.ts
@@ -433,16 +433,49 @@ describe('a chapter the reader has been through', () => {
     expect(nodeReadiness(yesterday, NOW, null)).toBe('ready');
   });
 
-  it('never unlocks the engine on its own', () => {
-    /*
-     * The cold start asks whether this is an account someone has been studying in, and reading
-     * is the one signal that arrives with no writing at all. Five read chapters and nothing
-     * else must not open the queue, or a new reader's first week is five chapter quizzes.
-     */
+  /*
+   * This used to assert the opposite: "never unlocks the engine on its own", on the reasoning
+   * that reading is the one signal arriving with no writing at all, and that five read chapters
+   * would make a new reader's first week five chapter quizzes.
+   *
+   * The fear was right and the guard was in the wrong place. What it actually refused was the
+   * reader it was written to protect — someone who had read eleven chapters and gone back to six
+   * of them, studying by any honest reading of the word, and no closer to a feature that exists
+   * to bring their study back. Reading is how a great many people study.
+   *
+   * The protection lives in `nodeReadiness`, which is where it belongs, and the pair below is
+   * the whole argument: chapters that were read count, chapters that were merely opened do not.
+   */
+  it('unlocks the engine when the chapters were genuinely read', () => {
     const chapters = [1, 2, 3, 4, 5, 6, 7].map((n) =>
       chapter(nodeKey.chapter({ book: 'John', chapter: n }), { revisitCount: 2 }),
     );
-    expect(engineHasEnoughReady(chapters, NOW, new Map())).toBe(false);
+    expect(engineHasEnoughReady(chapters, NOW, new Map())).toBe(true);
+  });
+
+  it('is not unlocked by chapters that were only opened', () => {
+    /*
+     * The case the old exclusion was really aimed at, and the one it never had to catch itself.
+     * `countCommittedSignals` scores a glance at nothing: exposure however high is worth zero
+     * for a chapter, so "turned to seven chapters" is seven nodes that are not ready.
+     */
+    const glanced = [1, 2, 3, 4, 5, 6, 7].map((n) =>
+      chapter(nodeKey.chapter({ book: 'John', chapter: n }), { revisitCount: 0, exposureCount: 9 }),
+    );
+    expect(engineHasEnoughReady(glanced, NOW, new Map())).toBe(false);
+  });
+
+  it('counts a chapter that was read once and marked in', () => {
+    // One read plus a highlight is two deliberate acts, the same bar a note or verse clears.
+    const key = nodeKey.chapter({ book: 'John', chapter: 3 });
+    const read = [1, 2, 3, 4, 5].map((n) =>
+      chapter(nodeKey.chapter({ book: 'John', chapter: n }), { revisitCount: 1 }),
+    );
+    expect(engineHasEnoughReady(read, NOW, new Map())).toBe(false);
+    const marked = read.map((c) => ({ ...c, nodeKey: key }));
+    expect(
+      engineHasEnoughReady(marked, NOW, new Map(), { highlightedChapterKeys: new Set([key]) }),
+    ).toBe(true);
   });
 
   it('is picked once the account has cleared the gate on its own study', () => {
@@ -517,14 +550,25 @@ describe('describeEngineColdStart', () => {
     expect(describeEngineColdStart(barren, NOW, new Map()).opensAt).toBeNull();
   });
 
-  it('does not count chapters, matching the gate it describes', () => {
-    // Reading arrives without writing; counting it would unlock the engine on chapters alone.
+  it('counts read chapters, matching the gate it describes', () => {
+    // Was asserted the other way, alongside the exclusion in `engineHasEnoughReady`. These two
+    // have to agree about what a ready node is, or the estimate describes a different gate.
     const chapters = ['a', 'b', 'c', 'd', 'e'].map((k) =>
-      node({ nodeKind: 'chapter', nodeKey: k, exposureCount: 2, revisitCount: 1, firstStudiedAt: daysAgo(30) }),
+      node({ nodeKind: 'chapter', nodeKey: k, revisitCount: 2, firstStudiedAt: daysAgo(30) }),
     );
     const state = describeEngineColdStart(chapters, NOW, new Map());
-    expect(state.ready).toBe(0);
-    expect(state.opensAt).toBeNull();
+    expect(state.ready).toBe(5);
+    expect(engineHasEnoughReady(chapters, NOW, new Map())).toBe(true);
+  });
+
+  it('dates a chapter a day out, not three', () => {
+    // Chapters mature on `ENGINE_MIN_CHAPTER_AGE_DAYS`. Using the note threshold here would put
+    // the estimate two days behind the gate.
+    const chapters = ['a', 'b', 'c', 'd', 'e'].map((k) =>
+      node({ nodeKind: 'chapter', nodeKey: k, revisitCount: 2, firstStudiedAt: daysAgo(0) }),
+    );
+    const state = describeEngineColdStart(chapters, NOW, new Map());
+    expect(state.opensAt!.getTime()).toBe(daysAgo(0).getTime() + ENGINE_MIN_CHAPTER_AGE_DAYS * 24 * 60 * 60 * 1000);
   });
 
   it('agrees with the gate about when the engine may run', () => {

--- a/src/utils/review-opportunity-scoring.ts
+++ b/src/utils/review-opportunity-scoring.ts
@@ -304,15 +304,28 @@ export function engineHasEnoughReady(
   let ready = 0;
   for (const node of nodes) {
     /*
-     * Chapters do not count toward the cold start.
+     * Chapters count, and used to not.
      *
-     * The gate asks whether this is an account someone has been *studying* in, and reading is
-     * the one signal that arrives without any writing at all. Counted here, a reader who has
-     * turned to five chapters and written nothing would unlock the engine and be asked about
-     * five chapters — which is the demo-of-a-feature the cold start exists to prevent. They
-     * still get chapter items once the account clears the gate on its own study.
+     * The exclusion read: "reading is the one signal that arrives without any writing at all.
+     * Counted here, a reader who has turned to five chapters and written nothing would unlock
+     * the engine and be asked about five chapters — the demo-of-a-feature the cold start exists
+     * to prevent."
+     *
+     * The fear is right and the guard was in the wrong place, because it describes chapters that
+     * `nodeIsReady` already refuses. A chapter needs two committed signals, and for a chapter
+     * those are reads and study dwells, plus one for having marked something in it —
+     * `countCommittedSignals` scores a glance at nothing at all. "Turned to five chapters" is
+     * five glances: none of them ready, none of them counted, with or without this line.
+     *
+     * What the line did instead was refuse the reader it was written to protect. Someone who has
+     * read eleven chapters and gone back to six of them has been studying by any honest reading
+     * of the word, and none of it moved them one step closer to a feature that exists to bring
+     * their study back. Reading is how a great many people study, and an engine that waits for
+     * writing before it believes them is making a claim about what study looks like that this
+     * app should not make.
+     *
+     * `nodeIsReady` is the arbiter, which is what it is for.
      */
-    if (node.nodeKind === 'chapter') continue;
     const weight = node.noteId ? meaningWeightByNoteId.get(node.noteId) ?? null : null;
     if (nodeIsReady(node, now, weight, context)) {
       ready += 1;
@@ -363,8 +376,6 @@ export function describeEngineColdStart(
   const maturesAt: number[] = [];
 
   for (const node of nodes) {
-    // Chapters are excluded here for the same reason they are excluded from the gate itself.
-    if (node.nodeKind === 'chapter') continue;
     const weight = node.noteId ? meaningWeightByNoteId.get(node.noteId) ?? null : null;
     const readiness = nodeReadiness(node, now, weight, context);
     if (readiness === 'ready') {
@@ -373,7 +384,15 @@ export function describeEngineColdStart(
     }
     if (readiness !== 'too-new') continue;
 
-    const matureAt = new Date(node.firstStudiedAt.getTime() + ENGINE_MIN_NODE_AGE_DAYS * DAY_MS);
+    /*
+     * A chapter matures a day after it was read, not three — reading is a different act from
+     * writing and `nodeReadiness` already says so. Asking the wrong threshold here would put the
+     * estimate two days behind the gate it is describing, which is the quiet way an explanation
+     * stops being about the thing it explains.
+     */
+    const minAge =
+      node.nodeKind === 'chapter' ? ENGINE_MIN_CHAPTER_AGE_DAYS : ENGINE_MIN_NODE_AGE_DAYS;
+    const matureAt = new Date(node.firstStudiedAt.getTime() + minAge * DAY_MS);
     if (nodeReadiness(node, matureAt, weight, context) === 'ready') maturesAt.push(matureAt.getTime());
   }
 


### PR DESCRIPTION
Chapters were excluded from Review's cold-start gate. The reasoning was written down:

> reading is the one signal that arrives without any writing at all. Counted here, a reader who has turned to five chapters and written nothing would unlock the engine and be asked about five chapters — the demo-of-a-feature the cold start exists to prevent.

**The fear is right and the guard was in the wrong place.** It describes chapters that `nodeReadiness` already refuses. A chapter needs two committed signals, and for a chapter those are reads and study dwells plus one for having marked something in it — `countCommittedSignals` scores a glance at nothing at all. "Turned to five chapters" is five glances: not ready, not counted, with or without the exclusion.

What the line did instead was refuse the reader it was written to protect.

## Measured against the account that prompted it

```
before   {ready: 0, needed: 5, opensAt: null}         nothing ready, no date at all
after    {ready: 3, needed: 5, opensAt: 2026-09-08}   three ready, opens tomorrow
```

Eleven chapters read, six of them returned to, and none of it moved them one step closer to a feature that exists to bring their study back. Their empty state goes from "keep studying" with no date to naming a day, because for the first time waiting is genuinely all it takes.

Reading is how a great many people study, and an engine that waits for writing before it believes them makes a claim about what study looks like that this app should not be making.

## What keeps it safe

The protection moves to `nodeReadiness`, where it belongs, and three tests are the whole argument:

- chapters that were **read** unlock the gate
- chapters that were **only opened** do not, however many times
- one read **plus a highlight** clears the same bar a note or verse clears

## Also

`describeEngineColdStart` drops the same exclusion — otherwise the explanation would describe a gate that no longer exists, which is the parity failure that took Review off Home earlier today. It also now uses `ENGINE_MIN_CHAPTER_AGE_DAYS` when dating a chapter's maturity, where it had been using the note threshold and putting the estimate two days late.

5869 tests, typecheck ratchet 125, perf:check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
