### PR TITLE
fix(review): let Review see the notes you wrote

### DIFF
--- a/Changelog/3.9.1.md
+++ b/Changelog/3.9.1.md
@@ -1,0 +1,9 @@
+# Version 3.9.1
+
+**Release Date**: September 7, 2026
+
+## Fixes
+
+- Review now draws on the notes you have written, not only the ones citing scripture
+- Stop installed and shared study being recorded as something you wrote
+- Trim the empty Review state to two lines

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.8.0",
+  "version": "3.9.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "skl:seed": "tsx server/scripts/seed-scripture-knowledge.ts",
     "fingerprints:backfill": "tsx server/scripts/backfill-note-fingerprints.ts",
     "study-bible:backfill": "tsx server/scripts/backfill-study-bible-layer.ts",
+    "study-bible:notes": "tsx server/scripts/backfill-note-written-nodes.ts",
     "recall:kind-rates": "tsx server/scripts/recall-open-rate-by-kind.ts",
     "review:schema": "tsx server/scripts/add-review-challenges-schema.ts",
     "review:schema:apply": "tsx server/scripts/add-review-challenges-schema.ts --apply",

--- a/release-notes/2026-09-07.md
+++ b/release-notes/2026-09-07.md
@@ -1,9 +1,9 @@
 # What's New in Harvous — September 7, 2026
 
 **Release Date:** September 7, 2026
-**Versions:** v3.6.1–v3.8.0
+**Versions:** v3.6.1–v3.9.1
 
-Home now arrives as one page instead of filling in around you. Review explains itself before it has anything to ask, the daily sample for free accounts is finally daily, and live sync between your devices is talking again.
+Review now draws on the notes you have written, which is what it was always meant to do. Home arrives as one page instead of filling in around you, the daily sample for free accounts is finally daily, and live sync between your devices is talking again.
 
 ---
 
@@ -19,6 +19,17 @@ Home now arrives as one page instead of filling in around you. Review explains i
 **How it helps you:**
 - Nothing shifts under you while you are already reading it.
 - Opening the app lands somewhere finished rather than somewhere still assembling.
+
+### Review draws on the notes you wrote
+
+**What changed:**
+- Reviews were meant to come from your own study, and notes are most of what that is. But a note only ever became something Review could ask about if it happened to have a scripture reference in it. Write a page of your own thinking with no verse quoted in it, and Review could not see it at all.
+- On top of that, Review would only ask about a note once you had gone back to it. Writing it did not count on its own.
+- Both are gone. Writing a substantial note is now enough, and notes you wrote months ago and never opened again are included from today.
+
+**How it helps you:**
+- Review is about your study rather than about the parts of it that happened to quote a verse.
+- Not having gone back to something is not a reason to let it go. Often it is the reason to be asked.
 
 ### Review says what it is waiting for
 
@@ -92,6 +103,7 @@ Home now arrives as one page instead of filling in around you. Review explains i
 
 **What changed:**
 - Text under an empty state wraps into even lines rather than running the full width of the panel and leaving a word or two stranded underneath.
+- The empty Review panel is two short lines instead of four.
 - Pointing at a review option you have already answered no longer washes it out and hides its words.
 - Added to the home screen on Android, the app opens as its own window again rather than inside a browser tab.
 - The reminders settings page no longer offers to send you a test notification. Checking that notifications arrive is something we do while building them, and your schedule already says what will arrive and when.

--- a/server/scripts/backfill-note-written-nodes.ts
+++ b/server/scripts/backfill-note-written-nodes.ts
@@ -1,0 +1,96 @@
+/**
+ * Backfill: give every note the reader wrote its `note:` node in the Study Bible layer.
+ *
+ * Notes are recorded on save now (`noteWrittenTouches`, called from process-scripture-references),
+ * but nothing recorded them before that, and a note only became a node if it happened to carry a
+ * scripture pill. Measured on a real account: of 31 notes substantial enough to be worth asking
+ * about, exactly one existed as a node. Those notes will not get one until they are next saved,
+ * which for most of them is never.
+ *
+ * **Idempotent and resumable, by construction rather than by care.** It writes only for notes that
+ * have no node, so a second run finds nothing and cannot double-count. Use this rather than
+ * `backfill-study-bible-layer --reset`, which deletes the account's rows and takes accumulated
+ * counters and the review mirrors reconstructed from ReviewItems with them.
+ *
+ * The touch is dated at the note's `createdAt`, which is the point: `firstStudiedAt` folds with
+ * LEAST, so a note written two years ago lands on the far side of the age gate rather than three
+ * days in front of it.
+ *
+ * Usage (requires `SUPABASE_DATABASE_URL` or `SUPABASE_DIRECT_URL` in env — same as the API):
+ *   npx tsx server/scripts/backfill-note-written-nodes.ts --dry-run
+ *   npx tsx server/scripts/backfill-note-written-nodes.ts --userId=user_xxx --dry-run
+ *   npx tsx server/scripts/backfill-note-written-nodes.ts --userId=user_xxx
+ *   npx tsx server/scripts/backfill-note-written-nodes.ts --limit=500
+ */
+
+import 'dotenv/config';
+import { db, Notes } from '../db';
+import { findNotesMissingNoteNode, noteWrittenTouches, touchNodes } from '../utils/study-bible-layer';
+import { requireDbTarget } from '../utils/require-db-target';
+
+/** One upsert statement per chunk; `touchNodes` chunks again internally. */
+const BATCH = 500;
+
+function parseArgs() {
+  const dryRun = process.argv.includes('--dry-run');
+  let userId: string | undefined;
+  let limit: number | undefined;
+  for (const a of process.argv) {
+    if (a.startsWith('--userId=')) userId = a.slice('--userId='.length).trim() || undefined;
+    if (a.startsWith('--limit=')) {
+      const n = parseInt(a.slice('--limit='.length), 10);
+      if (!Number.isNaN(n) && n > 0) limit = n;
+    }
+  }
+  return { dryRun, userId, limit };
+}
+
+async function targetUserIds(userId: string | undefined): Promise<string[]> {
+  if (userId) return [userId];
+  const rows = await db.selectDistinct({ userId: Notes.userId }).from(Notes);
+  return rows.map((r) => r.userId).filter(Boolean);
+}
+
+async function main() {
+  const { dryRun, userId, limit } = parseArgs();
+  requireDbTarget({ scriptName: 'backfill-note-written-nodes', writes: !dryRun });
+
+  const users = await targetUserIds(userId);
+  console.log(`[backfill-note-nodes] ${users.length} user(s)${dryRun ? ' (dry-run)' : ''}`);
+
+  const now = new Date();
+  let written = 0;
+  let skipped = 0;
+
+  for (const uid of users) {
+    const missing = await findNotesMissingNoteNode(uid);
+    // Split before the limit so the skipped count reports what the exclusions turned away rather
+    // than what the limit cut off — the two mean different things when checking a dry run.
+    const touches = missing.flatMap((note) => noteWrittenTouches(note, now));
+    skipped += missing.length - touches.length;
+    const capped = limit != null ? touches.slice(0, Math.max(0, limit - written)) : touches;
+    if (!capped.length) continue;
+
+    console.log(
+      `[backfill-note-nodes] user ${uid}: ${capped.length} note(s)` +
+        (missing.length !== touches.length ? ` (${missing.length - touches.length} not theirs to claim)` : ''),
+    );
+    if (!dryRun) {
+      for (let i = 0; i < capped.length; i += BATCH) {
+        await touchNodes(uid, capped.slice(i, i + BATCH));
+      }
+    }
+    written += capped.length;
+    if (limit != null && written >= limit) break;
+  }
+
+  console.log(
+    `[backfill-note-nodes] done. notes=${written} skipped=${skipped}${dryRun ? ' (dry-run, nothing written)' : ''}`,
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[backfill-note-nodes] fatal:', err);
+  process.exit(1);
+});

