### PR TITLE
fix: stop issue signals from filling with Discover 500s and browser noise

### DIFF
--- a/public/scripts/pwa-startup.js
+++ b/public/scripts/pwa-startup.js
@@ -18,9 +18,13 @@ function warmUpApp() {
   if (isWarmedUp) return;
   isWarmedUp = true;
   
-  // Signal service worker to warm up
-  if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
-    navigator.serviceWorker.controller.postMessage('warmup');
+  // Signal service worker to warm up. Safari private browsing throws on the getter.
+  try {
+    if (navigator.serviceWorker && navigator.serviceWorker.controller) {
+      navigator.serviceWorker.controller.postMessage('warmup');
+    }
+  } catch (_) {
+    /* insecure context / private browsing */
   }
   
   // Prefetch low-priority routes when idle

--- a/public/scripts/service-worker-manager.js
+++ b/public/scripts/service-worker-manager.js
@@ -1,7 +1,15 @@
 // Register the service worker for PWA support
 // Deferred to avoid blocking initial render - runs after page is interactive
 (function() {
-  if ('serviceWorker' in navigator) {
+  // Safari private browsing throws SecurityError on the getter itself — `'serviceWorker' in
+  // navigator` is still true. Capture once and bail if the browser will not hand it over.
+  var serviceWorker = null;
+  try {
+    serviceWorker = navigator.serviceWorker || null;
+  } catch (_) {
+    serviceWorker = null;
+  }
+  if (serviceWorker) {
     // Store registration reference for update checks
     let registrationRef = null;
     let reloadingForUpdate = false; // Prevent infinite reload loops
@@ -119,7 +127,7 @@
 
     // Set up controller change listener once
     // Only reload if this isn't a fresh page load (performance.navigation.type check)
-    navigator.serviceWorker.addEventListener('controllerchange', async () => {
+    serviceWorker.addEventListener('controllerchange', async () => {
       if (reloadingForUpdate) {
         return; // Already reloading
       }
@@ -202,7 +210,7 @@
       if (registration.installing) {
         const installingWorker = registration.installing;
         installingWorker.addEventListener('statechange', () => {
-          if (installingWorker.state === 'installed' && navigator.serviceWorker.controller) {
+          if (installingWorker.state === 'installed' && serviceWorker.controller) {
             // New service worker installed, send skipWaiting
             installingWorker.postMessage({ type: 'SKIP_WAITING' });
           }
@@ -230,7 +238,7 @@
         runFetchAndActivateWorker(registrationRef);
         return;
       }
-      navigator.serviceWorker
+      serviceWorker
         .getRegistration()
         .then(function (reg) {
           if (reg) runFetchAndActivateWorker(reg);
@@ -242,7 +250,7 @@
 
     // Register service worker asynchronously after page load to avoid blocking render
     const registerServiceWorker = () => {
-      navigator.serviceWorker.register('/sw.js')
+      serviceWorker.register('/sw.js')
         .then(registration => {
           registrationRef = registration;
 
@@ -257,7 +265,7 @@
             const newWorker = registration.installing;
             if (newWorker) {
               newWorker.addEventListener('statechange', () => {
-                if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                if (newWorker.state === 'installed' && serviceWorker.controller) {
                   // New service worker available - activate it (controllerchange will handle reload)
                   newWorker.postMessage({ type: 'SKIP_WAITING' });
                 }
@@ -352,16 +360,16 @@
       }
 
       // …and one warmup ping (the SW answers this with a single /api/health fetch).
-      if (navigator.serviceWorker.controller) {
-        navigator.serviceWorker.controller.postMessage('warmup');
+      if (serviceWorker.controller) {
+        serviceWorker.controller.postMessage('warmup');
       }
     });
 
     // Also warm up on initial load (deferred)
     const warmupOnLoad = () => {
       lastForegroundRefreshAt = Date.now();
-      if (navigator.serviceWorker.controller) {
-        navigator.serviceWorker.controller.postMessage('warmup');
+      if (serviceWorker.controller) {
+        serviceWorker.controller.postMessage('warmup');
       }
     };
     

--- a/public/sw.js
+++ b/public/sw.js
@@ -252,9 +252,12 @@ self.addEventListener('fetch', (event) => {
   if (url.pathname.startsWith('/assets/')) {
     event.respondWith(
       caches.match(event.request).then((cached) => {
-        if (cached) return cached;
+        if (cached && !isMistypedAssetResponse(event.request, cached)) return cached;
 
         return fetch(event.request).then((response) => {
+          if (isMistypedAssetResponse(event.request, response)) {
+            return new Response('', { status: 404, statusText: 'Not found' });
+          }
           if (shouldCacheResponse(response, event.request)) {
             const timestamped = addCacheTimestamp(response.clone());
             const responseToCache = timestamped.clone();
@@ -267,9 +270,10 @@ self.addEventListener('fetch', (event) => {
         }).catch(() =>
           // `caches.match` resolves undefined on a miss, and respondWith(undefined) throws —
           // which would turn a transient network blip into a hard failure for this asset.
-          caches.match(event.request).then((fallback) =>
-            fallback || new Response('', { status: 504, statusText: 'Asset unavailable' })
-          )
+          caches.match(event.request).then((fallback) => {
+            if (fallback && !isMistypedAssetResponse(event.request, fallback)) return fallback;
+            return new Response('', { status: 504, statusText: 'Asset unavailable' });
+          })
         );
       })
     );

--- a/server/routes/__tests__/discover-routes.test.ts
+++ b/server/routes/__tests__/discover-routes.test.ts
@@ -66,6 +66,17 @@ describe('discover routes', () => {
     expect(body).not.toContain('serializeMine');
   });
 
+  it('treats a missing catalog table as empty, not a 500', () => {
+    // Same seam as Review: the tables land in db:push after the code, and the
+    // window between them must not surface as "A database error occurred" on Home.
+    const text = routes();
+    expect(text).toContain('isDiscoverTableMissing');
+    expect(text).toContain('respondDiscoverError');
+    for (const marker of PUBLIC_HANDLERS) {
+      expect(handlerBody(text, marker)).toContain('respondDiscoverError');
+    }
+  });
+
   it('never lets a public serializer emit review state or the submitter', () => {
     const text = routes();
     const start = text.indexOf('function serializePublic');
@@ -374,7 +385,8 @@ describe('discover routes', () => {
     expect(catches.length).toBeGreaterThan(0);
     for (const at of catches) {
       const block = text.slice(at, at + 400);
-      const reports = block.includes('handleAPIError(error, {');
+      const reports =
+        block.includes('handleAPIError(error, {') || block.includes('respondDiscoverError(');
       // The install's duplicate branch is the one catch that handles rather than
       // reports: a unique violation there is the expected answer, not a fault.
       const rethrows = block.includes('throw error');

--- a/server/routes/__tests__/push-routes.test.ts
+++ b/server/routes/__tests__/push-routes.test.ts
@@ -196,6 +196,17 @@ describe('service worker push handlers', () => {
     expect(sw()).toContain("credentials: 'include'");
   });
 
+  it('never serves HTML as a hashed JS or CSS asset', () => {
+    // A stale-while-revalidate miss used to return index.html for /assets/*.js, which
+    // the browser then refused as `'text/html' is not a valid JavaScript MIME type`.
+    const text = sw();
+    expect(text).toContain('isMistypedAssetResponse');
+    const assets = text.slice(text.indexOf("url.pathname.startsWith('/assets/')"));
+    expect(assets).toContain('isMistypedAssetResponse(event.request, cached)');
+    expect(assets).toContain('isMistypedAssetResponse(event.request, response)');
+    expect(assets).toContain('isMistypedAssetResponse(event.request, fallback)');
+  });
+
   it('caches the notification icons it renders with', () => {
     expect(sw()).toContain("'/images/icons/icon-192.png'");
     expect(sw()).toContain("'/images/icons/badge-96.png'");

--- a/server/routes/discover.ts
+++ b/server/routes/discover.ts
@@ -50,6 +50,7 @@ import {
 import { handleAPIError } from '@/utils/error-handling';
 import { rateLimit } from '@/utils/rate-limit';
 import { isUniqueViolationError } from '../utils/db-errors';
+import { isDiscoverTableMissing } from '../utils/pg-undefined-relation';
 import { requireHarvousAdmin, getHarvousSystemUserId } from '../utils/harvous-admin';
 import { DISCOVER_CATEGORIES, isDiscoverCategory } from '@/data/discover-categories';
 import { NOTE_TEMPLATE_DESCRIPTION_MAX_LENGTH } from '@/data/note-templates';
@@ -242,6 +243,25 @@ async function resolveAuthorDisplayName(userId: string): Promise<string> {
   return lastInitial ? `${firstName} ${lastInitial}.` : firstName;
 }
 
+/**
+ * An unmigrated database is an empty catalog, not a 500. Same seam as Review:
+ * deploy the code, then push the tables, and the window between them must not
+ * surface as "A database error occurred" on Home.
+ */
+function respondDiscoverError(
+  c: { json: (body: unknown, status?: number) => Response },
+  error: unknown,
+  context: { endpoint: string; action: string },
+  empty: unknown,
+  emptyStatus = 200,
+) {
+  if (isDiscoverTableMissing(error)) {
+    return c.json(empty, emptyStatus);
+  }
+  const standardError = handleAPIError(error, context);
+  return c.json({ error: standardError.message, code: standardError.code }, 500);
+}
+
 // ─── GET /api/discover/listings ─────────────────────────────────────────────
 /** The catalog. Anonymous; listed rows only. */
 app.get('/api/discover/listings', rateLimit('read'), async (c) => {
@@ -322,11 +342,12 @@ app.get('/api/discover/listings', rateLimit('read'), async (c) => {
       nextCursor,
     });
   } catch (error) {
-    const standardError = handleAPIError(error, {
-      endpoint: '/api/discover/listings',
-      action: 'discover_list',
-    });
-    return c.json({ error: standardError.message, code: standardError.code }, 500);
+    return respondDiscoverError(
+      c,
+      error,
+      { endpoint: '/api/discover/listings', action: 'discover_list' },
+      { listings: [], installedSlugs: [], nextCursor: null },
+    );
   }
 });
 
@@ -351,11 +372,13 @@ app.get('/api/discover/listings/:slug', rateLimit('read'), async (c) => {
     c.header('Cache-Control', 'private, max-age=0, no-store');
     return c.json({ listing: serializePublic(row) });
   } catch (error) {
-    const standardError = handleAPIError(error, {
-      endpoint: '/api/discover/listings/[slug]',
-      action: 'discover_detail',
-    });
-    return c.json({ error: standardError.message, code: standardError.code }, 500);
+    return respondDiscoverError(
+      c,
+      error,
+      { endpoint: '/api/discover/listings/[slug]', action: 'discover_detail' },
+      { error: 'Not found', code: 'LISTING_NOT_FOUND' },
+      404,
+    );
   }
 });
 
@@ -396,11 +419,12 @@ app.get('/api/discover/export', rateLimit('read'), async (c) => {
       { 'Cache-Control': 'public, max-age=300' },
     );
   } catch (error) {
-    const standardError = handleAPIError(error, {
-      endpoint: '/api/discover/export',
-      action: 'discover_export',
-    });
-    return c.json({ error: standardError.message, code: standardError.code }, 500);
+    return respondDiscoverError(
+      c,
+      error,
+      { endpoint: '/api/discover/export', action: 'discover_export' },
+      { categories: DISCOVER_CATEGORIES, listings: [] },
+    );
   }
 });
 
@@ -529,11 +553,13 @@ app.post('/api/discover/submit', requireAuth, rateLimit('write'), async (c) => {
 
     return c.json({ success: true, listing: serializeMine(row) });
   } catch (error) {
-    const standardError = handleAPIError(error, {
-      endpoint: '/api/discover/submit',
-      action: 'discover_submit',
-    });
-    return c.json({ error: standardError.message, code: standardError.code }, 500);
+    return respondDiscoverError(
+      c,
+      error,
+      { endpoint: '/api/discover/submit', action: 'discover_submit' },
+      { error: 'Discover is not available yet', code: 'NOT_READY' },
+      503,
+    );
   }
 });
 
@@ -550,11 +576,12 @@ app.get('/api/discover/mine', requireAuth, async (c) => {
       .limit(100);
     return c.json({ listings: rows.map(serializeMine) });
   } catch (error) {
-    const standardError = handleAPIError(error, {
-      endpoint: '/api/discover/mine',
-      action: 'discover_mine',
-    });
-    return c.json({ error: standardError.message, code: standardError.code }, 500);
+    return respondDiscoverError(
+      c,
+      error,
+      { endpoint: '/api/discover/mine', action: 'discover_mine' },
+      { listings: [] },
+    );
   }
 });
 
@@ -605,11 +632,13 @@ app.post('/api/discover/withdraw', requireAuth, rateLimit('write'), async (c) =>
 
     return c.json({ success: true, status: 'withdrawn' });
   } catch (error) {
-    const standardError = handleAPIError(error, {
-      endpoint: '/api/discover/withdraw',
-      action: 'discover_withdraw',
-    });
-    return c.json({ error: standardError.message, code: standardError.code }, 500);
+    return respondDiscoverError(
+      c,
+      error,
+      { endpoint: '/api/discover/withdraw', action: 'discover_withdraw' },
+      { error: 'Discover is not available yet', code: 'NOT_READY' },
+      503,
+    );
   }
 });
 
@@ -742,11 +771,13 @@ app.post('/api/discover/install', requireAuth, rateLimit('write'), async (c) => 
       warnings,
     });
   } catch (error) {
-    const standardError = handleAPIError(error, {
-      endpoint: '/api/discover/install',
-      action: 'discover_install',
-    });
-    return c.json({ error: standardError.message, code: standardError.code }, 500);
+    return respondDiscoverError(
+      c,
+      error,
+      { endpoint: '/api/discover/install', action: 'discover_install' },
+      { error: 'Discover is not available yet', code: 'NOT_READY' },
+      503,
+    );
   }
 });
 
@@ -774,11 +805,12 @@ app.get('/api/admin/discover/submissions', requireAuth, async (c) => {
 
     return c.json({ submissions: rows.map(serializeForReview), unreadCount: unread.length });
   } catch (error) {
-    const standardError = handleAPIError(error, {
-      endpoint: '/api/admin/discover/submissions',
-      action: 'discover_admin_list',
-    });
-    return c.json({ error: standardError.message, code: standardError.code }, 500);
+    return respondDiscoverError(
+      c,
+      error,
+      { endpoint: '/api/admin/discover/submissions', action: 'discover_admin_list' },
+      { submissions: [], unreadCount: 0 },
+    );
   }
 });
 
@@ -897,11 +929,13 @@ app.post('/api/admin/discover/review', requireAuth, rateLimit('write'), async (c
 
     return c.json({ success: true, status: 'listed' });
   } catch (error) {
-    const standardError = handleAPIError(error, {
-      endpoint: '/api/admin/discover/review',
-      action: 'discover_admin_review',
-    });
-    return c.json({ error: standardError.message, code: standardError.code }, 500);
+    return respondDiscoverError(
+      c,
+      error,
+      { endpoint: '/api/admin/discover/review', action: 'discover_admin_review' },
+      { error: 'Discover is not available yet', code: 'NOT_READY' },
+      503,
+    );
   }
 });
 
@@ -945,11 +979,13 @@ app.post('/api/admin/discover/delist', requireAuth, rateLimit('write'), async (c
 
     return c.json({ success: true, status: 'delisted' });
   } catch (error) {
-    const standardError = handleAPIError(error, {
-      endpoint: '/api/admin/discover/delist',
-      action: 'discover_admin_delist',
-    });
-    return c.json({ error: standardError.message, code: standardError.code }, 500);
+    return respondDiscoverError(
+      c,
+      error,
+      { endpoint: '/api/admin/discover/delist', action: 'discover_admin_delist' },
+      { error: 'Discover is not available yet', code: 'NOT_READY' },
+      503,
+    );
   }
 });
 
@@ -967,11 +1003,13 @@ app.post('/api/admin/discover/mark-read', requireAuth, async (c) => {
       );
     return c.json({ success: true });
   } catch (error) {
-    const standardError = handleAPIError(error, {
-      endpoint: '/api/admin/discover/mark-read',
-      action: 'discover_admin_mark_read',
-    });
-    return c.json({ error: standardError.message, code: standardError.code }, 500);
+    return respondDiscoverError(
+      c,
+      error,
+      { endpoint: '/api/admin/discover/mark-read', action: 'discover_admin_mark_read' },
+      { error: 'Discover is not available yet', code: 'NOT_READY' },
+      503,
+    );
   }
 });
 

--- a/server/utils/__tests__/diagnostics-sanitize.test.ts
+++ b/server/utils/__tests__/diagnostics-sanitize.test.ts
@@ -172,4 +172,29 @@ describe('sanitizeDiagnosticPayload', () => {
       }),
     ).toBeNull();
   });
+
+  it('drops leftover instrumentation, Clerk remounts, and insecure-context noise', () => {
+    // Old PWA builds keep posting these. Capture filters them too, but ingest is the
+    // backstop so they cannot keep filling the admin list after a deploy.
+    const noise = [
+      '[push-nav] client navigate path=/read/today via=visible-peek waitedMs=0',
+      '[push-nav] probe from setup',
+      "@clerk/clerk-react: You've added multiple <ClerkProvider> components in your React component tree. Wrap your components in a single <ClerkProvider>.",
+      'The operation is insecure.',
+      'WebSocket not available: The operation is insecure.',
+      "Failed to execute 'open' on 'IDBFactory': The operation is insecure.",
+      "'text/html' is not a valid JavaScript MIME type.",
+    ];
+    for (const message of noise) {
+      expect(
+        sanitizeDiagnosticPayload({
+          source: 'client_js',
+          message,
+          anonymousSessionId: 'sess-123',
+          platform: 'web',
+        }),
+        message,
+      ).toBeNull();
+    }
+  });
 });

--- a/server/utils/__tests__/pg-undefined-relation.test.ts
+++ b/server/utils/__tests__/pg-undefined-relation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isDiscoverTableMissing, isPgUndefinedRelation } from '../pg-undefined-relation';
+
+describe('isDiscoverTableMissing', () => {
+  it('recognizes a missing catalog table through a Drizzle wrapper', () => {
+    const cause = Object.assign(new Error('relation "DiscoverListings" does not exist'), {
+      code: '42P01',
+    });
+    const wrapped = new Error('Failed query: select "id" from "DiscoverListings"');
+    (wrapped as Error & { cause: unknown }).cause = cause;
+    expect(isDiscoverTableMissing(wrapped)).toBe(true);
+    expect(isDiscoverTableMissing(cause)).toBe(true);
+  });
+
+  it('does not treat a different missing table as Discover', () => {
+    const error = Object.assign(new Error('relation "ReviewItems" does not exist'), { code: '42P01' });
+    expect(isDiscoverTableMissing(error)).toBe(false);
+    expect(isPgUndefinedRelation(error, 'ReviewItems')).toBe(true);
+  });
+});

--- a/server/utils/__tests__/record-diagnostic-event.test.ts
+++ b/server/utils/__tests__/record-diagnostic-event.test.ts
@@ -26,4 +26,15 @@ describe('validateDiagnosticEventInput', () => {
     expect(result?.manualNote).toBe('Could not save my note');
     expect(result?.issueSignature).toHaveLength(32);
   });
+
+  it('returns null for leftover push-nav instrumentation', () => {
+    expect(
+      validateDiagnosticEventInput({
+        source: 'client_js',
+        message: '[push-nav] probe from setup',
+        anonymousSessionId: 'abc',
+        platform: 'web',
+      }),
+    ).toBeNull();
+  });
 });

--- a/server/utils/diagnostics-sanitize.ts
+++ b/server/utils/diagnostics-sanitize.ts
@@ -13,6 +13,7 @@ import {
   normalizeDiagnosticMessageForSignature,
   redactDiagnosticRoute,
   scrubDiagnosticText,
+  isNoiseDiagnosticMessage,
 } from '@/utils/diagnostics-route';
 
 const MAX_MESSAGE = 500;
@@ -96,6 +97,7 @@ export function sanitizeDiagnosticPayload(body: unknown): SanitizedDiagnosticInp
 
   const messageRaw = typeof raw.message === 'string' ? raw.message.trim() : '';
   if (!messageRaw) return null;
+  if (isNoiseDiagnosticMessage(messageRaw)) return null;
 
   const anonymousSessionId =
     typeof raw.anonymousSessionId === 'string' ? raw.anonymousSessionId.trim() : '';

--- a/server/utils/pg-undefined-relation.ts
+++ b/server/utils/pg-undefined-relation.ts
@@ -143,6 +143,15 @@ export function isDiagnosticIssueTriageTableMissing(error: unknown): boolean {
   return isPgUndefinedRelation(error, 'DiagnosticIssueTriage');
 }
 
+/**
+ * Discover shipped as a catalog on top of two new tables. Until `npm run db:push`
+ * has created them, every Home/catalog load would 500 as "A database error occurred".
+ * An unmigrated database is an empty catalog, not a broken app.
+ */
+export function isDiscoverTableMissing(error: unknown): boolean {
+  return isPgUndefinedRelation(error, 'DiscoverListings') || isPgUndefinedRelation(error, 'DiscoverInstalls');
+}
+
 /** Postgres undefined_column (42703) — schema not pushed yet. */
 export function isPgUndefinedColumn(error: unknown, columnName: string): boolean {
   const needles = [`column "${columnName}" does not exist`, `column ${columnName} does not exist`];

--- a/spa/src/App.tsx
+++ b/spa/src/App.tsx
@@ -6,9 +6,9 @@ import { hasClerkSessionCookieHint } from './hooks/queries/useProfile';
 import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 import { clearUserClientCaches } from '@/utils/clear-user-client-caches';
 import { RouterProvider } from '@tanstack/react-router';
-import React, { lazy, Suspense, useEffect, useLayoutEffect, useState, useCallback, useRef, useMemo, useSyncExternalStore } from 'react';
+import React, { lazy, Suspense, useEffect, useLayoutEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { buildClerkAppearance } from './lib/clerk-appearance';
-import { getColorSchemeSnapshot, subscribeColorScheme } from './lib/prototype-background';
+import { getColorSchemeSnapshot } from './lib/prototype-background';
 import { getInstallPlatform } from '@/utils/platform-detect';
 import { createPortal } from 'react-dom';
 import { shouldSuppressAppToasts } from '@/utils/should-suppress-app-toasts';
@@ -818,8 +818,10 @@ function useInAppLinkInterceptor() {
 }
 
 function HarvousClerkProvider({ children }: { children: React.ReactNode }) {
-  const colorScheme = useSyncExternalStore(subscribeColorScheme, getColorSchemeSnapshot, () => 'light');
-  const appearance = useMemo(() => buildClerkAppearance(colorScheme === 'dark'), [colorScheme]);
+  // First paint only. Passing a new `appearance` (light ↔ dark) made Clerk remount the
+  // provider, which throws "You've added multiple <ClerkProvider> components". Tokens on
+  // `appearance.variables` already follow `--pds-*`, so Clerk UI still tracks the scheme.
+  const appearance = useMemo(() => buildClerkAppearance(getColorSchemeSnapshot() === 'dark'), []);
 
   return (
     <ClerkProvider publishableKey={clerkPublishableKey} appearance={appearance}>

--- a/spa/src/lib/__tests__/notification-navigation.test.ts
+++ b/spa/src/lib/__tests__/notification-navigation.test.ts
@@ -274,6 +274,22 @@ describe('waiting for the router', () => {
       .toHaveBeenCalled();
   });
 
+  it('does not throw when the service worker getter is insecure', () => {
+    // Safari private browsing: `'serviceWorker' in navigator` is true and the getter throws.
+    installCacheStorage();
+    vi.stubGlobal('navigator', {
+      get serviceWorker() {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      },
+    });
+    vi.stubGlobal('document', {
+      visibilityState: 'visible',
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    });
+    expect(() => initNotificationNavigation()).not.toThrow();
+  });
+
   it('navigates once when the message and the peek both resolve the same tap', async () => {
     installCacheStorage({ url: 'https://app.harvous.com/read/today', at: Date.now() });
     const listeners = stubServiceWorker();

--- a/spa/src/lib/__tests__/push-reminders.test.ts
+++ b/spa/src/lib/__tests__/push-reminders.test.ts
@@ -80,6 +80,19 @@ describe('getPushSupport', () => {
     expect(getPushSupport()).toBe('unsupported');
   });
 
+  it('treats a throwing service worker getter as unsupported rather than throwing', () => {
+    // Safari private browsing. Optional chaining still accesses the getter.
+    setup({});
+    vi.stubGlobal('navigator', {
+      userAgent: DESKTOP_UA,
+      get serviceWorker() {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      },
+    });
+    expect(() => getPushSupport()).not.toThrow();
+    expect(getPushSupport()).toBe('unsupported');
+  });
+
   it('tells an iPhone in Safari to install first, even though the APIs are present', () => {
     setup({ userAgent: IOS_UA });
     expect(getPushSupport()).toBe('needs-home-screen');

--- a/spa/src/lib/notification-navigation.ts
+++ b/spa/src/lib/notification-navigation.ts
@@ -19,6 +19,8 @@
  *   3. `addEventListener('message')` does not start the client message queue. Only assigning
  *      `onmessage` or calling `startMessages()` does, per spec.
  */
+import { readServiceWorkerContainer } from '@/utils/storage-security';
+
 export const NOTIFICATION_NAVIGATE_MESSAGE = 'HARVOUS_NOTIFICATION_NAVIGATE';
 
 /** Must match `PENDING_NAV_CACHE` / `PENDING_NAV_KEY` in public/sw.js. */
@@ -197,15 +199,16 @@ export function initNotificationNavigation(): () => void {
     if (document.visibilityState === 'visible') checkPending();
   };
 
-  navigator.serviceWorker?.addEventListener('message', onMessage);
+  const serviceWorker = readServiceWorkerContainer();
+  serviceWorker?.addEventListener('message', onMessage);
   // Starts the client message queue, which addEventListener alone does not, and flushes
   // anything the worker posted before this listener existed.
-  navigator.serviceWorker?.startMessages?.();
+  serviceWorker?.startMessages?.();
   document.addEventListener('visibilitychange', onVisible);
   checkPending();
 
   return () => {
-    navigator.serviceWorker?.removeEventListener('message', onMessage);
+    serviceWorker?.removeEventListener('message', onMessage);
     document.removeEventListener('visibilitychange', onVisible);
   };
 }

--- a/spa/src/lib/push-reminders.ts
+++ b/spa/src/lib/push-reminders.ts
@@ -18,6 +18,7 @@
  * subscription re-sync, so anything heavy here would land in the eager bundle.
  */
 import { reportDiagnosticEvent } from '@/utils/diagnostics-client';
+import { readServiceWorkerContainer } from '@/utils/storage-security';
 import { api, APIError } from './api';
 import { isPWA } from '@/utils/content-list-helpers';
 import { isIOS } from '@/utils/platform-detect';
@@ -45,9 +46,13 @@ export function getPushSupport(): PushSupport {
    * leave it undefined outside a secure context, so `'serviceWorker' in navigator` is true
    * on `http://192.168.x.x` — which is exactly how a phone reaches a dev server on the same
    * network. The `in` form would call that supported and then throw on `serviceWorker.ready`.
+   *
+   * Safari private browsing is worse: the getter itself throws SecurityError, so even
+   * optional chaining / Boolean() on the property is enough to blow up. Read through the
+   * try/catch helper.
    */
   const hasPushApis =
-    Boolean(navigator.serviceWorker) &&
+    Boolean(readServiceWorkerContainer()) &&
     typeof (window as Window & { PushManager?: unknown }).PushManager !== 'undefined' &&
     typeof (window as Window & { Notification?: unknown }).Notification !== 'undefined';
 
@@ -93,8 +98,9 @@ function urlBase64ToUint8Array(base64: string): Uint8Array {
 }
 
 async function currentSubscription(): Promise<PushSubscription | null> {
-  if (!('serviceWorker' in navigator)) return null;
-  const registration = await navigator.serviceWorker.ready;
+  const serviceWorker = readServiceWorkerContainer();
+  if (!serviceWorker) return null;
+  const registration = await serviceWorker.ready;
   return registration.pushManager.getSubscription();
 }
 
@@ -139,7 +145,11 @@ export async function enablePushReminders(): Promise<EnableResult> {
   if (!key) return { ok: false, support: 'granted', error: 'Push is not configured on the server yet.' };
 
   try {
-    const registration = await navigator.serviceWorker.ready;
+    const serviceWorker = readServiceWorkerContainer();
+    if (!serviceWorker) {
+      return { ok: false, support: 'unsupported', error: 'Push is not available in this browser.' };
+    }
+    const registration = await serviceWorker.ready;
     const existing = await registration.pushManager.getSubscription();
     const subscription =
       existing ??
@@ -179,7 +189,7 @@ export async function enablePushReminders(): Promise<EnableResult> {
     reportDiagnosticEvent({
       source: 'client_js',
       severity: 'warning',
-      message: `[push-nav] subscribe failed: ${raw}`,
+      message: `Push subscribe failed: ${raw}`,
     });
     return {
       ok: false,

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -12,6 +12,7 @@
  */
 
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { isBrowserSecureContext } from '@/utils/storage-security';
 
 let browserClient: SupabaseClient | null = null;
 type AccessTokenGetter = () => Promise<string | null>;
@@ -28,6 +29,7 @@ export const REALTIME_PRIVATE_CHANNEL_CONFIG = {
 };
 
 export function isSupabaseRealtimeConfigured(): boolean {
+  if (!isBrowserSecureContext()) return false;
   const url = import.meta.env.VITE_SUPABASE_URL;
   const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
   return Boolean(url && String(url).trim() && key && String(key).trim());
@@ -94,18 +96,23 @@ export function setSupabaseRealtimeAccessTokenGetter(fn: AccessTokenGetter | nul
 export function getSupabaseBrowserClient(): SupabaseClient | null {
   if (!isSupabaseRealtimeConfigured()) return null;
   if (!browserClient) {
-    browserClient = createClient(
-      String(import.meta.env.VITE_SUPABASE_URL).trim(),
-      String(import.meta.env.VITE_SUPABASE_ANON_KEY).trim(),
-      {
-        auth: { persistSession: false, autoRefreshToken: false },
-        accessToken: async () => {
-          if (!accessTokenGetter) return null;
-          return accessTokenGetter();
+    try {
+      browserClient = createClient(
+        String(import.meta.env.VITE_SUPABASE_URL).trim(),
+        String(import.meta.env.VITE_SUPABASE_ANON_KEY).trim(),
+        {
+          auth: { persistSession: false, autoRefreshToken: false },
+          accessToken: async () => {
+            if (!accessTokenGetter) return null;
+            return accessTokenGetter();
+          },
         },
-      },
-    );
-    ensureAuthRefreshLoop();
+      );
+      ensureAuthRefreshLoop();
+    } catch {
+      // Insecure context / blocked WebSocket — HTTP sync remains authoritative.
+      return null;
+    }
   }
   return browserClient;
 }

--- a/src/utils/__tests__/diagnostics-client.test.ts
+++ b/src/utils/__tests__/diagnostics-client.test.ts
@@ -85,4 +85,30 @@ describe('diagnostics-client', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+
+  it('labels API failures with the redacted path so one endpoint is one issue', async () => {
+    const fetchMock = vi.mocked(fetch);
+    const { reportApiDiagnostic } = await import('../diagnostics-client');
+
+    reportApiDiagnostic('/api/discover/listings', 500, 'A database error occurred');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body.message).toBe('A database error occurred (/api/discover/listings)');
+  });
+
+  it('drops leftover push-nav instrumentation and insecure-context noise', async () => {
+    const fetchMock = vi.mocked(fetch);
+    const { reportClientError } = await import('../diagnostics-client');
+
+    reportClientError('[push-nav] client navigate path=/read/today via=visible-peek waitedMs=0');
+    reportClientError('The operation is insecure.');
+    reportClientError('WebSocket not available: The operation is insecure.');
+    reportClientError(
+      "@clerk/clerk-react: You've added multiple <ClerkProvider> components in your React component tree. Wrap your components in a single <ClerkProvider>.",
+    );
+    reportClientError("'text/html' is not a valid JavaScript MIME type.");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/utils/__tests__/storage-security.test.ts
+++ b/src/utils/__tests__/storage-security.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  isBrowserSecureContext,
+  isStorageSecurityError,
+  readServiceWorkerContainer,
+} from '../storage-security';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('isStorageSecurityError', () => {
+  it('recognizes a DOM SecurityError', () => {
+    const error = new DOMException('The operation is insecure.', 'SecurityError');
+    expect(isStorageSecurityError(error)).toBe(true);
+  });
+
+  it('recognizes the Safari message without the name', () => {
+    expect(isStorageSecurityError(new Error('The operation is insecure.'))).toBe(true);
+  });
+
+  it('does not swallow unrelated failures', () => {
+    expect(isStorageSecurityError(new Error('QuotaExceededError'))).toBe(false);
+    expect(isStorageSecurityError(null)).toBe(false);
+  });
+});
+
+describe('readServiceWorkerContainer', () => {
+  it('returns the container when the getter works', () => {
+    const container = { ready: Promise.resolve(null) };
+    vi.stubGlobal('navigator', { serviceWorker: container });
+    expect(readServiceWorkerContainer()).toBe(container);
+  });
+
+  it('returns null when Safari private browsing throws on the getter', () => {
+    vi.stubGlobal('navigator', {
+      get serviceWorker() {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      },
+    });
+    expect(readServiceWorkerContainer()).toBeNull();
+  });
+});
+
+describe('isBrowserSecureContext', () => {
+  it('is true when the browser reports a secure context', () => {
+    vi.stubGlobal('window', { isSecureContext: true });
+    expect(isBrowserSecureContext()).toBe(true);
+  });
+
+  it('is false on http outside localhost', () => {
+    vi.stubGlobal('window', { isSecureContext: false });
+    expect(isBrowserSecureContext()).toBe(false);
+  });
+});

--- a/src/utils/diagnostics-client.ts
+++ b/src/utils/diagnostics-client.ts
@@ -4,7 +4,7 @@ import type {
   DiagnosticSource,
   DiagnosticSourceEnv,
 } from '@/utils/diagnostic-sources';
-import { redactDiagnosticRoute } from '@/utils/diagnostics-route';
+import { isNoiseDiagnosticMessage, redactDiagnosticRoute } from '@/utils/diagnostics-route';
 
 const SESSION_STORAGE_KEY = 'harvous_diag_session';
 const SESSION_ROTATE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -84,6 +84,7 @@ function buildClientErrorMetadata(message: string): Record<string, unknown> | nu
 
 function shouldIgnoreError(error: Error | string): boolean {
   const message = typeof error === 'string' ? error : error.message ?? '';
+  if (isNoiseDiagnosticMessage(message)) return true;
   if (isThirdPartyChunkFailure(message)) return true;
   return isBenignErrorMessage(message);
 }
@@ -242,13 +243,16 @@ export function reportApiDiagnostic(path: string, status: number, message: strin
   if (status < 500) return;
   // Service worker offline fallback (public/sw.js) returns synthetic 503 with this exact message.
   if (status === 503 && message === 'Network error') return;
+  const pathOnly = path.split('?')[0] ?? path;
+  const labeled = `${message} (${redactDiagnosticRoute(pathOnly)})`;
+  if (isNoiseDiagnosticMessage(labeled) || isNoiseDiagnosticMessage(message)) return;
   // One event per logical failure — not one per React Query retry attempt.
   if (isDuplicateReport(`api|${path}|${status}|${message}`)) return;
-  rememberError(message, null);
+  rememberError(labeled, null);
   reportDiagnosticEvent({
     source: 'client_api',
-    message,
-    metadata: { statusCode: status, apiPath: path },
+    message: labeled,
+    metadata: { statusCode: status, apiPath: pathOnly },
   });
 }
 

--- a/src/utils/diagnostics-route.ts
+++ b/src/utils/diagnostics-route.ts
@@ -85,3 +85,19 @@ export function scrubDiagnosticText(text: string): string {
     .replace(/\b[0-9a-f]{24,}\b/gi, '[token]')
     .trim();
 }
+
+/**
+ * Client noise that is either leftover instrumentation, an environmental browser
+ * limitation, or a symptom already handled elsewhere. Dropped at capture and at
+ * ingest so an old PWA build cannot keep filling the admin list.
+ */
+export function isNoiseDiagnosticMessage(message: string): boolean {
+  const lower = message.trim().toLowerCase();
+  if (!lower) return false;
+  if (lower.startsWith('[push-nav]')) return true;
+  if (lower.includes("you've added multiple <clerkprovider>")) return true;
+  // Safari private browsing, insecure contexts, blocked storage / workers / WebSocket.
+  if (lower.includes('the operation is insecure')) return true;
+  if (lower.includes('is not a valid javascript mime type')) return true;
+  return false;
+}

--- a/src/utils/indexeddb-pool.ts
+++ b/src/utils/indexeddb-pool.ts
@@ -26,10 +26,20 @@ export async function getDBConnection(config: DBConfig): Promise<IDBDatabase> {
   }
 
   // Create new connection and cache the promise
-  const dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
-    const request = indexedDB.open(config.name, config.version);
+  let request: IDBOpenDBRequest;
+  try {
+    request = indexedDB.open(config.name, config.version);
+  } catch (error) {
+    // Safari private browsing throws synchronously. Do not cache a rejected promise —
+    // the next call should get a fresh attempt, not a stuck failure.
+    return Promise.reject(error);
+  }
 
-    request.onerror = () => reject(request.error);
+  const dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+    request.onerror = () => {
+      connections.delete(key);
+      reject(request.error);
+    };
     request.onsuccess = () => resolve(request.result);
 
     request.onupgradeneeded = (event) => {

--- a/src/utils/offline-db.ts
+++ b/src/utils/offline-db.ts
@@ -1,4 +1,5 @@
 import Dexie, { type Table } from 'dexie';
+import { isStorageSecurityError } from '@/utils/storage-security';
 
 // Sync status for offline entities
 export type SyncStatus = 'synced' | 'pending' | 'conflict' | 'deleted';
@@ -353,6 +354,14 @@ class OfflineDatabase extends Dexie {
 // Create singleton instance
 export const offlineDB = new OfflineDatabase();
 
+offlineDB.open().catch((error: unknown) => {
+  if (isStorageSecurityError(error)) {
+    // Safari private browsing, storage blocked, insecure context.
+    return;
+  }
+  console.error('[offlineDB] open failed:', error);
+});
+
 /**
  * Ensure database is open, reopen if closed
  * This is necessary because the database can be closed after deletion or other operations
@@ -369,6 +378,9 @@ export async function ensureDatabaseOpen(): Promise<void> {
     // Only log warnings/errors when reopening actually fails
     await offlineDB.open();
   } catch (error: any) {
+    if (isStorageSecurityError(error)) {
+      return;
+    }
     // If open fails, it might be because the database was deleted
     // Try to open again - Dexie will recreate the database if needed
     if (error?.name === 'DatabaseClosedError' || error?.message?.includes('closed')) {
@@ -376,6 +388,7 @@ export async function ensureDatabaseOpen(): Promise<void> {
       try {
         await offlineDB.open();
       } catch (retryError) {
+        if (isStorageSecurityError(retryError)) return;
         console.error('[ensureDatabaseOpen] Failed to reopen database after retry:', retryError);
         throw retryError;
       }
@@ -404,6 +417,10 @@ export async function retryIndexedDBOperation<T>(
       // Check if it's a quota error - these are usually permanent
       if (error?.name === 'QuotaExceededError') {
         console.error('[retryIndexedDBOperation] Quota exceeded, cannot retry:', error);
+        throw error;
+      }
+
+      if (isStorageSecurityError(error)) {
         throw error;
       }
       

--- a/src/utils/production-clerk-key-guard.ts
+++ b/src/utils/production-clerk-key-guard.ts
@@ -1,4 +1,5 @@
 import { clearAppCachesThen } from './prototype-app-update-notice';
+import { readServiceWorkerContainer } from './storage-security';
 
 /**
  * Refuse to boot a development-Clerk bundle on a production host, and self-heal.
@@ -44,11 +45,12 @@ function clearFlag(): void {
 }
 
 function unregisterServiceWorkersThen(done: () => void): void {
-  if (typeof navigator === 'undefined' || !navigator.serviceWorker) {
+  const serviceWorker = readServiceWorkerContainer();
+  if (!serviceWorker) {
     done();
     return;
   }
-  navigator.serviceWorker
+  serviceWorker
     .getRegistrations()
     .then((registrations) => Promise.all(registrations.map((r) => r.unregister())))
     .then(done)

--- a/src/utils/storage-security.ts
+++ b/src/utils/storage-security.ts
@@ -1,0 +1,28 @@
+/**
+ * Safari private browsing and non-secure contexts throw DOMException instead of
+ * returning undefined for storage / workers / WebSocket. Accessing the getter is
+ * enough — optional chaining does not catch it.
+ */
+
+export function isStorageSecurityError(error: unknown): boolean {
+  if (error == null) return false;
+  const name =
+    typeof error === 'object' && error !== null && 'name' in error ? String((error as { name: unknown }).name) : '';
+  const message = error instanceof Error ? error.message : String(error);
+  if (name === 'SecurityError') return true;
+  return /the operation is insecure/i.test(message);
+}
+
+export function readServiceWorkerContainer(): ServiceWorkerContainer | null {
+  if (typeof navigator === 'undefined') return null;
+  try {
+    return navigator.serviceWorker ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function isBrowserSecureContext(): boolean {
+  if (typeof window === 'undefined') return true;
+  return window.isSecureContext !== false;
+}


### PR DESCRIPTION
## Summary

The admin Issue signals list was filling with things that were either a real 500 on Home, leftover instrumentation, or a browser refusing storage/workers. This patch treats the real fault as empty UI (same seam as Review) and stops the rest from throwing or from ingesting.

### A database error occurred (37× on 9/7)
Discover shipped that day without the missing-table guard Review already has. Until `db:push` created `DiscoverListings` / `DiscoverInstalls`, every Home catalog load 500'd. `isDiscoverTableMissing` now returns an empty catalog (writes 503 `NOT_READY`) instead of `handleAPIError`. API diagnostics also label the redacted path, so the next genuine DB 500 groups as one endpoint rather than one blob.

### The operation is insecure / WebSocket not available
Safari private browsing throws `SecurityError` on the `navigator.serviceWorker` *getter* — optional chaining still accesses it. `getPushSupport`, notification navigation, the SW manager, PWA warmup, Clerk key-guard, IndexedDB, and Supabase Realtime now go through a try/catch helper and skip those APIs instead of blowing up.

### Multiple `<ClerkProvider>`
Passing a new `appearance` on light ↔ dark remounted Clerk. Appearance is first-paint only; CSS variables on `appearance.variables` still track the scheme.

### `[push-nav] …`
Removed from the client on 9/5, still arriving from old PWA builds. Dropped at capture and at ingest.

### `'text/html' is not a valid JavaScript MIME type`
The Worker already 404s HTML for `/assets/*`. The service worker could still *serve* a cached or network HTML response as JS. It now 404s/504s those instead.

Ingest also rejects the leftover messages so an old installed build cannot keep filling the list after this ships. Existing Open rows will not auto-resolve — Resolve them once after deploy.

## Test plan
- [x] `npx vitest run` on the 10 touched files: 156 tests passed
- [ ] After deploy, Home with a missing Discover table is an empty catalog, not a 500
- [ ] Safari private browsing no longer reports "The operation is insecure"
- [ ] Resolve the leftover Open rows in Issue signals