### PR TITLE
fix(review): stop the engine piling up study you have not answered

### DIFF
--- a/Changelog/3.9.2.md
+++ b/Changelog/3.9.2.md
@@ -1,0 +1,8 @@
+# Version 3.9.2
+
+**Release Date**: September 7, 2026
+
+## Fixes
+
+- Stop the engine piling up study you have not answered
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.8.0
+**Version:** 3.9.2
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-8-0';
+const CACHE_NAME = 'harvous-cache-v3-9-2';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/release-notes/2026-09-07.md
+++ b/release-notes/2026-09-07.md
@@ -1,7 +1,7 @@
 # What's New in Harvous — September 7, 2026
 
 **Release Date:** September 7, 2026
-**Versions:** v3.6.1–v3.9.1
+**Versions:** v3.6.1–v3.9.2
 
 Review now draws on the notes you have written, which is what it was always meant to do. Home arrives as one page instead of filling in around you, the daily sample for free accounts is finally daily, and live sync between your devices is talking again.
 
@@ -30,6 +30,16 @@ Review now draws on the notes you have written, which is what it was always mean
 **How it helps you:**
 - Review is about your study rather than about the parts of it that happened to quote a verse.
 - Not having gone back to something is not a reason to let it go. Often it is the reason to be asked.
+
+### Review will not let a pile build up behind you
+
+**What changed:**
+- Review adds a few questions a day from your own study. It had no limit on how many could sit there unanswered, so leaving it alone for a month meant a queue quietly growing to a size nobody would want to be handed.
+- It now stops adding once enough is waiting, and starts again as soon as you have worked through some of it.
+- Questions you set yourself are not counted, and neither is anything not due yet.
+
+**How it helps you:**
+- Coming back after a while away means a handful of questions rather than a backlog.
 
 ### Review says what it is waiting for
 

--- a/server/utils/__tests__/review-engine-backlog-cap.test.ts
+++ b/server/utils/__tests__/review-engine-backlog-cap.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  REVIEW_ENGINE_DAILY_CAP,
+  REVIEW_ENGINE_MAX_OUTSTANDING,
+  REVIEW_INBOX_MAX_ROWS,
+} from '@/utils/review-item-kinds';
+
+/**
+ * The ceiling on how much unanswered study the engine will let accumulate.
+ *
+ * `refillReviewQueue` runs one query against a real table, so the shape of the guard is what is
+ * readable here — in the style of study-bible-layer.test.ts next door. The constant itself is
+ * pure and is checked directly.
+ */
+const repoRoot = join(__dirname, '..', '..', '..');
+const refill = readFileSync(join(repoRoot, 'server/utils/review-opportunities.ts'), 'utf8');
+
+describe('the backlog ceiling', () => {
+  it('leaves room for several sittings before it ever trips', () => {
+    // Low enough to matter, high enough that skipping a day or two cannot reach it.
+    expect(REVIEW_ENGINE_MAX_OUTSTANDING).toBe(REVIEW_INBOX_MAX_ROWS * 4);
+    expect(REVIEW_ENGINE_MAX_OUTSTANDING).toBeGreaterThan(REVIEW_ENGINE_DAILY_CAP);
+  });
+
+  it('stops the refill rather than shrinking it', () => {
+    /*
+     * Half a batch on top of a backlog is still a backlog. Returning early also means the block
+     * clears itself the moment the reader answers a few, with no state to reset.
+     */
+    expect(refill).toContain('if (outstanding.length >= REVIEW_ENGINE_MAX_OUTSTANDING) return [];');
+  });
+
+  it('counts only what is due, and only what the engine added', () => {
+    const guard = refill.slice(refill.indexOf('const [recent, outstanding]'), refill.indexOf('const room ='));
+    // Due: something scheduled for next week is not owed yet and must not hold the queue.
+    expect(guard).toContain('lte(ReviewItems.dueAt, now)');
+    // Active: an item the reader paused or archived is one they put down, not one they owe.
+    expect(guard).toContain("eq(ReviewItems.status, 'active')");
+    // Engine-added: items the reader added by hand are theirs to stack up as high as they like.
+    expect(guard).toContain("eq(ReviewItems.origin, 'engine')");
+    // Bounded read — the count is only ever compared against the ceiling.
+    expect(guard).toContain('.limit(REVIEW_ENGINE_MAX_OUTSTANDING)');
+  });
+
+  it('costs no extra round trip', () => {
+    // Asked alongside the daily-cap query rather than before it, on a path that runs inline on
+    // /api/review/inbox — which was cut from 2094ms to ~1000ms and should stay there.
+    expect(refill).toContain('const [recent, outstanding] = await Promise.all([');
+  });
+});

--- a/server/utils/review-opportunities.ts
+++ b/server/utils/review-opportunities.ts
@@ -16,13 +16,14 @@
  * query around it.
  */
 
