### PR TITLE
fix: load Pulse and Usage again after the Fly API move

### DIFF
--- a/Changelog/3.9.4.md
+++ b/Changelog/3.9.4.md
@@ -1,0 +1,11 @@
+# Version 3.9.4
+
+**Release Date**: September 8, 2026
+
+## Fixes
+
+- Admin Pulse and Usage load again after the API move to Fly. Those dashboards were opening every aggregation at once against the one shared Postgres pool, then waiting forever for a first byte the proxy never sent.
+
+## Internal
+
+- Cache Pulse/Usage payloads in the Fly process, cap their query concurrency, and time out the browser fetch so a miss shows an error instead of an endless spinner.

--- a/docs/FLY_MIGRATION.md
+++ b/docs/FLY_MIGRATION.md
@@ -316,6 +316,15 @@ app, the native app and the offline queue.
 The other scheduled workflows are short and unaffected, but any new job that
 might exceed roughly half a minute belongs on the direct host.
 
+Admin Pulse and Usage are the other long-running path. They used to fan out
+~20 aggregations through `Promise.all` against a pool of ten — harmless on
+Netlify (one isolate, one pool, one request) and fatal on Fly (one process,
+every other request queued behind them, no first byte before the idle
+timeout). They now run three-wide, cache in-process for a minute, and the
+browser gives up at 45s so the tab cannot spin forever. The first compute
+after a cold cache still continues on Fly after a client timeout; retrying
+joins that in-flight work.
+
 ## Do not "upgrade" the Netlify plan
 
 Netlify may offer to move the account onto its newer credit-based free tier.

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -65,6 +65,7 @@ import { createInitialNoteVersion } from '../utils/note-version-service';
 import { getCurrentSeason } from '@/utils/season-helpers';
 import { getUsageOverview, getUsageTrends, getUsageDiscovery } from '../utils/admin-usage-stats';
 import { getAdminPulse } from '../utils/admin-pulse-stats';
