### PR TITLE
fix(design): today's passage uses the new-note icon

### DIFF
--- a/spa/src/pages/prototype/PrototypeDailyPassagePill.tsx
+++ b/spa/src/pages/prototype/PrototypeDailyPassagePill.tsx
@@ -182,7 +182,7 @@ export default function PrototypeDailyPassagePill({
           you would come to this row at all, and putting the day's one invitation to study
           behind a menu is a tap charged for the thing the row exists to offer. The
           suggestion rows earn their menu because their answers differ by forever and need
-          words; these two are a plus and a cross, and mean what they look like. */}
+          words; these two are the new-note glyph and a cross, and mean what they look like. */}
       <PrototypeHomeRow
         icon="scroll"
         title={votd.reference}
@@ -199,9 +199,11 @@ export default function PrototypeDailyPassagePill({
                 title="View notes on this passage"
                 onClick={openScripturePassageNotes}
               >
-                {/* An eye for looking at what is there; the `plus` in the other branch is a
-                    create. Same pairing as the what's-new row, so "view" reads the same
-                    wherever it appears in a Home group. */}
+                {/* An eye for looking at what is there; the `pen-to-square` in the other
+                    branch is a create — the same glyph the toolbar's New note button wears,
+                    so "write a note" reads as one action wherever it appears. Not a plus:
+                    that is how this app draws "add an item to a list", and composing is not
+                    that. */}
                 <Icon name="eye" size={12} aria-hidden />
               </button>
             ) : (
@@ -212,7 +214,7 @@ export default function PrototypeDailyPassagePill({
                 title="Add passage to notes"
                 onClick={() => studyNow(votd)}
               >
-                <Icon name="plus" size={12} aria-hidden />
+                <Icon name="pen-to-square" size={12} aria-hidden />
               </button>
             )}
             <button

--- a/spa/src/pages/prototype/__tests__/daily-passage-add-note-icon.test.ts
+++ b/spa/src/pages/prototype/__tests__/daily-passage-add-note-icon.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Today's passage "make a note" control wears the same glyph as New note.
+ *
+ * The trailing slot used a plus, which is how every other "add something" control in the
+ * app draws itself — add a person, add a gathering, add a space. Making a note is not
+ * adding an item to a list; it is composing, and the toolbar already has a glyph for that.
+ *
+ * Source-inspected because the seam is JSX, not a value. The regression this exists for is
+ * the plus coming back, which would look correct in isolation and wrong next to the
+ * toolbar's New note button.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+
+function addNoteBranch(): string {
+  const file = source('spa/src/pages/prototype/PrototypeDailyPassagePill.tsx');
+  const start = file.indexOf('aria-label="Add passage to notes"');
+  expect(start).toBeGreaterThan(-1);
+  return file.slice(start, start + 400);
+}
+
+describe("today's passage add-note glyph", () => {
+  it('uses the same icon the toolbar uses for New note', () => {
+    const branch = addNoteBranch();
+    expect(branch).toContain('name="pen-to-square"');
+    expect(branch).not.toContain('name="plus"');
+  });
+
+  it('is the glyph ShellModeSegmented draws for compose', () => {
+    const toolbar = source('spa/src/pages/prototype/ShellModeSegmented.tsx');
+    expect(toolbar).toContain('<Icon name="pen-to-square"');
+  });
+});


### PR DESCRIPTION
## Summary
- The Today's passage row on Home/Activity offered a plus for starting a note from the day's passage. Plus is how this app draws "add an item to a list" (a person, a gathering, a space). Composing a note already has a glyph: the toolbar's New note button, `pen-to-square`.
- That trailing control now wears `pen-to-square`, so "write a note" reads as one action next to the toolbar.

## Test plan
- [x] Source-contract test asserts the add-note branch uses `pen-to-square` (not `plus`) and that it is the same glyph `ShellModeSegmented` draws for compose.
- [ ] On Home or Activity, with today's passage still undismissed and no note yet: the trailing control is the compose glyph, not a plus. Tap still opens compose seeded with the passage. Once a note exists, the eye is unchanged.