### PR TITLE
Review: unique sittings, not five of the same question

### DIFF
--- a/server/routes/review.ts
+++ b/server/routes/review.ts
@@ -107,7 +107,16 @@ route.get('/api/review/inbox', requireAuth, rateLimit('read'), requireFeature('r
       now,
     );
     const askable = await filterAskableReviewRows(auth.userId, due, { dropUnaskable: true });
-    const built = await buildReviewItemViews(auth.userId, askable, { dropUnaskable: true });
+    /*
+     * Same order the sitting uses. Activity was showing dueAt order, so a handful queued
+     * together (three verses of one chapter, all "pick how it begins") looked like a quiz
+     * even though the session would have mixed them.
+     */
+    const ordered = interleaveSession(
+      askable.map((row) => ({ ...row, groupKey: sessionGroupKeyFor(row) })),
+      now,
+    );
+    const built = await buildReviewItemViews(auth.userId, ordered, { dropUnaskable: true });
     const items = built.slice(0, REVIEW_INBOX_MAX_ROWS);
 
     /*

--- a/server/utils/review-opportunities.ts
+++ b/server/utils/review-opportunities.ts
@@ -46,6 +46,7 @@ import {
   verseReferenceLabel,
   type NodeKind,
 } from '@/utils/study-bible-nodes';
+import { openingLadderStep } from '@/utils/review-prompts';
 import { createReviewItem, noteHasReviewableMaterial, type ReviewItemRow } from './review-service';
 import {
   isUserNodeStatesTableMissing,
@@ -347,6 +348,7 @@ export async function refillReviewQueue(
     });
 
     const created: ReviewItemRow[] = [];
+    const addedOfKind: Record<string, number> = { verse: 0, note: 0, chapter: 0 };
     for (const pick of picks) {
       if (created.length >= room) break;
       const kind = REVIEW_KIND_FOR_NODE[pick.nodeKind];
@@ -390,10 +392,15 @@ export async function refillReviewQueue(
           // Copied, not read live, so a row's stated reason never changes mid-sitting.
           sourceLabel: pick.lastSourceLabel,
           sourceAt: pick.lastSourceAt,
+          // A handful of new verses must not all open on "pick how it begins".
+          ladderStep: openingLadderStep(kind, addedOfKind[kind] ?? 0),
         },
         now,
       );
-      if ('item' in result && result.created) created.push(result.item);
+      if ('item' in result && result.created) {
+        created.push(result.item);
+        addedOfKind[kind] = (addedOfKind[kind] ?? 0) + 1;
+      }
     }
 
     return created;

--- a/server/utils/review-service.ts
+++ b/server/utils/review-service.ts
@@ -1116,6 +1116,11 @@ export interface CreateReviewItemInput {
   /** Engine only: why this is here, in the reader's words. See study-bible-source-copy.ts. */
   sourceLabel?: string | null;
   sourceAt?: Date | null;
+  /**
+   * Opening rung. Engine sittings stagger this so five new verses are not the same exercise.
+   * User-added items omit it and start at 0.
+   */
+  ladderStep?: number;
 }
 
 export function reviewSourceKey(input: {
@@ -1287,7 +1292,7 @@ export async function createReviewItem(
         dueAt: firstDueAtFor(input.kind, input.origin ?? 'user', now),
         successStreak: 0,
         reviewCount: 0,
-        ladderStep: 0,
+        ladderStep: Number.isFinite(input.ladderStep) ? Math.max(0, Math.trunc(input.ladderStep!)) : 0,
         origin: input.origin ?? 'user',
         challengeId: input.challengeId ?? null,
         sourceLabel: input.sourceLabel?.trim() || null,

--- a/server/utils/review-service.ts
+++ b/server/utils/review-service.ts
@@ -654,7 +654,11 @@ async function threadTitleFor(userId: string, repNoteId: string): Promise<string
  */
 function noteRungFor(row: ReviewItemRow, material: Map<string, NoteMaterial>) {
   if (row.kind !== 'note' || !row.noteId) return null;
-  return resolveNoteRung(row.ladderStep, material.get(row.noteId) ?? EMPTY_NOTE_MATERIAL);
+  return resolveNoteRung(
+    row.ladderStep,
+    material.get(row.noteId) ?? EMPTY_NOTE_MATERIAL,
+    `${row.id}:${row.ladderStep}`,
+  );
 }
 
 /**
@@ -2777,7 +2781,7 @@ async function buildNoteExercise(
 
   const material = (await loadNoteMaterial(userId, [item.noteId])).get(item.noteId);
   if (!material) return null;
-  const rung = resolveNoteRung(item.ladderStep, material);
+  const rung = resolveNoteRung(item.ladderStep, material, `${item.id}:${item.ladderStep}`);
   if (!rung) return null;
 
   const seed = `${item.id}:${item.ladderStep}`;

--- a/src/utils/__tests__/note-ladder-exercises.test.ts
+++ b/src/utils/__tests__/note-ladder-exercises.test.ts
@@ -54,6 +54,15 @@ describe('resolveNoteRung', () => {
     expect(resolveNoteRung(99, ALL)).toBeTruthy();
     expect(resolveNoteRung(Number.NaN, ALL)).toBe('note.recognize');
   });
+
+  it('spreads notes on the same step across different questions', () => {
+    const keys = ['n1', 'n2', 'n3', 'n4', 'n5', 'n6', 'n7', 'n8'].map((id) =>
+      resolveNoteRung(0, ALL, `${id}:0`),
+    );
+    expect(new Set(keys).size).toBeGreaterThan(1);
+    // Same seed, same question — list, reveal and grader must agree.
+    expect(resolveNoteRung(0, ALL, 'n1:0')).toBe(resolveNoteRung(0, ALL, 'n1:0'));
+  });
 });
 
 describe('noteFragment', () => {

--- a/src/utils/__tests__/review-opportunity-scoring.test.ts
+++ b/src/utils/__tests__/review-opportunity-scoring.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   ENGINE_PER_KIND_CAP,
+  ENGINE_PER_CHAPTER_CAP,
+  ENGINE_PER_BOOK_CAP,
   NOTE_MEANING_WEIGHT_FLOOR,
   ENGINE_MIN_CHAPTER_AGE_DAYS,
   ENGINE_MIN_NODE_AGE_DAYS,
@@ -132,9 +134,9 @@ describe('selectReviewBatch', () => {
   it('mixes kinds rather than offering three of the same shape', () => {
     const candidates = [
       verse(nodeKey.verse({ book: 'John', chapter: 15, verse: 1 })),
-      verse(nodeKey.verse({ book: 'John', chapter: 15, verse: 2 })),
-      verse(nodeKey.verse({ book: 'John', chapter: 15, verse: 3 })),
-      verse(nodeKey.verse({ book: 'John', chapter: 15, verse: 4 })),
+      verse(nodeKey.verse({ book: 'Romans', chapter: 8, verse: 1 })),
+      verse(nodeKey.verse({ book: 'Psalms', chapter: 23, verse: 1 })),
+      verse(nodeKey.verse({ book: 'Genesis', chapter: 1, verse: 1 })),
       node({ nodeKind: 'note', nodeKey: nodeKey.note('n1'), noteId: 'n1' }),
     ];
     const picked = selectReviewBatch(candidates, {
@@ -184,13 +186,63 @@ describe('selectReviewBatch', () => {
   it('picks the same rows twice over the same data', () => {
     const candidates = [
       verse(nodeKey.verse({ book: 'John', chapter: 15, verse: 1 })),
-      verse(nodeKey.verse({ book: 'John', chapter: 15, verse: 2 })),
+      verse(nodeKey.verse({ book: 'Romans', chapter: 8, verse: 1 })),
       node({ nodeKind: 'note', nodeKey: nodeKey.note('n1'), noteId: 'n1' }),
       node({ nodeKind: 'note', nodeKey: nodeKey.note('n2'), noteId: 'n2' }),
     ];
     const first = selectReviewBatch(candidates, { now: NOW, existingSourceKeys: emptyKeys });
     const second = selectReviewBatch([...candidates].reverse(), { now: NOW, existingSourceKeys: emptyKeys });
     expect(first.map((n) => n.nodeKey)).toEqual(second.map((n) => n.nodeKey));
+  });
+
+  it('never offers two verses from the same chapter', () => {
+    const candidates = [
+      verse(nodeKey.verse({ book: 'John', chapter: 3, verse: 16 })),
+      verse(nodeKey.verse({ book: 'John', chapter: 3, verse: 17 })),
+      verse(nodeKey.verse({ book: 'John', chapter: 3, verse: 18 })),
+      verse(nodeKey.verse({ book: 'Romans', chapter: 8, verse: 28 })),
+    ];
+    const picked = selectReviewBatch(candidates, { now: NOW, existingSourceKeys: emptyKeys });
+    const john3 = picked.filter((p) => p.nodeKey.includes('John') && p.nodeKey.includes('|3|'));
+    expect(john3).toHaveLength(ENGINE_PER_CHAPTER_CAP);
+    expect(picked.some((p) => p.nodeKey === nodeKey.verse({ book: 'Romans', chapter: 8, verse: 28 }))).toBe(true);
+  });
+
+  it('does not pair a chapter with a verse from it', () => {
+    const john3 = nodeKey.chapter({ book: 'John', chapter: 3 });
+    const candidates = [
+      node({
+        nodeKind: 'chapter',
+        nodeKey: john3,
+        revisitCount: 2,
+        exposureCount: 0,
+        firstStudiedAt: daysAgo(10),
+        lastSeenAt: daysAgo(3),
+      }),
+      verse(nodeKey.verse({ book: 'John', chapter: 3, verse: 16 })),
+      verse(nodeKey.verse({ book: 'Romans', chapter: 8, verse: 28 })),
+    ];
+    const picked = selectReviewBatch(candidates, { now: NOW, existingSourceKeys: emptyKeys });
+    const fromJohn3 = picked.filter(
+      (p) => p.nodeKey === john3 || p.nodeKey === nodeKey.verse({ book: 'John', chapter: 3, verse: 16 }),
+    );
+    expect(fromJohn3).toHaveLength(1);
+    expect(picked.some((p) => p.nodeKey === nodeKey.verse({ book: 'Romans', chapter: 8, verse: 28 }))).toBe(true);
+  });
+
+  it('caps a book at two passages', () => {
+    const candidates = [
+      verse(nodeKey.verse({ book: 'John', chapter: 1, verse: 1 })),
+      verse(nodeKey.verse({ book: 'John', chapter: 3, verse: 16 })),
+      verse(nodeKey.verse({ book: 'John', chapter: 15, verse: 5 })),
+      verse(nodeKey.verse({ book: 'Romans', chapter: 8, verse: 28 })),
+    ];
+    const picked = selectReviewBatch(candidates, { now: NOW, existingSourceKeys: emptyKeys });
+    const john = picked.filter((p) => p.nodeKey.startsWith('verse:John|') || p.nodeKey.startsWith('verse:john|'));
+    // nodeKey.verse uses the book as given
+    const johnActual = picked.filter((p) => p.nodeKey.includes('John'));
+    expect(johnActual.length).toBeLessThanOrEqual(ENGINE_PER_BOOK_CAP);
+    expect(picked.some((p) => p.nodeKey.includes('Romans'))).toBe(true);
   });
 });
 

--- a/src/utils/__tests__/review-prompts.test.ts
+++ b/src/utils/__tests__/review-prompts.test.ts
@@ -537,8 +537,8 @@ describe('openingLadderStep', () => {
     expect(openingLadderStep('verse', 3)).toBe(0);
   });
 
-  it('never opens a note off the first rung', () => {
-    expect(openingLadderStep('note', 0)).toBe(0);
+  it('walks new notes across recognize, passage, connect, annotation', () => {
+    expect([0, 1, 2, 3].map((n) => openingLadderStep('note', n))).toEqual([0, 1, 2, 3]);
     expect(openingLadderStep('note', 4)).toBe(0);
   });
 

--- a/src/utils/__tests__/review-prompts.test.ts
+++ b/src/utils/__tests__/review-prompts.test.ts
@@ -14,6 +14,8 @@ import {
   pickPromptKey,
   reviewPromptFor,
   VERSE_NEXT_STEP,
+  openingLadderStep,
+  VERSE_OPENING_STEPS,
   reviewRungIsGraded,
   VERSE_SEQUENCE_STEP,
   VERSE_LOCATE_STEP,
@@ -525,5 +527,24 @@ describe('a family with two members draws both', () => {
     expect(chapterRungFor(2, 'review_x:2', chapterMaterial)).toEqual(
       chapterRungFor(2, 'review_x:2', chapterMaterial),
     );
+  });
+});
+
+describe('openingLadderStep', () => {
+  it('staggers new verses across recognize, rebuild, and next', () => {
+    expect(VERSE_OPENING_STEPS).toEqual([0, 1, 3]);
+    expect([0, 1, 2].map((n) => openingLadderStep('verse', n))).toEqual([0, 1, 3]);
+    expect(openingLadderStep('verse', 3)).toBe(0);
+  });
+
+  it('never opens a note off the first rung', () => {
+    expect(openingLadderStep('note', 0)).toBe(0);
+    expect(openingLadderStep('note', 4)).toBe(0);
+  });
+
+  it('alternates chapter openings between verse-in-it and finish', () => {
+    expect(openingLadderStep('chapter', 0)).toBe(0);
+    expect(openingLadderStep('chapter', 1)).toBe(1);
+    expect(openingLadderStep('chapter', 2)).toBe(0);
   });
 });

--- a/src/utils/__tests__/review-row-subtitle.test.ts
+++ b/src/utils/__tests__/review-row-subtitle.test.ts
@@ -188,11 +188,43 @@ describe('reviewRowSubject', () => {
     expect(
       reviewRowSubject({
         prompt: 'x',
+        kind: 'note',
+        noteLabel: 'Adoption',
+        ladderStep: 0,
+        promptKey: 'note.recognize',
+      }),
+    ).toBe('One of your notes');
+    expect(
+      reviewRowSubject({
+        prompt: 'x',
         kind: 'verse',
         scriptureReference: 'John 15:5',
         ladderStep: VERSE_LOCATE_STEP,
       }),
     ).toBe('One of your passages');
+  });
+
+  it('names the note when the resolved rung is not recognize', () => {
+    // Step 0 with a walked-forward prompt used to hide the name too, so "Pick a passage
+    // you cited" sat under "One of your notes" five times in a row.
+    expect(
+      reviewRowSubject({
+        prompt: 'x',
+        kind: 'note',
+        noteLabel: 'Adoption, not slavery',
+        ladderStep: 0,
+        promptKey: 'note.passage',
+      }),
+    ).toBe('Adoption, not slavery');
+    expect(
+      reviewRowSubject({
+        prompt: 'x',
+        kind: 'note',
+        noteLabel: 'Romans 8:15',
+        ladderStep: 0,
+        promptKey: 'note.connect',
+      }),
+    ).toBe('Romans 8:15');
   });
 
   it('falls back to when it was written, and never to nothing', () => {

--- a/src/utils/__tests__/review-session-order.test.ts
+++ b/src/utils/__tests__/review-session-order.test.ts
@@ -91,3 +91,14 @@ describe('sessionGroupKeyFor', () => {
     expect(sessionGroupKeyFor({})).toBeNull();
   });
 });
+
+describe('rung shape', () => {
+  it('prefers a different exercise when two of the same kind are waiting', () => {
+    const items = [
+      { ...item('a', 'verse', 'john 3', 1), ladderStep: 0 },
+      { ...item('b', 'verse', 'romans 8', 1), ladderStep: 0 },
+      { ...item('c', 'verse', 'psalm 23', 1), ladderStep: 1 },
+    ];
+    expect(ids(interleaveSession(items, NOW))).toEqual(['a', 'c', 'b']);
+  });
+});

--- a/src/utils/note-ladder-exercises.ts
+++ b/src/utils/note-ladder-exercises.ts
@@ -21,7 +21,7 @@
  */
 
 import { buildChoiceExercise, gradeChoiceExercise, type ChoiceExercise } from '@/utils/choice-exercise';
-import { hashSeed, mulberry32 } from '@/utils/verse-cloze';
+import { hashSeed, mulberry32, seededIndex } from '@/utils/verse-cloze';
 import type { ReviewPromptKey } from '@/utils/review-prompts';
 import { NOTE_LADDER } from '@/utils/review-prompts';
 
@@ -48,7 +48,11 @@ export interface NoteMaterial {
  * `review-opportunities.ts`. A note with no body, no passages and no links is not yet
  * reviewable, and inventing a question for it would mean inventing the answer too.
  */
-export function resolveNoteRung(step: number, material: NoteMaterial): ReviewPromptKey | null {
+export function resolveNoteRung(
+  step: number,
+  material: NoteMaterial,
+  seed?: string,
+): ReviewPromptKey | null {
   const can: Record<ReviewPromptKey, boolean> = {
     'note.recognize': material.canRecognize,
     'note.passage': material.canPassage,
@@ -56,7 +60,15 @@ export function resolveNoteRung(step: number, material: NoteMaterial): ReviewPro
     'note.annotation': material.canAnnotation,
   } as Record<ReviewPromptKey, boolean>;
 
-  const start = Number.isFinite(step) ? Math.max(0, Math.trunc(step)) % NOTE_LADDER.length : 0;
+  const nominal = Number.isFinite(step) ? Math.max(0, Math.trunc(step)) : 0;
+  /*
+   * A seed rotates the walk so five notes on step 0 are not five "which note is this?".
+   * The same seed must be passed from the list, the reveal and the grader — `${id}:${step}`.
+   * Without a seed this is the old walk, so callers that only care whether *anything* can
+   * be asked (the reviewable-material probe) do not change.
+   */
+  const offset = seed ? seededIndex(seed, NOTE_LADDER.length) : 0;
+  const start = (nominal + offset) % NOTE_LADDER.length;
   for (let i = 0; i < NOTE_LADDER.length; i++) {
     const key = NOTE_LADDER[(start + i) % NOTE_LADDER.length];
     if (can[key]) return key;

--- a/src/utils/review-opportunity-scoring.ts
+++ b/src/utils/review-opportunity-scoring.ts
@@ -26,11 +26,16 @@ import {
   forgettingAwarePriority,
 } from '@/utils/prototype-home-trends';
 import {
+  chapterKeyPartsFromNodeKey,
+  chapterReferenceLabel,
   reviewSourceKeyForNode,
+  verseKeyPartsFromNodeKey,
+  verseReferenceLabel,
   type NodeKind,
   type NodeSignal,
 } from '@/utils/study-bible-nodes';
 import { REVIEW_ENGINE_DAILY_CAP } from '@/utils/review-item-kinds';
+import { sessionGroupKeyFor } from '@/utils/review-session-order';
 
 /** The shape the engine needs from a UserNodeStates row. */
 export interface ReviewCandidateNode {
@@ -77,6 +82,18 @@ export const ENGINE_NODE_KINDS: readonly NodeKind[] = ['verse', 'note', 'chapter
 
 /** At most three of one kind in a handful, so a sitting can mix without being five of the same. */
 export const ENGINE_PER_KIND_CAP = 3;
+
+/**
+ * At most one question about a given chapter — verse or the chapter itself.
+ *
+ * John 3:16 then John 3:17 then "what's in John 3" is one memory, asked three ways, and the
+ * sitting feels like a quiz on the last answer. The session interleaver can only rearrange
+ * that; it cannot drop it. So the engine never queues the second one.
+ */
+export const ENGINE_PER_CHAPTER_CAP = 1;
+
+/** Two passages from one book is a theme. A third is a quiz on that book. */
+export const ENGINE_PER_BOOK_CAP = 2;
 
 /**
  * Nothing seen in the last day is asked about.
@@ -499,6 +516,27 @@ export interface SelectReviewBatchOptions {
   signalContext?: CommittedSignalContext;
 }
 
+
+/**
+ * What a candidate is *about*, matching `sessionGroupKeyFor` so the engine and the sitting
+ * agree. A verse and its chapter collapse to one key ("john 3"); a note is itself.
+ */
+export function candidateGroupKey(node: ReviewCandidateNode): string | null {
+  const verse = verseKeyPartsFromNodeKey(node.nodeKey);
+  if (verse) return sessionGroupKeyFor({ scriptureReference: verseReferenceLabel(verse) });
+  const chapter = chapterKeyPartsFromNodeKey(node.nodeKey);
+  if (chapter) return sessionGroupKeyFor({ scriptureReference: chapterReferenceLabel(chapter) });
+  return node.noteId ?? null;
+}
+
+function candidateBook(node: ReviewCandidateNode): string | null {
+  const verse = verseKeyPartsFromNodeKey(node.nodeKey);
+  if (verse) return verse.book.trim().toLowerCase();
+  const chapter = chapterKeyPartsFromNodeKey(node.nodeKey);
+  if (chapter) return chapter.book.trim().toLowerCase();
+  return null;
+}
+
 /**
  * Choose what to add, deterministically.
  *
@@ -542,12 +580,22 @@ export function selectReviewBatch(
 
   const picked: ReviewCandidateNode[] = [];
   const perKind = new Map<NodeKind, number>();
+  const perChapter = new Map<string, number>();
+  const perBook = new Map<string, number>();
 
   for (const { node } of scored) {
     if (picked.length >= limit) break;
     const used = perKind.get(node.nodeKind) ?? 0;
     if (used >= perKindCap) continue;
+    const chapter = candidateGroupKey(node);
+    if (chapter && node.nodeKind !== 'note' && (perChapter.get(chapter) ?? 0) >= ENGINE_PER_CHAPTER_CAP) {
+      continue;
+    }
+    const book = candidateBook(node);
+    if (book && (perBook.get(book) ?? 0) >= ENGINE_PER_BOOK_CAP) continue;
     perKind.set(node.nodeKind, used + 1);
+    if (chapter && node.nodeKind !== 'note') perChapter.set(chapter, (perChapter.get(chapter) ?? 0) + 1);
+    if (book) perBook.set(book, (perBook.get(book) ?? 0) + 1);
     picked.push(node);
   }
 

--- a/src/utils/review-prompts.ts
+++ b/src/utils/review-prompts.ts
@@ -309,16 +309,18 @@ export const VERSE_LADDER_MAX_STEP = VERSE_LADDER.length - 1;
  * "pick how it begins".
  *
  * Recognize, rebuild (blanks), then next/before. Never recall or locate on a first asking —
- * those are how a verse is kept, not how it is met. Notes stay on step 0: the note resolver
- * already picks among recognize / passage / connect from the note's own material.
+ * those are how a verse is kept, not how it is met.
+ *
+ * Notes walk the four rungs so a handful of new notes is not five "pick the note this is from".
  */
 export const VERSE_OPENING_STEPS = [0, 1, 3] as const;
 export const CHAPTER_OPENING_STEPS = [0, 1] as const;
+export const NOTE_OPENING_STEPS = [0, 1, 2, 3] as const;
 
 export function openingLadderStep(kind: 'verse' | 'note' | 'chapter', alreadyOfKind: number): number {
   if (kind === 'verse') return VERSE_OPENING_STEPS[alreadyOfKind % VERSE_OPENING_STEPS.length];
   if (kind === 'chapter') return CHAPTER_OPENING_STEPS[alreadyOfKind % CHAPTER_OPENING_STEPS.length];
-  return 0;
+  return NOTE_OPENING_STEPS[alreadyOfKind % NOTE_OPENING_STEPS.length];
 }
 
 /**

--- a/src/utils/review-prompts.ts
+++ b/src/utils/review-prompts.ts
@@ -305,6 +305,23 @@ export const VERSE_LADDER: readonly ReviewPromptKey[] = [
 export const VERSE_LADDER_MAX_STEP = VERSE_LADDER.length - 1;
 
 /**
+ * First-sitting rungs the engine may open on, so a handful of new verses is not five
+ * "pick how it begins".
+ *
+ * Recognize, rebuild (blanks), then next/before. Never recall or locate on a first asking —
+ * those are how a verse is kept, not how it is met. Notes stay on step 0: the note resolver
+ * already picks among recognize / passage / connect from the note's own material.
+ */
+export const VERSE_OPENING_STEPS = [0, 1, 3] as const;
+export const CHAPTER_OPENING_STEPS = [0, 1] as const;
+
+export function openingLadderStep(kind: 'verse' | 'note' | 'chapter', alreadyOfKind: number): number {
+  if (kind === 'verse') return VERSE_OPENING_STEPS[alreadyOfKind % VERSE_OPENING_STEPS.length];
+  if (kind === 'chapter') return CHAPTER_OPENING_STEPS[alreadyOfKind % CHAPTER_OPENING_STEPS.length];
+  return 0;
+}
+
+/**
  * What a verse is asked once it has climbed the whole ladder.
  *
  * Without this the top rung is terminal: a verse someone has worked all the way up asks "where

--- a/src/utils/review-row-subtitle.ts
+++ b/src/utils/review-row-subtitle.ts
@@ -35,6 +35,8 @@ export interface ReviewRowSubtitleInput {
   /** Needed to know whether this row's question is one with a right answer. */
   kind?: string | null;
   ladderStep?: number | null;
+  /** The resolved rung. A step alone can only name the family default. */
+  promptKey?: string | null;
   /** Server-resolved: title, else the note's opening line, else the passage it cites. */
   noteLabel?: string | null;
   /** The note's own opening words. Preferred over everything else — it is the context line. */
@@ -193,7 +195,12 @@ export function rungIdentityIsTheAnswer(item: {
   promptKey?: string | null;
 }): boolean {
   // "Which of your notes says this?" — the note's identity is the whole answer.
-  if (item.kind === 'note') return item.ladderStep === NOTE_RECOGNIZE_STEP;
+  // The resolved prompt wins: a note still on step 0 may be asked a passage or a
+  // link instead, and hiding its name there left a shelf of identical rows.
+  if (item.kind === 'note') {
+    if (item.promptKey) return item.promptKey === 'note.recognize';
+    return item.ladderStep === NOTE_RECOGNIZE_STEP;
+  }
   // A chapter is named in every one of its prompts and is never the answer to any of them.
   if (item.kind !== 'verse') return false;
   // "Where is this from?" — so is the reference. The server's resolved rung wins: with families a

--- a/src/utils/review-session-order.ts
+++ b/src/utils/review-session-order.ts
@@ -38,6 +38,8 @@ export interface SessionOrderInput {
   groupKey: string | null;
   dueAt: Date;
   reviewCount: number;
+  /** Rung family. Prefer not to ask the same shape twice in a row when other work is waiting. */
+  ladderStep?: number;
 }
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -70,7 +72,9 @@ function drain<T extends SessionOrderInput>(bucket: T[], out: T[]): void {
     const last = out[out.length - 1];
     const pick =
       (last &&
-        (pending.find((c) => c.kind !== last.kind && !sameSubject(c, last)) ??
+        (pending.find((c) => c.kind !== last.kind && !sameSubject(c, last) && !sameRung(c, last)) ??
+          pending.find((c) => c.kind !== last.kind && !sameSubject(c, last)) ??
+          pending.find((c) => !sameSubject(c, last) && !sameRung(c, last)) ??
           pending.find((c) => !sameSubject(c, last)))) ??
       pending[0];
     pending.splice(pending.indexOf(pick), 1);
@@ -80,6 +84,10 @@ function drain<T extends SessionOrderInput>(bucket: T[], out: T[]): void {
 
 function sameSubject(a: SessionOrderInput, b: SessionOrderInput): boolean {
   return Boolean(a.groupKey) && a.groupKey === b.groupKey;
+}
+
+function sameRung(a: SessionOrderInput, b: SessionOrderInput): boolean {
+  return (a.ladderStep ?? 0) === (b.ladderStep ?? 0);
 }
 
 export function interleaveSession<T extends SessionOrderInput>(items: T[], now: Date = new Date()): T[] {


### PR DESCRIPTION
Follow-up to #106. Volume is fixed; this is the uniqueness of a sitting — so Review feels like distinct memory work, not five copies of “One of your notes.”

Hand-authored prompts and the verse ladder stay. What changes is *which* items enter the queue, *how* a handful is ordered, and *how a note is named* on the row.

## What you saw

Five expanded rows, all titled “One of your notes,” alternating two tasks. They were all still on ladder step 0. The row hides the name whenever step is 0, even when the question had already walked forward to “pick a passage you cited.”

## What changed

**Neighborhood (engine)**
- At most **one** item about a given chapter (a verse and its chapter are the same subject)
- At most **two** passages from the same book

**Opening rungs**
- New verses open on recognize → rebuild → next
- New notes walk recognize → passage → connect → annotation

**Notes already in the queue**
- Hide the name only when the resolved prompt is `note.recognize` (the name *is* the answer there)
- Seed the note-rung walk so five notes on step 0 get different questions. List, reveal and grader share the same seed.

**Sitting order**
- Activity inbox uses the same interleave as the session
- Prefers a different rung shape when both are waiting

## After merge

Hard-refresh Review. Expect mixed tasks, and rows that are not recognize to lead with the note’s title, opening line, or cited passage — not “One of your notes” five times.