--- a/server/scripts/backfill-study-bible-layer.ts
+++ b/server/scripts/backfill-study-bible-layer.ts
@@ -48,6 +48,7 @@ import {
   scriptureTouches,
   touchNodes,
   type NodeTouch,
+  noteWrittenTouches,
 } from '../utils/study-bible-layer';
 import { nodeKey } from '@/utils/study-bible-nodes';
 import type { RecallState } from '@/utils/review-item-kinds';
@@ -58,7 +59,6 @@ import {
   readChapterSource,
   LINKED_NOTES_SOURCE,
   NOTE_OPENED_SOURCE,
-  NOTE_WRITTEN_SOURCE,
   REVIEWED_SOURCE,
   THREAD_NAMED_SOURCE,
 } from '@/utils/study-bible-source-copy';
@@ -127,26 +127,33 @@ class TouchCollector {
 
 async function collectForUser(userId: string, since: Date): Promise<TouchCollector> {
   const collector = new TouchCollector();
+  const now = new Date();
 
   // ── Notes: written, and every later checkpoint as an expansion ──────────────
   const notes = await db
-    .select({ id: Notes.id, title: Notes.title, createdAt: Notes.createdAt })
+    .select({
+      id: Notes.id,
+      title: Notes.title,
+      createdAt: Notes.createdAt,
+      noteType: Notes.noteType,
+      addedBy: Notes.addedBy,
+      threadId: Notes.threadId,
+      primaryCollection: Notes.primaryCollection,
+    })
     .from(Notes)
     .where(and(eq(Notes.userId, userId), ne(Notes.noteType, 'scripture'), countableUserNotesWhere()));
   const titleById = new Map(notes.map((n) => [n.id, n.title]));
 
-  collector.add(
-    'notes',
-    notes.map((note) =>
-      noteTouch({
-        noteId: note.id,
-        title: note.title,
-        signal: 'exposure',
-        at: note.createdAt ?? since,
-        sourceLabel: NOTE_WRITTEN_SOURCE,
-      }),
-    ),
-  );
+  /*
+   * Through `noteWrittenTouches`, which is what the live save path calls, so a replay and a save
+   * cannot claim different things about the same note.
+   *
+   * It also carries an exclusion this block did not have: `countableUserNotesWhere()` only filters
+   * `addedBy = 'system'`, so a Discover install or a shared-space import — `'discover'` and
+   * `'shared'` — was replayed as twenty nodes labelled "You wrote this" about someone else's
+   * study. The builder refuses those.
+   */
+  collector.add('notes', notes.flatMap((note) => noteWrittenTouches({ ...note, createdAt: note.createdAt ?? since }, now)));
 
   const noteIds = notes.map((n) => n.id);
   if (noteIds.length) {

--- a/server/scripts/preview-review-engine.ts
+++ b/server/scripts/preview-review-engine.ts
@@ -1,8 +1,17 @@
 /**
- * Read-only: what the review engine currently makes of this reader's chapter nodes.
+ * Read-only: what the review engine currently makes of one reader's study.
  *
- * Prints each chapter node with its counters and the readiness verdict, so the gates can be
- * checked against real reading without creating anything.
+ * Prints the readiness verdict for every node, a tally per kind, whether the cold start has
+ * opened, and what the engine would pick next — creating nothing. `selectReviewBatch` and
+ * `nodeReadiness` are pure, and nothing here writes, so it is safe to point at production.
+ *
+ * Usage:
+ *   npx tsx server/scripts/preview-review-engine.ts --user=user_xxx
+ *
+ * `--user` is required on purpose. It used to default to a hardcoded account, which is how you
+ * end up measuring one reader and drawing conclusions about another — the exact mistake that
+ * sent a day's worth of "Review is empty" debugging in the wrong direction, because the dev and
+ * live Clerk instances mint different ids against the same database.
  */
 import 'dotenv/config';
 import { db, UserNodeStates, StudyThreadEntries, ReviewItems, NoteFingerprints, eq, and, isNull, desc } from '../db';
@@ -15,7 +24,11 @@ import {
 } from '@/utils/review-opportunity-scoring';
 import { nodeKey, verseNodesForReference, type NodeKind } from '@/utils/study-bible-nodes';
 
-const uid = process.argv.find((a) => a.startsWith('--user='))?.split('=')[1] ?? 'user_2x04WKuLGMxuPpNpvwwA4JgRplX';
+const uid = process.argv.find((a) => a.startsWith('--user='))?.split('=')[1];
+if (!uid) {
+  console.error('usage: npx tsx server/scripts/preview-review-engine.ts --user=<clerk user id>');
+  process.exit(1);
+}
 const now = new Date();
 
 const marks = await db
@@ -78,5 +91,17 @@ const picks = selectReviewBatch(candidates, {
   existingSourceKeys: new Set(existing.map((r) => r.sourceKey)),
   signalContext: { highlightedChapterKeys },
 });
+
+// Readiness across every kind, which is the number the cold start is actually counting.
+const byKind: Record<string, Record<string, number>> = {};
+for (const c of candidates) {
+  const weight = c.noteId ? weights.get(c.noteId) ?? null : null;
+  const verdict = nodeReadiness(c, now, weight, { highlightedChapterKeys });
+  (byKind[c.nodeKind] ??= {})[verdict] = ((byKind[c.nodeKind] ??= {})[verdict] ?? 0) + 1;
+}
+for (const [kind, verdicts] of Object.entries(byKind)) {
+  console.log(`${kind.padEnd(8)} ${JSON.stringify(verdicts)}`);
+}
+
 for (const pick of picks) console.log('would add:', pick.nodeKind, pick.nodeKey, '|', pick.label);
 process.exit(0);

--- a/server/utils/__tests__/study-bible-layer.test.ts
+++ b/server/utils/__tests__/study-bible-layer.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { noteWrittenTouches } from '../study-bible-layer';
+import { NOTE_WRITTEN_SOURCE } from '@/utils/study-bible-source-copy';
 
 /**
  * Source contract, in the style of review-routes.test.ts.
@@ -71,6 +73,94 @@ describe('activity paths write to the layer', () => {
       expect(read(path)).toContain('touchNodes(');
     });
   }
+});
+
+describe('a note the reader wrote', () => {
+  /*
+   * Behavioural, not source-inspection: `noteWrittenTouches` is pure, so it can be run.
+   *
+   * The rest of this file reads source because the writer needs a database. This one does not,
+   * and it is the piece that decides whether someone's own writing is ever askable — the reason
+   * Review saw 1 of 31 substantial notes on a real account was that nothing wrote the node.
+   */
+  const authored = {
+    id: 'n1',
+    title: 'Covenant and kingship',
+    createdAt: new Date('2026-06-01T09:00:00Z'),
+    noteType: 'default',
+    addedBy: 'user' as string | null,
+    threadId: 'thread_abc',
+    primaryCollection: null as string | null,
+  };
+  const NOW = new Date('2026-09-01T12:00:00Z');
+
+  it('records it as written, dated when it was written', () => {
+    const [touch] = noteWrittenTouches(authored, NOW);
+    expect(touch.kind).toBe('note');
+    expect(touch.signal).toBe('exposure');
+    expect(touch.noteId).toBe('n1');
+    expect(touch.sourceLabel).toBe(NOTE_WRITTEN_SOURCE);
+    /*
+     * `createdAt`, not now. `firstStudiedAt` folds with LEAST, so this is what keeps a note
+     * written two years ago from being three days short of reviewable; and `lastSourceLabel`
+     * only moves when `lastSourceAt` does, so backdating is what stops "You wrote this" racing
+     * the "You added to this" that `/api/notes/update` fires on the very same request.
+     */
+    expect(touch.at).toBe(authored.createdAt);
+  });
+
+  it('clamps a client clock that is ahead of ours', () => {
+    // Offline sync carries the device's own time; a future date would park the label permanently
+    // in front of every real event.
+    const [touch] = noteWrittenTouches({ ...authored, createdAt: new Date('2027-01-01T00:00:00Z') }, NOW);
+    expect(touch.at).toBe(NOW);
+  });
+
+  it('says nothing about writing the reader did not do', () => {
+    // A scripture child note is the app's text pasted in beside theirs.
+    expect(noteWrittenTouches({ ...authored, noteType: 'scripture' }, NOW)).toEqual([]);
+    /*
+     * Installed and shared content. Both run the same enrichment pass as a real save, so without
+     * this a twenty-note Discover install would write twenty nodes claiming the reader wrote it.
+     */
+    for (const addedBy of ['discover', 'shared', 'harvous', 'system']) {
+      expect(noteWrittenTouches({ ...authored, addedBy }, NOW)).toEqual([]);
+    }
+    // Onboarding, on the same terms as every other usage count.
+    expect(noteWrittenTouches({ ...authored, threadId: 'thread_onboarding_1' }, NOW)).toEqual([]);
+    expect(noteWrittenTouches({ ...authored, primaryCollection: 'Welcome to Harvous' }, NOW)).toEqual([]);
+  });
+});
+
+describe('the save path records the note itself', () => {
+  const save = read('server/utils/process-scripture-references.ts');
+
+  it('records it whether or not the note cites a passage', () => {
+    /*
+     * `toContain('touchNodes(')` above would pass with the note touch deleted, and effectively
+     * did: the only note touch used to sit behind `if (!passages.length) return;` inside the
+     * passage recorder, so a note with no scripture pill became no node at all.
+     *
+     * The claim is about the enrichment block, so read that block rather than the whole file:
+     * the write-touch is called there unconditionally, and before the passage work, which is
+     * what "whether or not it cites a passage" means once the guard moved out of sight.
+     */
+    const block = save.slice(save.indexOf('computeAndStoreNoteFingerprint(noteId, userId)'));
+    const written = block.indexOf('noteWrittenTouches(note');
+    const passages = block.indexOf('recordCitedPassageNodes(noteId');
+    expect(written).toBeGreaterThan(-1);
+    expect(passages).toBeGreaterThan(-1);
+    expect(written).toBeLessThan(passages);
+    // Nothing between the two may make the write-touch conditional.
+    expect(block.slice(0, written)).not.toContain('passages');
+  });
+
+  it('does not also count the note on the passage path', () => {
+    // Two touches per save on pill notes and one on prose notes would make `exposureCount`
+    // mean different things for the two, which the score has no way to tell apart.
+    const passages = save.slice(save.indexOf('async function recordCitedPassageNodes'));
+    expect(passages).not.toContain('noteTouch(');
+  });
 });
 
 describe('note deletion', () => {

--- a/server/utils/process-scripture-references.ts
+++ b/server/utils/process-scripture-references.ts
@@ -410,6 +410,11 @@ export function mergeAdditionalScriptureReferences(
 /**
  * Record the passages a note cites in the reader's Study Bible layer.
  *
+ * The note itself is *not* recorded here — `noteWrittenTouches` does that, unconditionally, one
+ * line above the call site. It used to be recorded here, behind the early return below, which
+ * meant a note only became a node if it happened to carry a pill. Keeping both would double the
+ * `exposureCount` of pill notes relative to prose ones and quietly make the score untrustworthy.
+ *
  * Reads through `getNotePassages`, which already unions the note's own ScriptureMetadata with
  * the canonical scripture children linked to it — the pill points at the scripture child note,
  * not the reader's, so a naive join on noteId finds nothing.
@@ -417,8 +422,12 @@ export function mergeAdditionalScriptureReferences(
  * Non-throwing by construction: touchNodes swallows its own failures and this awaits inside
  * the caller's try, so nothing here can fail a save.
  */
-async function recordCitedPassageNodes(noteId: string, userId: string): Promise<void> {
-  const [{ getNotePassages }, { knowledgeTouchesForVerses, noteTouch, touchNodes, verseTouches }, { citedInNoteSource }] =
+async function recordCitedPassageNodes(
+  noteId: string,
+  userId: string,
+  title: string | null,
+): Promise<void> {
+  const [{ getNotePassages }, { knowledgeTouchesForVerses, touchNodes, verseTouches }, { citedInNoteSource }] =
     await Promise.all([
       import('./scripture-knowledge'),
       import('./study-bible-layer'),
@@ -428,20 +437,13 @@ async function recordCitedPassageNodes(noteId: string, userId: string): Promise<
   const passages = (await getNotePassages(noteId)).slice(0, 30);
   if (!passages.length) return;
 
-  const [note] = await db
-    .select({ title: Notes.title })
-    .from(Notes)
-    .where(and(eq(Notes.id, noteId), eq(Notes.userId, userId)))
-    .limit(1);
-
   const at = new Date();
-  const sourceLabel = citedInNoteSource(note?.title);
+  const sourceLabel = citedInNoteSource(title);
   const chapters = [...new Map(passages.map((p) => [`${p.book}|${p.chapter}`, { book: p.book, chapter: p.chapter }])).values()];
 
   await touchNodes(userId, [
     ...verseTouches({ verses: passages, chapters, signal: 'exposure', at, sourceLabel }),
     ...(await knowledgeTouchesForVerses({ verses: passages, signal: 'exposure', at, sourceLabel })),
-    noteTouch({ noteId, title: note?.title ?? null, signal: 'exposure', at, sourceLabel: null }),
   ]);
 }
 
@@ -1558,10 +1560,22 @@ async function processScriptureReferencesInternal(
       // substrate forgetting-aware resurfacing and study arcs read from.
       const { computeAndStoreNoteFingerprint } = await import('./note-fingerprint');
       await computeAndStoreNoteFingerprint(noteId, userId);
-      // Study Bible layer: the verses this note actually cites, the chapters above them, and
-      // the curated themes at those verses. Citing a passage in your own writing is the same
-      // contact as marking it in the reader, so both land on the same nodes.
-      await recordCitedPassageNodes(noteId, userId);
+      /*
+       * Study Bible layer, in two parts.
+       *
+       * First the note itself: writing it is the study, and this is the only place a save
+       * records that. It runs whether or not the note cites anything — the reason Review could
+       * not see prose notes at all was that the only note touch lived behind the passage check
+       * below. `note` is the row loaded at the top of this function, so this costs no query.
+       */
+      const { noteWrittenTouches, touchNodes: touchStudyNodes } = await import('./study-bible-layer');
+      await touchStudyNodes(userId, noteWrittenTouches(note, new Date()));
+      /*
+       * Then the verses it cites, the chapters above them, and the curated themes at those
+       * verses. Citing a passage in your own writing is the same contact as marking it in the
+       * reader, so both land on the same nodes.
+       */
+      await recordCitedPassageNodes(noteId, userId, note.title);
     } catch (tagErr: unknown) {
       console.error(
         '[processScriptureReferences] Auto-tag parent note failed (non-critical):',

--- a/server/utils/review-opportunities.ts
+++ b/server/utils/review-opportunities.ts
@@ -221,10 +221,11 @@ export async function engineColdStartFor(
 /**
  * Top up the reader's queue from their own study, and return whatever it added.
  *
- * **Waits before it offers anything.** A node has to be a few days old, carry two distinct
- * deliberate acts, and — for a note — hold enough study to clear `NOTE_MEANING_WEIGHT_FLOOR`;
- * and the account itself has to have `ENGINE_COLD_START_MIN_READY` such nodes before the engine
- * runs at all. Before this the only gate was a 24-hour quiet rule, so anything opened once and
+ * **Waits before it offers anything.** A node has to be a few days old; a verse or a chapter has
+ * to carry two distinct deliberate acts; a note has to clear `NOTE_MEANING_WEIGHT_FLOOR`, which
+ * for a note is the whole test, because writing one is already the deliberate act and asking for
+ * a second said that study does not count until you come back to it. The account itself has to
+ * have `ENGINE_COLD_START_MIN_READY` such nodes before the engine runs at all. Before this the only gate was a 24-hour quiet rule, so anything opened once and
  * abandoned was eligible — and because learning need is measured from `lastSeenAt`, the longer
  * it was ignored the higher it climbed. Against a real account the gate takes 86 candidates down
  * to 14.

--- a/server/utils/study-bible-layer.ts
+++ b/server/utils/study-bible-layer.ts
@@ -36,6 +36,8 @@ import type { VerseKeyParts } from '@/utils/scripture-verse-keys';
 import type { RecallState } from '@/utils/review-item-kinds';
 import { getKnowledgeForPassages, MIN_THEME_CORROBORATION_RELEVANCE } from './scripture-knowledge';
 import { pickRepNoteIdFromGraph } from './study-thread-cluster-count';
+import { isCountableUserNote } from './purge-onboarding-content';
+import { NOTE_WRITTEN_SOURCE } from '@/utils/study-bible-source-copy';
 
 export interface NodeTouch {
   key: string;
@@ -228,6 +230,101 @@ export async function touchNodes(userId: string, touches: readonly NodeTouch[]):
 
 // ─── Touch builders ───────────────────────────────────────────────────────────
 // Shared shapes, so a highlight and a pill on the same verse produce identical nodes.
+
+/**
+ * The node for "you wrote this" — the act Review is actually about.
+ *
+ * Writing a note is the most deliberate thing this app can observe someone do, and until this
+ * existed the live save path recorded it nowhere. A note only became a node if it happened to
+ * carry a scripture pill, so Review could not see prose at all: on a real account, of 31 notes
+ * substantial enough to be worth asking about, exactly one existed as a node.
+ *
+ * **Returns nothing for anything the reader did not author**, which is the whole reason this is a
+ * function rather than a line at the call site. A Discover install and a shared-space import both
+ * run the same enrichment pass as a real save, so without these three exclusions installing a
+ * twenty-note study would write twenty nodes labelled "You wrote this" about someone else's work.
+ *
+ * **`at` is the note's own `createdAt`, not now**, and that carries more weight than it looks:
+ *
+ * - `firstStudiedAt` folds with `LEAST`, so the age gate measures when the study happened. A note
+ *   written two years ago and edited today is not three days from being reviewable.
+ * - `lastSourceLabel` only moves when `lastSourceAt` moves forward. `/api/notes/update` fires
+ *   "You added to this" at `now` on the same request; dating this at `now` would race it, and the
+ *   row's reason line would come out nondeterministically wrong on every edit. Backdated, "You
+ *   wrote this" wins only where there is no more recent reason — which is exactly a fresh node.
+ *
+ * Clamped to `now` because offline sync carries a client's clock and a future date would park the
+ * label permanently ahead of every real event.
+ *
+ * Pure: reads the row it is handed and touches nothing. Shared with the backfill so a replay and
+ * a live save cannot drift.
+ */
+/**
+ * The reader's notes that have no `note:` node yet — the backfill's whole query.
+ *
+ * A LEFT JOIN rather than "read every note and every node and diff them in JavaScript", which is
+ * how the neighbouring repair used to work and what made it cost 243ms on a hot path.
+ *
+ * **This is what makes the backfill idempotent.** A note that already has a node is not in the
+ * result, so a second run writes nothing and no counter is ever double-incremented. That is why
+ * this exists rather than reaching for the full replay's `--reset`, which deletes the account's
+ * rows and takes accumulated counters and review mirrors with them.
+ *
+ * The exclusions are deliberately *not* applied here — `noteWrittenTouches` applies them, and
+ * duplicating them in SQL is how the two would eventually disagree about who wrote what.
+ */
+export async function findNotesMissingNoteNode(
+  userId: string,
+): Promise<Parameters<typeof noteWrittenTouches>[0][]> {
+  return db
+    .select({
+      id: Notes.id,
+      title: Notes.title,
+      createdAt: Notes.createdAt,
+      noteType: Notes.noteType,
+      addedBy: Notes.addedBy,
+      threadId: Notes.threadId,
+      primaryCollection: Notes.primaryCollection,
+    })
+    .from(Notes)
+    .leftJoin(
+      UserNodeStates,
+      and(
+        eq(UserNodeStates.userId, Notes.userId),
+        eq(UserNodeStates.nodeKey, sql`'note:' || ${Notes.id}`),
+      ),
+    )
+    .where(and(eq(Notes.userId, userId), sql`${UserNodeStates.nodeKey} IS NULL`));
+}
+
+export function noteWrittenTouches(
+  note: {
+    id: string;
+    title: string | null;
+    createdAt: Date | null;
+    noteType: string;
+    addedBy: string | null;
+    threadId: string;
+    primaryCollection: string | null;
+  },
+  now: Date,
+): NodeTouch[] {
+  // A scripture child note is the app's text. `computeAndStoreNoteFingerprint` refuses to weigh
+  // one for the same reason, so these would fail the meaning floor anyway — but a node labelled
+  // "You wrote this" about a pasted passage is wrong whether or not anything reads it.
+  if (note.noteType === 'scripture') return [];
+  // Installed, shared and seeded content. `Notes.addedBy` defaults to 'user', so first-party
+  // create, update, offline sync and web import all keep the touch — a web import *is* the
+  // reader's own writing.
+  if ((note.addedBy ?? 'user') !== 'user') return [];
+  // Onboarding threads and the Welcome folder, on the same terms as every other usage count.
+  if (!isCountableUserNote(note)) return [];
+
+  const at = note.createdAt && note.createdAt.getTime() <= now.getTime() ? note.createdAt : now;
+  return [
+    noteTouch({ noteId: note.id, title: note.title, signal: 'exposure', at, sourceLabel: NOTE_WRITTEN_SOURCE }),
+  ];
+}
 
 export function noteTouch(input: {
   noteId: string;

--- a/spa/src/pages/prototype/proto-review-copy.ts
+++ b/spa/src/pages/prototype/proto-review-copy.ts
@@ -81,11 +81,15 @@ export const REVIEW_EMPTY_COPY = 'Nothing waiting. Keep studying.';
  *
  * The nothing-yet one says where reviews come from, because a new reader looking at an empty
  * feature has no way to know it is fed by their own study rather than by a button they missed.
+ *
+ * It says only that. It used to add "Mark a verse or write a note, and they start showing up
+ * here", which pushed the block to four lines and, sat above a date, read as a list of chores
+ * standing between the reader and the thing they were promised. One sentence for where reviews
+ * come from and one for when, and the pair fits in two lines.
  */
 export const REVIEW_EMPTY_UP_TO_DATE_TITLE = 'You are up to date';
 export const REVIEW_EMPTY_NOTHING_YET_TITLE = 'Nothing to review yet';
-export const REVIEW_EMPTY_NOTHING_YET_BODY =
-  'Reviews come from your own study. Mark a verse or write a note, and they start showing up here.';
+export const REVIEW_EMPTY_NOTHING_YET_BODY = 'Reviews come from your own study.';
 export const REVIEW_EMPTY_SETTLED_BODY = 'Nothing waiting right now.';
 export const reviewNextDueCopy = (when: string) => `The next one comes back ${when}.`;
 

--- a/src/utils/__tests__/review-opportunity-scoring.test.ts
+++ b/src/utils/__tests__/review-opportunity-scoring.test.ts
@@ -3,6 +3,7 @@ import {
   ENGINE_PER_KIND_CAP,
   NOTE_MEANING_WEIGHT_FLOOR,
   ENGINE_MIN_CHAPTER_AGE_DAYS,
+  ENGINE_MIN_NODE_AGE_DAYS,
   ENGINE_NODE_KINDS,
   countCommittedSignals,
   engineDailyRoom,
@@ -18,6 +19,7 @@ import { nodeKey } from '@/utils/study-bible-nodes';
 
 const NOW = new Date('2026-09-01T12:00:00Z');
 const daysAgo = (days: number) => new Date(NOW.getTime() - days * 24 * 60 * 60 * 1000);
+const daysFromNow = (days: number) => new Date(NOW.getTime() + days * 24 * 60 * 60 * 1000);
 
 function node(overrides: Partial<ReviewCandidateNode> & Pick<ReviewCandidateNode, 'nodeKind' | 'nodeKey'>): ReviewCandidateNode {
   return {
@@ -225,10 +227,15 @@ describe('nodeReadiness', () => {
       explicitConnectionCount: 0,
       synthesisCount: 0,
     });
-    expect(nodeReadiness(seenALot, NOW, 0.5)).toBe('too-few-signals');
-    // Two opens plus one deliberate act is two distinct signals, which is enough.
+    /*
+     * Nine opens is still one signal, and that is the idea this case was written for. It no
+     * longer decides the note's readiness — a substantial note is ready on the strength of having
+     * been written — so the claim is asserted where it is still load-bearing: `intentScore` reads
+     * these counters to rank one ready note above another.
+     */
+    expect(countCommittedSignals(seenALot)).toBe(1);
     expect(
-      nodeReadiness(
+      countCommittedSignals(
         node({
           nodeKind: 'note',
           nodeKey: 'note:n1',
@@ -238,10 +245,8 @@ describe('nodeReadiness', () => {
           revisitCount: 0,
           expansionCount: 1,
         }),
-        NOW,
-        0.5,
       ),
-    ).toBe('ready');
+    ).toBe(2);
   });
 
   it('reads exposure differently for a passage than for a note', () => {
@@ -307,7 +312,15 @@ describe('nodeReadiness', () => {
       reviewCount: 9,
     });
     expect(countCommittedSignals(reviewed)).toBe(0);
-    expect(nodeReadiness(reviewed, NOW, 0.5)).toBe('too-few-signals');
+    /*
+     * Readiness is no longer where this is caught for a note — a substantial one is ready on the
+     * strength of having been written. A note already on a schedule is kept out by `scoreNode`'s
+     * `nextReviewAt` check and by `existingSourceKeys`, which is the right place for it: having
+     * answered a question is a reason not to ask it *again yet*, not a reason to decide the study
+     * was never worth asking about.
+     */
+    expect(nodeReadiness(reviewed, NOW, 0.5)).toBe('ready');
+    expect(scoreNode({ ...reviewed, nextReviewAt: daysFromNow(4) }, NOW)).toBe(0);
   });
 
   it('holds a note to the meaning floor, and a verse to none', () => {
@@ -318,6 +331,52 @@ describe('nodeReadiness', () => {
     expect(nodeReadiness(thin, NOW, null)).toBe('too-thin');
     // A verse has no fingerprint and needs none: citing it is the deliberate act.
     expect(nodeReadiness(verse('v', ready), NOW, null)).toBe('ready');
+  });
+
+  it('asks about a note you wrote and never went back to', () => {
+    /*
+     * The case the whole note rule exists for. One `exposure` and nothing else is what the save
+     * path writes when someone writes a note and leaves it — no revisit, no link, no tag. Under
+     * the old two-signal rule that was zero signals and the note was unaskable forever, which on
+     * a real account made 30 of 31 substantial notes invisible to Review.
+     *
+     * Never returning to something is not evidence you would rather forget what is in it.
+     */
+    const written = noteNode('n', {
+      firstStudiedAt: daysAgo(30),
+      exposureCount: 1,
+      revisitCount: 0,
+      expansionCount: 0,
+      explicitConnectionCount: 0,
+      synthesisCount: 0,
+      manualTagCount: 0,
+    });
+    expect(countCommittedSignals(written)).toBe(0);
+    expect(nodeReadiness(written, NOW, NOTE_MEANING_WEIGHT_FLOOR)).toBe('ready');
+
+    // The floor is the whole test, so it still turns a jotting away.
+    expect(nodeReadiness(written, NOW, 0.19)).toBe('too-thin');
+    expect(nodeReadiness(written, NOW, null)).toBe('too-thin');
+
+    // And the age gate still holds — nothing written today is asked about today.
+    expect(nodeReadiness({ ...written, firstStudiedAt: daysAgo(2) }, NOW, 0.5)).toBe('too-new');
+  });
+
+  it('widens notes and nothing else', () => {
+    /*
+     * The regression this change could have caused. Dropping the signals gate for notes must not
+     * drop it for the two kinds whose nodes are created by contact rather than by authorship —
+     * one glance at a chapter is not study, however many times it is repeated.
+     */
+    const once = { firstStudiedAt: daysAgo(30), exposureCount: 1, revisitCount: 0 };
+    expect(nodeReadiness(verse('v', once), NOW, null)).toBe('too-few-signals');
+    expect(
+      nodeReadiness(
+        node({ nodeKind: 'chapter', nodeKey: nodeKey.chapter({ book: 'John', chapter: 3 }), ...once, exposureCount: 50 }),
+        NOW,
+        null,
+      ),
+    ).toBe('too-few-signals');
   });
 });
 
@@ -357,16 +416,24 @@ describe('a tag the reader applied by hand', () => {
     expect(countCommittedSignals({ ...filed, manualTagCount: 0 })).toBe(0);
   });
 
-  it('can be the signal that makes a note ready, alongside one other', () => {
+  it('is still counted, though a note no longer needs it to be ready', () => {
+    /*
+     * This used to be the case that made a note ready — two signals, one of them the filing.
+     * Readiness for a note is the meaning floor alone now, so the tag decides nothing here. The
+     * count is still true and still feeds `intentScore`, which is what ranks one ready note above
+     * another, so it is asserted on its own terms rather than deleted.
+     */
     const opened = noteNode('n', {
       firstStudiedAt: daysAgo(30),
       exposureCount: 2,
       revisitCount: 0,
       manualTagCount: 0,
     });
-    // A real meaning weight, since the thinness gate is a separate question from this one.
-    expect(nodeReadiness(opened, NOW, 0.6)).toBe('too-few-signals');
-    expect(nodeReadiness({ ...opened, manualTagCount: 2 }, NOW, 0.6)).toBe('ready');
+    expect(nodeReadiness(opened, NOW, 0.6)).toBe('ready');
+    expect(countCommittedSignals(opened)).toBe(1);
+    expect(countCommittedSignals({ ...opened, manualTagCount: 2 })).toBe(2);
+    // And the floor is still the thing that can turn a note away.
+    expect(nodeReadiness({ ...opened, manualTagCount: 2 }, NOW, 0.1)).toBe('too-thin');
   });
 
   it('says nothing about a passage, which has no tags of its own', () => {
@@ -575,5 +642,35 @@ describe('describeEngineColdStart', () => {
     const five = ['a', 'b', 'c', 'd', 'e'].map(readyVerse);
     expect(engineHasEnoughReady(five, NOW, new Map())).toBe(true);
     expect(describeEngineColdStart(five, NOW, new Map()).ready).toBeGreaterThanOrEqual(5);
+  });
+
+  it('counts written notes, matching the gate it describes', () => {
+    /*
+     * The same parity claim as the chapter case above, for the kind that just changed. These two
+     * functions have to agree about what a ready node is; when they drifted this morning the
+     * estimate described a gate that was not the one running, and Review left Home entirely.
+     *
+     * Five notes written and never returned to — nothing but the write touch on any of them.
+     */
+    const written = ['a', 'b', 'c', 'd', 'e'].map((k) =>
+      noteNode(k, { exposureCount: 1, revisitCount: 0, firstStudiedAt: daysAgo(30) }),
+    );
+    const weights = new Map(written.map((n) => [n.noteId!, 0.5]));
+    expect(describeEngineColdStart(written, NOW, weights).ready).toBe(5);
+    expect(engineHasEnoughReady(written, NOW, weights)).toBe(true);
+  });
+
+  it('dates a written note that is only too new, and promises nothing for a thin one', () => {
+    const young = ['a', 'b', 'c', 'd', 'e'].map((k) =>
+      noteNode(k, { exposureCount: 1, revisitCount: 0, firstStudiedAt: daysAgo(0) }),
+    );
+    const substantial = new Map(young.map((n) => [n.noteId!, 0.5]));
+    expect(describeEngineColdStart(young, NOW, substantial).opensAt!.getTime()).toBe(
+      daysAgo(0).getTime() + ENGINE_MIN_NODE_AGE_DAYS * 24 * 60 * 60 * 1000,
+    );
+
+    // Thin notes never qualify by waiting, so no date is the honest answer.
+    const thin = new Map(young.map((n) => [n.noteId!, 0.1]));
+    expect(describeEngineColdStart(young, NOW, thin).opensAt).toBeNull();
   });
 });

--- a/src/utils/review-opportunity-scoring.ts
+++ b/src/utils/review-opportunity-scoring.ts
@@ -173,12 +173,24 @@ export const ENGINE_MIN_COMMITTED_SIGNALS = 2;
 export const ENGINE_COLD_START_MIN_READY = 5;
 
 /**
- * The `meaningWeight` a note must clear.
+ * The `meaningWeight` a note must clear — and, since the signals gate stopped applying to notes,
+ * the whole of what Review asks of one.
  *
  * From `computeMeaningWeight`: a 200-character body is 0.10, one cited passage 0.05, one
  * highlight 0.067, and each of pinned / deliberately filed / linked is 0.125. So 0.2 is roughly
- * "a real paragraph plus one deliberate act", and it excludes the two things that made the
- * queue feel arbitrary — a note holding a single scripture pill, and a two-line jotting.
+ * "a real paragraph, or a short one that was also done something with", and it excludes the two
+ * things that made the queue feel arbitrary — a note holding a single scripture pill, and a
+ * two-line jotting.
+ *
+ * **It stays at 0.2 now that it stands alone, and raising it would not be a smaller widening —
+ * it would be a widening plus a narrowing.** A note with two committed signals and a weight of
+ * 0.25 is askable today; at 0.3 it becomes `too-thin` and stops being offered. On the account
+ * this was measured against that is 5 of 31 notes. Shipping a fix for "I have nothing in Review"
+ * that simultaneously retires notes which already qualified is the wrong trade.
+ *
+ * What makes one number safe is that `meaningWeight ?? 0` fails closed: a note with no
+ * fingerprint row scores zero, and `computeAndStoreNoteFingerprint` writes none for a
+ * `noteType === 'scripture'` note, so generated passage notes can never clear it.
  *
  * Notes only. A verse has no fingerprint and needs none: citing it *is* the deliberate act.
  */
@@ -250,8 +262,15 @@ function countCommittedSignalsForNote(node: ReviewCandidateNode): number {
     // Opening a note twice is a signal; opening it thirty times is still one.
     signals += 1;
   }
-  // Filing a note under a tag by hand is a deliberate act about *this* note. One signal however
-  // many tags: the decision was to file it, not how many drawers.
+  /*
+   * Filing a note under a tag by hand is a deliberate act about *this* note. One signal however
+   * many tags: the decision was to file it, not how many drawers.
+   *
+   * `nodeReadiness` no longer consults this for notes — writing one is itself the deliberate act
+   * and the meaning floor is the gate. Kept because it is a true measure of intent and this
+   * function is exported on its own, and because putting the two-signal rule back on notes is a
+   * decision someone should have to make on purpose rather than by restoring a line.
+   */
   if (node.nodeKind === 'note' && (node.manualTagCount ?? 0) > 0) signals += 1;
   return signals;
 }
@@ -273,10 +292,28 @@ export function nodeReadiness(
   const minAge =
     node.nodeKind === 'chapter' ? ENGINE_MIN_CHAPTER_AGE_DAYS : ENGINE_MIN_NODE_AGE_DAYS;
   if (daysBetween(node.firstStudiedAt, now) < minAge) return 'too-new';
-  if (countCommittedSignals(node, context) < ENGINE_MIN_COMMITTED_SIGNALS) return 'too-few-signals';
-  if (node.nodeKind === 'note' && (meaningWeight ?? 0) < NOTE_MEANING_WEIGHT_FLOOR) {
-    return 'too-thin';
+
+  /*
+   * For a note the meaning floor *is* the gate, and the signal count does not apply.
+   *
+   * The signals gate asks "has the reader done something with this beyond seeing it?" — which is
+   * the right question for a verse or a chapter, where the node is created by contact. A note is
+   * not created by contact. Someone sat down and wrote it, and no counter in this file can
+   * observe an act more deliberate than that.
+   *
+   * Requiring a *second* act on top of it said that writing something does not count until you
+   * come back to it, and the effect was not subtle: on a real account, 31 notes cleared the
+   * floor and one was ever askable. Never returning to a note is not evidence you would rather
+   * forget what is in it.
+   *
+   * The age gate above still applies, and it is the one doing the work the cold start cares
+   * about — nothing written today is asked about today, however substantial it is.
+   */
+  if (node.nodeKind === 'note') {
+    return (meaningWeight ?? 0) < NOTE_MEANING_WEIGHT_FLOOR ? 'too-thin' : 'ready';
   }
+
+  if (countCommittedSignals(node, context) < ENGINE_MIN_COMMITTED_SIGNALS) return 'too-few-signals';
   return 'ready';
 }
 


### PR DESCRIPTION
## The problem

Review drew on almost nothing for accounts full of writing. Measured against the live database for one account with 44 notes:

```
substantial notes (meaningWeight >= 0.2):   31
  ...of those, older than the 3-day gate:   31
  ...of those, present as a note node:       1
```

Thirty notes someone had written were not ranked low. They were **absent**, and no amount of tuning downstream could have found them.

Two independent gates produced that, and both are changed here.

**A note only became a node if it cited scripture.** The one place a save recorded a `note:` node sat behind `if (!passages.length) return;`. Writing prose and leaving it produced nothing, ever.

**Readiness required two committed signals, which writing alone can never supply.** `countCommittedSignalsForNote` gives one point for `exposureCount >= 2` against a minimum of 2, so a note written and not returned to was `too-few-signals` permanently.

The product owner's direction on the second one:

> there is still a difference between suggestions and reviews as just because i never returned to something doesnt mean I want to not remember what's in my study

## The change

- The note is recorded on **every** save, through `noteWrittenTouches` — the same builder the backfill has always used, so a replay and a live save now agree rather than merely claiming to.
- For a note, the meaning floor is the whole readiness test. Verses and chapters keep their signals gate untouched, and the age gate still holds for everything: nothing written today is asked about today.
- **A pure widening.** The old rule required the floor *and* two signals, so every note that was ready before is still ready.

### Two things caught in review that would have shipped wrong

**Installed content claiming to be yours.** Discover installs (`addedBy: 'discover'`) and shared-space imports (`'shared'`) run the same enrichment pass as a real save, so without an exclusion a twenty-note install wrote twenty nodes labelled "You wrote this" about someone else's study. `countableUserNotesWhere()` only filters `'system'`, so the existing full backfill had the same hole — it now shares the builder.

**Dating the touch at `now` would have corrupted the reason line.** `lastSourceLabel` only moves when `lastSourceAt` moves forward, and `/api/notes/update` fires "You added to this" at `now` on the same request. The two would race and the row's reason would come out nondeterministically wrong on every edit. Touches are dated at `createdAt`, which also means `firstStudiedAt` (folded with `LEAST`) puts an old note past the age gate rather than three days in front of it.

## Backfill

`npm run study-bible:notes` — missing-only, so it is idempotent by construction rather than by care: it writes only for notes with no node, so a second run finds nothing and cannot double-count. Deliberately **not** `backfill-study-bible-layer --reset`, which deletes the account's rows and takes accumulated counters and the review mirrors with them.

## Verified

Against the live database, on the affected account:

```
before   chapter {too-new:1, too-few-signals:7, ready:3}
         note    {too-new:3}
         cold start passed: false

after    chapter {too-new:1, too-few-signals:7, ready:3}
         note    {too-new:3, ready:30, too-thin:11}
         cold start passed: true
         would add: chapter Exodus 11 | chapter Exodus 12 | note "Giving 10%"
```

Backfill re-run finds 0 (idempotent). Rows carry `lastSourceLabel: 'You wrote this'` with `firstStudiedAt` backdated to January, not today.

The live save path was exercised end-to-end on throwaway notes belonging to no real account, then cleaned up:

```
addedBy=discover   nodes=0
addedBy=shared     nodes=0
addedBy=user       nodes=1 (You wrote this)
```

5887 tests, typecheck ratchet 125, auth-gated-queries, `perf:check` 1149.9 KB.

## Also here

- The empty Review state is trimmed to two lines, per request.
- `tmp-engine-preview.ts` was `tmp-`-prefixed but committed to main and defaulted to a hardcoded account id. Promoted to `preview-review-engine.ts` with `--user` required — that default is how a day of debugging went in the wrong direction, since dev and live Clerk mint different ids against the same database.
- `package.json` had been left on 3.8.0 although 3.9.0 shipped; a PR merge resolved the file in favour of the lower number. Corrected forward to 3.9.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)