+import { cachedAdminDashboard } from '../utils/admin-dashboard-cache';
 import {
   generateAdminMonthlyReport,
   getStoredMonthlyReport,
@@ -109,7 +110,8 @@ app.get('/api/admin/usage/overview', async (c) => {
   if (denied) return denied;
   try {
     const daysParam = parseInt(c.req.query('days') ?? '30', 10);
-    const overview = await getUsageOverview(Number.isFinite(daysParam) ? daysParam : 30);
+    const days = Number.isFinite(daysParam) ? daysParam : 30;
+    const overview = await cachedAdminDashboard(`usage-overview:${days}`, () => getUsageOverview(days));
     return c.json(overview);
   } catch (error: unknown) {
     console.error('[admin usage overview]', error);
@@ -122,7 +124,8 @@ app.get('/api/admin/usage/trends', async (c) => {
   if (denied) return denied;
   try {
     const daysParam = parseInt(c.req.query('days') ?? '30', 10);
-    const trends = await getUsageTrends(Number.isFinite(daysParam) ? daysParam : 30);
+    const days = Number.isFinite(daysParam) ? daysParam : 30;
+    const trends = await cachedAdminDashboard(`usage-trends:${days}`, () => getUsageTrends(days));
     return c.json(trends);
   } catch (error: unknown) {
     console.error('[admin usage trends]', error);
@@ -135,7 +138,8 @@ app.get('/api/admin/usage/discovery', async (c) => {
   if (denied) return denied;
   try {
     const daysParam = parseInt(c.req.query('days') ?? '30', 10);
-    const discovery = await getUsageDiscovery(Number.isFinite(daysParam) ? daysParam : 30);
+    const days = Number.isFinite(daysParam) ? daysParam : 30;
+    const discovery = await cachedAdminDashboard(`usage-discovery:${days}`, () => getUsageDiscovery(days));
     return c.json(discovery);
   } catch (error: unknown) {
     console.error('[admin usage discovery]', error);
@@ -148,7 +152,8 @@ app.get('/api/admin/pulse', async (c) => {
   if (denied) return denied;
   try {
     const daysParam = parseInt(c.req.query('days') ?? '7', 10);
-    const pulse = await getAdminPulse(Number.isFinite(daysParam) ? daysParam : 7);
+    const days = Number.isFinite(daysParam) ? daysParam : 7;
+    const pulse = await cachedAdminDashboard(`pulse:${days}`, () => getAdminPulse(days));
     return c.json(pulse);
   } catch (error: unknown) {
     console.error('[admin pulse]', error);

--- a/server/utils/__tests__/admin-dashboard-cache.test.ts
+++ b/server/utils/__tests__/admin-dashboard-cache.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cachedAdminDashboard, clearAdminDashboardCache } from '../admin-dashboard-cache';
+
+describe('cachedAdminDashboard', () => {
+  afterEach(() => {
+    clearAdminDashboardCache();
+  });
+
+  it('computes once for a fresh key', async () => {
+    let calls = 0;
+    const load = async () => {
+      calls += 1;
+      return { n: calls };
+    };
+
+    await expect(cachedAdminDashboard('pulse:7', load, 10_000)).resolves.toEqual({ n: 1 });
+    await expect(cachedAdminDashboard('pulse:7', load, 10_000)).resolves.toEqual({ n: 1 });
+    expect(calls).toBe(1);
+  });
+
+  it('coalesces concurrent misses onto one load', async () => {
+    let calls = 0;
+    let release: () => void = () => {};
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const load = async () => {
+      calls += 1;
+      await gate;
+      return { n: calls };
+    };
+
+    const first = cachedAdminDashboard('usage:14', load, 10_000);
+    const second = cachedAdminDashboard('usage:14', load, 10_000);
+    release();
+    await expect(Promise.all([first, second])).resolves.toEqual([{ n: 1 }, { n: 1 }]);
+    expect(calls).toBe(1);
+  });
+
+  it('serves stale data while a refresh is in flight', async () => {
+    vi.useFakeTimers();
+    try {
+      let calls = 0;
+      const load = async () => {
+        calls += 1;
+        return { n: calls };
+      };
+
+      await expect(cachedAdminDashboard('pulse:30', load, 1_000)).resolves.toEqual({ n: 1 });
+      await vi.advanceTimersByTimeAsync(1_001);
+      await expect(cachedAdminDashboard('pulse:30', load, 1_000)).resolves.toEqual({ n: 1 });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(calls).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/server/utils/__tests__/admin-pulse-usage-fly.test.ts
+++ b/server/utils/__tests__/admin-pulse-usage-fly.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Source contract: Pulse and Usage must not pin Fly's shared Postgres pool.
+ *
+ * After the API moved to one always-on process, these two dashboards never
+ * loaded. The cause is in the shape of the work: a 20-wide Promise.all of
+ * COUNT DISTINCT queries plus a full NoteConnections graph walk, against a
+ * pool of ten, with no in-process cache and a browser fetch that waited
+ * forever. Netlify hid it — each isolate had its own pool. Fly does not.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+
+const fnBody = (path: string, exportName: string) => {
+  const text = source(path);
+  const start = text.indexOf(`export async function ${exportName}`);
+  expect(start).toBeGreaterThan(-1);
+  const end = text.indexOf('\nexport ', start + 1);
+  return text
+    .slice(start, end > start ? end : undefined)
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+};
+
+describe('admin Pulse / Usage on Fly', () => {
+  it('serves Pulse and Usage from the in-process cache', () => {
+    const routes = source('server/routes/admin.ts');
+    expect(routes).toContain("from '../utils/admin-dashboard-cache'");
+    expect(routes).toContain("cachedAdminDashboard(`pulse:${days}`");
+    expect(routes).toContain("cachedAdminDashboard(`usage-overview:${days}`");
+    expect(routes).toContain("cachedAdminDashboard(`usage-trends:${days}`");
+    expect(routes).toContain("cachedAdminDashboard(`usage-discovery:${days}`");
+  });
+
+  it('does not open Pulse aggregations all at once', () => {
+    const body = fnBody('server/utils/admin-pulse-stats.ts', 'getAdminPulse');
+    expect(body).toContain('runBounded');
+    expect(body).not.toMatch(/await Promise\.all\(\[/);
+  });
+
+  it('does not open Usage overview aggregations all at once', () => {
+    const body = fnBody('server/utils/admin-usage-stats.ts', 'getUsageOverview');
+    expect(body).toContain('runBounded');
+    expect(body).not.toMatch(/await Promise\.all\(\[/);
+  });
+
+  it('does not block Pulse on a cold full-platform graph walk', () => {
+    const threads = source('server/utils/admin-pulse-threads-stats.ts');
+    expect(threads).toContain('getPlatformThreadSnapshot');
+    expect(threads).toContain('fetchCheapThreadSnapshot');
+    expect(threads).toContain('refreshPlatformThreadSnapshot');
+    const stats = fnBody('server/utils/admin-pulse-threads-stats.ts', 'getAdminPulseThreadsStats');
+    expect(stats).not.toContain('fetchPlatformThreadSnapshot()');
+  });
+
+  it('times out the admin browser fetch so Loading… cannot last forever', () => {
+    const pulse = source('src/hooks/queries/useAdminPulse.ts');
+    const usage = source('src/hooks/queries/useAdminUsage.ts');
+    expect(pulse).toContain('AbortSignal.timeout');
+    expect(usage).toContain('AbortSignal.timeout');
+    expect(pulse).toMatch(/retry:\s*1/);
+    expect(usage).toMatch(/retry:\s*1/);
+  });
+});

--- a/server/utils/__tests__/run-bounded.test.ts
+++ b/server/utils/__tests__/run-bounded.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { runBounded } from '../run-bounded';
+
+describe('runBounded', () => {
+  it('preserves order while capping in-flight work', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const tasks = Array.from({ length: 8 }, (_, index) => async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+      return index;
+    });
+
+    await expect(runBounded(tasks, 3)).resolves.toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    expect(peak).toBeLessThanOrEqual(3);
+  });
+
+  it('runs nothing when given no tasks', async () => {
+    await expect(runBounded([], 3)).resolves.toEqual([]);
+  });
+});

--- a/server/utils/admin-dashboard-cache.ts
+++ b/server/utils/admin-dashboard-cache.ts
@@ -1,0 +1,62 @@
+/**
+ * In-process cache for the heavy admin Pulse / Usage payloads.
+ *
+ * Netlify Functions were a new isolate per request, so remembering work was
+ * pointless. Fly is one process: the first computation can fill the cache, and
+ * every admin tab after that is a memory read. In-flight coalescing matters as
+ * much as the TTL — React Query retries a hung Pulse as a second identical
+ * blast, and without this those retries stacked on the same 10-connection pool.
+ */
+
+type CacheEntry<T> = {
+  value: T;
+  expiresAt: number;
+};
+
+const store = new Map<string, CacheEntry<unknown>>();
+const inflight = new Map<string, Promise<unknown>>();
+
+export const ADMIN_DASHBOARD_TTL_MS = 60 * 1000;
+
+export async function cachedAdminDashboard<T>(
+  key: string,
+  load: () => Promise<T>,
+  ttlMs = ADMIN_DASHBOARD_TTL_MS,
+): Promise<T> {
+  const now = Date.now();
+  const hit = store.get(key) as CacheEntry<T> | undefined;
+  if (hit && hit.expiresAt > now) return hit.value;
+
+  const pending = inflight.get(key) as Promise<T> | undefined;
+  if (pending) return pending;
+
+  if (hit) {
+    const refresh = load()
+      .then((value) => {
+        store.set(key, { value, expiresAt: Date.now() + ttlMs });
+        return value;
+      })
+      .finally(() => {
+        inflight.delete(key);
+      });
+    inflight.set(key, refresh);
+    return hit.value;
+  }
+
+  const promise = load()
+    .then((value) => {
+      store.set(key, { value, expiresAt: Date.now() + ttlMs });
+      return value;
+    })
+    .finally(() => {
+      inflight.delete(key);
+    });
+  inflight.set(key, promise);
+  return promise;
+}
+
+/** Test hook — production callers never need this. */
+export function clearAdminDashboardCache() {
+  store.clear();
+  inflight.clear();
+}

--- a/server/utils/admin-pulse-stats.ts
+++ b/server/utils/admin-pulse-stats.ts
@@ -35,6 +35,7 @@ import { getAdminPulseThreadsStats, getAdminPulseThreadsSummaryForReport, type P
 import { adminWindowSince, adminWindowPreviousRange, clampAdminDays } from './admin-time-window';
 import { filterPulseDiscoveryThemes } from '@/utils/universal-bible-entities';
 import { formatPulseThemeLabels } from '@/utils/divine-name-display';
+import { runBounded } from './run-bounded';
 export type PulseHistoryMonth = {
   month: string;
   books: DiscoveryRankItem[];
@@ -328,27 +329,27 @@ export async function getAdminPulse(daysParam: number): Promise<AdminPulse> {
     previousDictionaryWords,
     previousFolders,
     threads,
-  ] = await Promise.all([
-    fetchUniquePassageCount(currentSince),
-    fetchPassages(currentSince, undefined, 10),
-    fetchPassages(previousSince, previousUntil, 10),
-    fetchBooks(currentSince, undefined, 10),
-    fetchBooks(previousSince, previousUntil, 10),
-    fetchBooks(previousSince, previousUntil),
-    fetchBooks(currentSince, undefined),
-    fetchThemes(currentSince, undefined, 10),
-    fetchThemes(previousSince, previousUntil, 10),
-    fetchTones(currentSince, undefined, 10),
-    fetchTags(currentSince, undefined),
-    fetchDictionaryWords(currentSince, undefined),
-    getTrendingAutoFolders(currentSince, 10),
-    fetchTranslations(currentSince, undefined),
-    fetchPulseHistory(6),
-    fetchPassages(previousSince, previousUntil, CURIOSITY_PREV_LIMIT),
-    fetchTags(previousSince, previousUntil, CURIOSITY_PREV_LIMIT),
-    fetchDictionaryWords(previousSince, previousUntil, CURIOSITY_PREV_LIMIT),
-    getTrendingAutoFolders(previousSince, CURIOSITY_PREV_LIMIT, previousUntil),
-    getAdminPulseThreadsStats(currentSince),
+  ] = await runBounded([
+    () => fetchUniquePassageCount(currentSince),
+    () => fetchPassages(currentSince, undefined, 10),
+    () => fetchPassages(previousSince, previousUntil, 10),
+    () => fetchBooks(currentSince, undefined, 10),
+    () => fetchBooks(previousSince, previousUntil, 10),
+    () => fetchBooks(previousSince, previousUntil),
+    () => fetchBooks(currentSince, undefined),
+    () => fetchThemes(currentSince, undefined, 10),
+    () => fetchThemes(previousSince, previousUntil, 10),
+    () => fetchTones(currentSince, undefined, 10),
+    () => fetchTags(currentSince, undefined),
+    () => fetchDictionaryWords(currentSince, undefined),
+    () => getTrendingAutoFolders(currentSince, 10),
+    () => fetchTranslations(currentSince, undefined),
+    () => fetchPulseHistory(6),
+    () => fetchPassages(previousSince, previousUntil, CURIOSITY_PREV_LIMIT),
+    () => fetchTags(previousSince, previousUntil, CURIOSITY_PREV_LIMIT),
+    () => fetchDictionaryWords(previousSince, previousUntil, CURIOSITY_PREV_LIMIT),
+    () => getTrendingAutoFolders(previousSince, CURIOSITY_PREV_LIMIT, previousUntil),
+    () => getAdminPulseThreadsStats(currentSince),
   ]);
 
   const risingBooks = computeRisingDeltas(currentBooks, previousBooks, 5);

--- a/server/utils/admin-pulse-threads-stats.ts
+++ b/server/utils/admin-pulse-threads-stats.ts
@@ -3,7 +3,7 @@
  */
 
 import { db, NoteConnections, Notes, eq, and, isNotNull, sql } from '../db';
-import { COUNTABLE_USER_NOTES_N_SQL, countableUserNotesWhere } from './purge-onboarding-content';
+import { COUNTABLE_USER_NOTES_N_SQL, COUNTABLE_USER_NOTES_SQL, countableUserNotesWhere } from './purge-onboarding-content';
 import {
   isNoteConnectionsTableMissing,
   isRecallEventsTableMissing,
@@ -124,6 +124,86 @@ async function fetchPlatformThreadSnapshot(): Promise<PlatformThreadSnapshot> {
     }
     throw error;
   }
+}
+
+const SNAPSHOT_TTL_MS = 15 * 60 * 1000;
+const SNAPSHOT_WAIT_MS = 8_000;
+
+let snapshotCache: { at: number; value: PlatformThreadSnapshot } | null = null;
+let snapshotInflight: Promise<PlatformThreadSnapshot> | null = null;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function refreshPlatformThreadSnapshot(): Promise<PlatformThreadSnapshot> {
+  if (snapshotInflight) return snapshotInflight;
+  snapshotInflight = fetchPlatformThreadSnapshot()
+    .then((value) => {
+      snapshotCache = { at: Date.now(), value };
+      return value;
+    })
+    .finally(() => {
+      snapshotInflight = null;
+    });
+  return snapshotInflight;
+}
+
+/**
+ * Cheap stand-in used when the full graph walk has not finished yet.
+ * Distinct users-with-links + titled singletons is not cluster-accurate, but it
+ * lets Pulse render instead of waiting on SELECT * FROM "NoteConnections".
+ */
+async function fetchCheapThreadSnapshot(): Promise<PlatformThreadSnapshot> {
+  const empty: PlatformThreadSnapshot = { totalThreads: 0, avgNotesPerThread: 0, threadNoteIds: [] };
+  try {
+    const rows = await db.execute<{ connections: number; titled: number }>(sql`
+      SELECT
+        (SELECT COUNT(DISTINCT "userId")::int FROM "NoteConnections") AS connections,
+        (SELECT COUNT(*)::int FROM "Notes"
+          WHERE "studyThreadUserOverride" = true
+            AND "studyThreadTitle" IS NOT NULL
+            AND TRIM(COALESCE("studyThreadTitle", '')) <> ''
+            AND ${COUNTABLE_USER_NOTES_SQL}
+        ) AS titled
+    `);
+    return {
+      totalThreads: Number(rows[0]?.connections ?? 0) + Number(rows[0]?.titled ?? 0),
+      avgNotesPerThread: 0,
+      threadNoteIds: [],
+    };
+  } catch (error) {
+    if (isNoteConnectionsTableMissing(error) || isStudyThreadNamingColumnMissing(error)) {
+      return empty;
+    }
+    throw error;
+  }
+}
+
+async function getPlatformThreadSnapshot(): Promise<PlatformThreadSnapshot> {
+  if (snapshotCache && Date.now() - snapshotCache.at < SNAPSHOT_TTL_MS) {
+    return snapshotCache.value;
+  }
+  if (snapshotCache) {
+    void refreshPlatformThreadSnapshot().catch((error) => {
+      console.warn('[admin pulse threads] snapshot refresh failed', error);
+    });
+    return snapshotCache.value;
+  }
+
+  const inflight = refreshPlatformThreadSnapshot();
+  const raced = await Promise.race([
+    inflight.then((value) => ({ ok: true as const, value })),
+    delay(SNAPSHOT_WAIT_MS).then(() => ({ ok: false as const })),
+  ]);
+  if (raced.ok) return raced.value;
+
+  void inflight.catch((error) => {
+    console.warn('[admin pulse threads] snapshot warm failed', error);
+  });
+  return fetchCheapThreadSnapshot();
 }
 
 async function fetchWindowLinkActivity(since: Date, until?: Date): Promise<WindowLinkActivity> {
@@ -290,7 +370,7 @@ async function fetchThreadRecallMetrics(since: Date, until?: Date): Promise<Puls
 
 export async function getAdminPulseThreadsStats(since: Date, until?: Date): Promise<PulseThreadsStats> {
   const [snapshot, windowActivity, recall] = await Promise.all([
-    fetchPlatformThreadSnapshot(),
+    getPlatformThreadSnapshot(),
     fetchWindowLinkActivity(since, until),
     fetchThreadRecallMetrics(since, until),
   ]);

--- a/server/utils/admin-usage-stats.ts
+++ b/server/utils/admin-usage-stats.ts
@@ -47,6 +47,7 @@ import { getAdminPulseXp, type PulseXpSummary } from './admin-pulse-xp-stats';
 import { adminWindowSince, adminWindowPreviousRange, clampAdminDays } from './admin-time-window';
 import { recallKindDisplayLabel } from '@/utils/recall-opportunity-kinds';
 import type { AdminMonthlyReportUsage } from './admin-report-types';
+import { runBounded } from './run-bounded';
 
 export type DiscoveryRankItem = { name: string; count: number };
 
@@ -141,9 +142,18 @@ export type UsageDiscovery = {
 async function getClerkTotalUserCount(): Promise<number | null> {
   const clerkSecretKey = process.env.CLERK_SECRET_KEY;
   if (!clerkSecretKey) return null;
-  const clerkClient = createClerkClient({ secretKey: clerkSecretKey });
-  const { totalCount } = await clerkClient.users.getUserList({ limit: 1, offset: 0 });
-  return totalCount ?? 0;
+  try {
+    const clerkClient = createClerkClient({ secretKey: clerkSecretKey });
+    const result = await Promise.race([
+      clerkClient.users.getUserList({ limit: 1, offset: 0 }),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('clerk timeout')), 2500);
+      }),
+    ]);
+    return result.totalCount ?? 0;
+  } catch {
+    return null;
+  }
 }
 
 function utcDateString(d: Date): string {
@@ -817,17 +827,18 @@ export async function getUsageOverview(daysParam: number): Promise<UsageOverview
     translationRows,
     studyThreadEntries,
     recallMetrics,
-  ] = await Promise.all([
-    getClerkTotalUserCount(),
-    db.execute<{
-      total_accounts: number;
-      users_with_content: number;
-      notes: number;
-      notes_created: number;
-      signups: number;
-      active_users: number;
-      notes_edited: number;
-    }>(sql`
+  ] = await runBounded([
+    () => getClerkTotalUserCount(),
+    () =>
+      db.execute<{
+        total_accounts: number;
+        users_with_content: number;
+        notes: number;
+        notes_created: number;
+        signups: number;
+        active_users: number;
+        notes_edited: number;
+      }>(sql`
     SELECT
       (SELECT COUNT(*) FROM "UserMetadata") AS total_accounts,
       (SELECT COUNT(DISTINCT "userId") FROM "Notes" WHERE ${COUNTABLE_USER_NOTES_SQL}) AS users_with_content,
@@ -837,28 +848,31 @@ export async function getUsageOverview(daysParam: number): Promise<UsageOverview
       (SELECT COUNT(DISTINCT "userId") FROM "Notes" WHERE COALESCE("updatedAt", "createdAt") >= ${sinceIso} AND ${COUNTABLE_USER_NOTES_SQL}) AS active_users,
       (SELECT COUNT(*) FROM "Notes" WHERE "updatedAt" >= ${sinceIso} AND "updatedAt" > "createdAt" AND ${COUNTABLE_USER_NOTES_SQL}) AS notes_edited
   `),
-    db
-      .select({ tier: UserMetadata.tier, count: sql<number>`COUNT(*)`.as('count') })
-      .from(UserMetadata)
-      .groupBy(UserMetadata.tier),
-    db
-      .select({ noteType: Notes.noteType, count: sql<number>`COUNT(*)`.as('count') })
-      .from(Notes)
-      .where(and(gte(Notes.createdAt, since), countableUserNotesWhere()))
-      .groupBy(Notes.noteType),
-    countNoteConnectionsSince(since),
-    countFoldersActiveSince(since),
-    fetchStudyBehaviorMetrics(since),
-    fetchVotdPassageEngagementMetrics(since),
-    countScripturePillsSince(since),
-    db
-      .select({ translation: UserMetadata.defaultTranslation, count: sql<number>`COUNT(*)`.as('count') })
-      .from(UserMetadata)
-      .groupBy(UserMetadata.defaultTranslation)
-      .orderBy(sql`COUNT(*) DESC`)
-      .limit(5),
-    countActiveStudyThreadEntries(since),
-    fetchRecallMetrics(since),
+    () =>
+      db
+        .select({ tier: UserMetadata.tier, count: sql<number>`COUNT(*)`.as('count') })
+        .from(UserMetadata)
+        .groupBy(UserMetadata.tier),
+    () =>
+      db
+        .select({ noteType: Notes.noteType, count: sql<number>`COUNT(*)`.as('count') })
+        .from(Notes)
+        .where(and(gte(Notes.createdAt, since), countableUserNotesWhere()))
+        .groupBy(Notes.noteType),
+    () => countNoteConnectionsSince(since),
+    () => countFoldersActiveSince(since),
+    () => fetchStudyBehaviorMetrics(since),
+    () => fetchVotdPassageEngagementMetrics(since),
+    () => countScripturePillsSince(since),
+    () =>
+      db
+        .select({ translation: UserMetadata.defaultTranslation, count: sql<number>`COUNT(*)`.as('count') })
+        .from(UserMetadata)
+        .groupBy(UserMetadata.defaultTranslation)
+        .orderBy(sql`COUNT(*) DESC`)
+        .limit(5),
+    () => countActiveStudyThreadEntries(since),
+    () => fetchRecallMetrics(since),
   ]);
 
   const xp = await getAdminPulseXp(days, since, previousSince, previousUntil);

--- a/server/utils/run-bounded.ts
+++ b/server/utils/run-bounded.ts
@@ -1,0 +1,35 @@
+/**
+ * Run async tasks with a cap on how many are in flight.
+ *
+ * Unbounded `Promise.all` against the Postgres pool is not parallelism on Fly.
+ * The pool is ten connections wide (`server/db/client.ts`) and shared with every
+ * other request on the one always-on process. Pulse used to open ~20 aggregations
+ * at once; Usage another dozen. On Netlify each function isolate had its own pool,
+ * so the fan-out only hurt that one request. Here it pinned the process: Pulse
+ * held every connection until the slowest COUNT DISTINCT finished, the proxy saw
+ * no first byte, and the dashboard sat on "Loading…".
+ */
+
+export async function runBounded<T extends readonly unknown[]>(
+  tasks: { readonly [K in keyof T]: () => Promise<T[K]> },
+  limit = 3,
+): Promise<{ -readonly [K in keyof T]: T[K] }> {
+  const list = tasks as ReadonlyArray<() => Promise<unknown>>;
+  if (list.length === 0) return [] as { -readonly [K in keyof T]: T[K] };
+
+  const results: unknown[] = new Array(list.length);
+  let next = 0;
+
+  async function worker() {
+    for (;;) {
+      const index = next;
+      next += 1;
+      if (index >= list.length) return;
+      results[index] = await list[index]();
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, list.length) }, () => worker());
+  await Promise.all(workers);
+  return results as { -readonly [K in keyof T]: T[K] };
+}

--- a/src/hooks/queries/useAdminPulse.ts
+++ b/src/hooks/queries/useAdminPulse.ts
@@ -8,13 +8,28 @@ const API_BASE =
     ? String(import.meta.env.VITE_API_BASE_URL)
     : '';
 
+const ADMIN_FETCH_MS = 45_000;
+
 async function adminApiGet<T>(path: string): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, { credentials: 'include' });
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error((body as { error?: string }).error || `HTTP ${res.status}`);
+  try {
+    const res = await fetch(`${API_BASE}${path}`, {
+      credentials: 'include',
+      signal: AbortSignal.timeout(ADMIN_FETCH_MS),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error((body as { error?: string }).error || `HTTP ${res.status}`);
+    }
+    return res.json() as Promise<T>;
+  } catch (error) {
+    if (error instanceof DOMException && (error.name === 'TimeoutError' || error.name === 'AbortError')) {
+      throw new Error('Timed out waiting for Pulse. Try again in a few seconds.');
+    }
+    if (error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError')) {
+      throw new Error('Timed out waiting for Pulse. Try again in a few seconds.');
+    }
+    throw error;
   }
-  return res.json() as Promise<T>;
 }
 
 export type RankDelta = {
@@ -138,6 +153,7 @@ export function useAdminPulse(days = 7) {
     enabled: admin.isSuccess && admin.data?.isAdmin === true,
     staleTime: 0,
     gcTime: ADMIN_PULSE_STALE_MS,
+    retry: 1,
     refetchOnMount: 'always',
     refetchOnWindowFocus: true,
     refetchOnReconnect: true,

--- a/src/hooks/queries/useAdminUsage.ts
+++ b/src/hooks/queries/useAdminUsage.ts
@@ -7,13 +7,28 @@ const API_BASE =
     ? String(import.meta.env.VITE_API_BASE_URL)
     : '';
 
+const ADMIN_FETCH_MS = 45_000;
+
 async function adminApiGet<T>(path: string): Promise<T> {
-  const res = await fetch(`${API_BASE}${path}`, { credentials: 'include' });
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({}));
-    throw new Error((body as { error?: string }).error || `HTTP ${res.status}`);
+  try {
+    const res = await fetch(`${API_BASE}${path}`, {
+      credentials: 'include',
+      signal: AbortSignal.timeout(ADMIN_FETCH_MS),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error((body as { error?: string }).error || `HTTP ${res.status}`);
+    }
+    return res.json() as Promise<T>;
+  } catch (error) {
+    if (error instanceof DOMException && (error.name === 'TimeoutError' || error.name === 'AbortError')) {
+      throw new Error('Timed out waiting for Usage. Try again in a few seconds.');
+    }
+    if (error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError')) {
+      throw new Error('Timed out waiting for Usage. Try again in a few seconds.');
+    }
+    throw error;
   }
-  return res.json() as Promise<T>;
 }
 
 export type DiscoveryRankItem = { name: string; count: number };
@@ -105,6 +120,7 @@ const ADMIN_USAGE_STALE_MS = 30 * 60 * 1000;
 const adminUsageQueryOptions = {
   staleTime: ADMIN_USAGE_STALE_MS,
   gcTime: ADMIN_USAGE_STALE_MS,
+  retry: 1,
   refetchOnWindowFocus: false,
   refetchOnReconnect: false,
 } as const;


### PR DESCRIPTION
Pulse and Usage never came back after `/api` moved to Fly. Those two dashboards were opening every aggregation at once (`Promise.all` of ~20 COUNT DISTINCTs plus a full `NoteConnections` graph walk) against the **one** shared Postgres pool of ten.

On Netlify that only hurt the isolate serving that request. On Fly it pins the process: Pulse holds every connection until the slowest query finishes, the proxy never sees a first byte, and the tab sits on Loading… forever. React Query retries then stacked a second identical blast on the same pool.

What changed:

- **In-process cache** (60s TTL, in-flight coalescing, stale-while-revalidate) so Fly actually uses being always-on. A retry joins the compute already in flight.
- **Concurrency cap of 3** for Pulse and Usage overview instead of unbounded `Promise.all`.
- **Thread snapshot** no longer blocks the first load on `SELECT * FROM NoteConnections`. Cold cache waits 8s, then a cheap SQL stand-in; the graph walk continues in the background and the next request is accurate.
- **45s browser timeout** and `retry: 1` so a miss shows an error instead of an endless spinner. Clerk user-count is also capped at 2.5s so it cannot stall Usage.

After this ships: open Pulse once. If the first load still times out, wait a few seconds and retry — the first compute will have filled the cache.