-import { db, UserNodeStates, ReviewItems, NoteTags, StudyThreadEntries, sql, eq, and, gt, desc, inArray, isNull,
+import { db, UserNodeStates, ReviewItems, NoteTags, StudyThreadEntries, sql, eq, and, gt, lte, desc, inArray, isNull,
   NoteFingerprints,
 } from '../db';
 import { isNoteFingerprintsTableMissing } from './pg-undefined-relation';
 import {
   REVIEW_ENGINE_DAILY_CAP,
   REVIEW_ENGINE_WINDOW_HOURS,
+  REVIEW_ENGINE_MAX_OUTSTANDING,
   type ReviewAskableKind,
 } from '@/utils/review-item-kinds';
 import {
@@ -244,20 +245,58 @@ export async function refillReviewQueue(
   try {
     const windowStart = new Date(now.getTime() - REVIEW_ENGINE_WINDOW_HOURS * 60 * 60 * 1000);
 
-    const recent = await db
-      .select({ id: ReviewItems.id })
-      .from(ReviewItems)
-      .where(
-        and(
-          eq(ReviewItems.userId, userId),
-          eq(ReviewItems.origin, 'engine'),
-          gt(ReviewItems.createdAt, windowStart),
-        ),
-      )
-      .limit(REVIEW_ENGINE_DAILY_CAP + 1);
+    /*
+     * Two questions, one round trip: how many were added today, and how many are still waiting.
+     */
+    const [recent, outstanding] = await Promise.all([
+      db
+        .select({ id: ReviewItems.id })
+        .from(ReviewItems)
+        .where(
+          and(
+            eq(ReviewItems.userId, userId),
+            eq(ReviewItems.origin, 'engine'),
+            gt(ReviewItems.createdAt, windowStart),
+          ),
+        )
+        .limit(REVIEW_ENGINE_DAILY_CAP + 1),
+      /*
+       * How much the reader already owes.
+       *
+       * The daily cap limits how fast the queue grows, not how large it gets. Three a day with
+       * nothing answered is ninety in a month, and the inbox only ever shows three — so the pile
+       * is invisible right up until something surfaces the count and the reader is told they are
+       * ninety behind. That is the number `review-item-kinds.ts` calls "a debt, not a practice".
+       *
+       * This was academic while the engine could barely find anything to ask about. Notes are in
+       * scope now, and an account with a few hundred of them can hit the cap every single day, so
+       * the ceiling has to be a real one.
+       *
+       * Counts only what is *due*: something scheduled for next week is not owed yet, and holding
+       * back because of it would stop the queue for a debt the reader does not have.
+       */
+      db
+        .select({ id: ReviewItems.id })
+        .from(ReviewItems)
+        .where(
+          and(
+            eq(ReviewItems.userId, userId),
+            eq(ReviewItems.origin, 'engine'),
+            eq(ReviewItems.status, 'active'),
+            lte(ReviewItems.dueAt, now),
+          ),
+        )
+        .limit(REVIEW_ENGINE_MAX_OUTSTANDING),
+    ]);
 
     const room = engineDailyRoom(recent.length);
     if (room <= 0) return [];
+    /*
+     * Stop adding, rather than adding less. Half a batch on top of a backlog is still a backlog,
+     * and the way out is answering some — which clears the block on its own, with no state to
+     * reset and nothing for the reader to dismiss.
+     */
+    if (outstanding.length >= REVIEW_ENGINE_MAX_OUTSTANDING) return [];
 
     const [engine, existing] = await Promise.all([
       loadEngineCandidates(userId),

--- a/src/utils/review-item-kinds.ts
+++ b/src/utils/review-item-kinds.ts
@@ -294,3 +294,19 @@ export const REVIEW_SESSION_CAP = 10;
  */
 export const REVIEW_ENGINE_DAILY_CAP = 3;
 export const REVIEW_ENGINE_WINDOW_HOURS = 24;
+
+/**
+ * How much unanswered study the engine will let pile up before it stops offering more.
+ *
+ * `REVIEW_ENGINE_DAILY_CAP` limits how fast the queue grows; nothing limited how big it got.
+ * Three a day, none of them answered, is ninety in a month — and because the inbox shows three,
+ * the pile stays invisible until something names the count and the reader is told they are ninety
+ * behind. This file already argues that a number like that is a debt rather than a practice.
+ *
+ * Twelve, which is four sittings' worth at `REVIEW_INBOX_MAX_ROWS`. Enough that a normal week of
+ * skipping a day does not trip it, low enough that nobody meets a wall of their own study.
+ *
+ * It is a pause, not a penalty: answering a few drops the count back under and the engine resumes
+ * on its own. Only *due* items count, so something scheduled for next week never holds it.
+ */
+export const REVIEW_ENGINE_MAX_OUTSTANDING = REVIEW_INBOX_MAX_ROWS * 4;


### PR DESCRIPTION
Follow-up to #100, which put notes in scope for the engine and made this reachable.

## The gap

`refillReviewQueue` caps *additions* at `REVIEW_ENGINE_DAILY_CAP` (3) per rolling day. Nothing capped the **total**. Three a day with none answered is ninety in a month, and since the inbox only ever shows three, the pile is invisible until something surfaces the count — at which point the reader is told they are ninety behind. `review-item-kinds.ts` already argues that a number like that reads as a debt rather than a practice; this arrives at the same failure from the other direction.

Academic while the engine could barely find anything to ask about. Notes are in scope now, so an account with a few hundred of them can hit the cap every single day.

## The change

`REVIEW_ENGINE_MAX_OUTSTANDING = REVIEW_INBOX_MAX_ROWS * 4` — twelve, four sittings' worth. High enough that skipping a day or two cannot trip it, low enough that nobody meets a wall of their own study.

- **Stops the refill rather than shrinking it.** Half a batch on top of a backlog is still a backlog.
- **A pause, not a penalty.** Answering a few drops the count back under and the engine resumes on its own — no state to reset, nothing for the reader to dismiss.
- **Counts only what is genuinely owed:** due (something scheduled for next week is not owed yet), `active` (a paused item is one the reader put down), and `origin: 'engine'` (items added by hand are theirs to stack as high as they like).
- **Costs no extra round trip.** Asked alongside the existing daily-cap query in one `Promise.all`, on a path that runs inline on `/api/review/inbox` — which was cut from 2094ms to ~1000ms earlier today and should stay there. The read is `.limit`ed to the ceiling, since the count is only ever compared against it.

5891 tests, typecheck ratchet 125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)