### PR TITLE
fix(design): paper-stack parked layer honors dark mode

### DIFF
--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -20051,7 +20051,7 @@ html.harvous-prototype-route button[class*="proto-"].proto-settings-danger__btn:
   .proto-editor-paper,
 .pds-paper-stack__sheet[data-stacked='false'] .proto-editor-paper,
 .pds-paper-stack__sheet[data-stacked='false'] .pds-reader__column {
-  background-color: #fff;
+  background-color: var(--pds-bg-page);
   background-image: none;
 }
 


### PR DESCRIPTION
## Summary
- The parked/behind paper in the note-reader paper-stack (`.pds-paper-stack__base`/`.pds-paper-stack__sheet[data-stacked='false']`) was hardcoded to `background-color: #fff`, so it stayed white even when the app is in dark mode.
- Swapped it to the dark-aware `var(--pds-bg-page)` token, which already carries the correct light (`#fff`-equivalent) and dark (`18% 0.01 285`) values.

## Test plan
- [x] Verified in `/__dev/design-system?scene=ds-15-paper-stack` with dark color scheme emulated: the parked paper now renders dark instead of white, both at rest and after flipping the sheet.
- [x] No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)