### PR TITLE
Review: named stems, mixed halves, close wrong answers

### DIFF
--- a/server/routes/__tests__/review-routes.test.ts
+++ b/server/routes/__tests__/review-routes.test.ts
@@ -646,11 +646,13 @@ describe('a scheduler that remembers', () => {
   it('orders the sitting rather than serving it by the clock', () => {
     const session = route().slice(route().indexOf("'/api/review/session'"));
     const listAt = session.indexOf('listDueReviewItems');
-    const orderAt = session.indexOf('interleaveSession');
+    const orderAt = session.indexOf('composeSitting');
     expect(orderAt).toBeGreaterThan(-1);
+    expect(session).toContain('listUpcomingReviewItems');
     // Ordered before the views are built, so what is dropped as unaskable does not reshuffle it.
     expect(orderAt).toBeLessThan(session.indexOf('buildReviewItemViews'));
-    expect(listAt).toBeGreaterThan(orderAt);
+    expect(listAt).toBeGreaterThan(-1);
+    expect(listAt).toBeLessThan(orderAt);
   });
 });
 

--- a/server/routes/review.ts
+++ b/server/routes/review.ts
@@ -11,7 +11,7 @@
  */
 
 import { reviewRungIsGraded } from '@/utils/review-prompts';
-import { interleaveSession, sessionGroupKeyFor } from '@/utils/review-session-order';
+import { composeSitting, sessionGroupKeyFor } from '@/utils/review-session-order';
 import { Hono } from 'hono';
 import { getAuthenticatedAuth, requireAuth } from '../middleware/auth';
 import { requireFeature } from '../middleware/require-feature';
@@ -43,6 +43,7 @@ import {
   deferReviewItem,
   getReviewItem,
   listDueReviewItems,
+  listUpcomingReviewItems,
   listReviewItems,
   nextScheduledReviewAt,
   recordReviewEvent,
@@ -101,23 +102,32 @@ route.get('/api/review/inbox', requireAuth, rateLimit('read'), requireFeature('r
      * production. The slack listed beyond the three rows exists precisely so a late drop costs a
      * row from the tail rather than from what is shown, and cutting first threw that away.
      */
-    const due = await listDueReviewItems(
-      auth.userId,
-      REVIEW_INBOX_MAX_ROWS + 1 + REVIEW_INBOX_UNASKABLE_SLACK,
-      now,
-    );
-    const askable = await filterAskableReviewRows(auth.userId, due, { dropUnaskable: true });
+    const dueLimit = REVIEW_INBOX_MAX_ROWS + 1 + REVIEW_INBOX_UNASKABLE_SLACK;
+    const [due, upcoming] = await Promise.all([
+      listDueReviewItems(auth.userId, dueLimit, now),
+      listUpcomingReviewItems(auth.userId, REVIEW_INBOX_MAX_ROWS, now),
+    ]);
+    const [askableDue, askableUpcoming] = await Promise.all([
+      filterAskableReviewRows(auth.userId, due, { dropUnaskable: true }),
+      filterAskableReviewRows(auth.userId, upcoming, { dropUnaskable: true }),
+    ]);
+    const withKey = <T extends { scriptureReference?: string | null; noteId?: string | null }>(row: T) => ({
+      ...row,
+      groupKey: sessionGroupKeyFor(row),
+    });
     /*
-     * Same order the sitting uses. Activity was showing dueAt order, so a handful queued
-     * together (three verses of one chapter, all "pick how it begins") looked like a quiz
-     * even though the session would have mixed them.
+     * Mix the two halves of a sitting. Five due notes with verses coming back tomorrow used
+     * to render as five copies of the same card; the verses sat in "coming back later".
      */
-    const ordered = interleaveSession(
-      askable.map((row) => ({ ...row, groupKey: sessionGroupKeyFor(row) })),
+    const ordered = composeSitting(
+      askableDue.map(withKey),
+      askableUpcoming.map(withKey),
+      REVIEW_INBOX_MAX_ROWS,
       now,
     );
     const built = await buildReviewItemViews(auth.userId, ordered, { dropUnaskable: true });
     const items = built.slice(0, REVIEW_INBOX_MAX_ROWS);
+    const shownIds = new Set(items.map((item) => item.id));
 
     /*
      * Why there is nothing, when there is nothing.
@@ -135,7 +145,7 @@ route.get('/api/review/inbox', requireAuth, rateLimit('read'), requireFeature('r
       items,
       /* `built`, not `askable`: the build applies one drop rule the filter cannot, so the count
          that answers "is there more" has to be the built one. See the note above the cut. */
-      hasMore: built.length > REVIEW_INBOX_MAX_ROWS,
+      hasMore: askableDue.some((row) => !shownIds.has(row.id)) || due.length >= dueLimit,
       coldStart: coldStart
         ? { ready: coldStart.ready, needed: coldStart.needed, opensAt: coldStart.opensAt?.toISOString() ?? null }
         : null,
@@ -202,12 +212,25 @@ route.get('/api/review/items', requireAuth, rateLimit('read'), requireFeature('r
 route.get('/api/review/session', requireAuth, rateLimit('read'), requireFeature('review'), async (c) => {
   try {
     const auth = getAuthenticatedAuth(c);
-    await refillReviewQueue(auth.userId);
-    const rows = interleaveSession(
-      (await listDueReviewItems(auth.userId, REVIEW_SESSION_CAP)).map((row) => ({
-        ...row,
-        groupKey: sessionGroupKeyFor(row),
-      })),
+    const now = new Date();
+    await refillReviewQueue(auth.userId, now);
+    const [due, upcoming] = await Promise.all([
+      listDueReviewItems(auth.userId, REVIEW_SESSION_CAP + REVIEW_INBOX_UNASKABLE_SLACK, now),
+      listUpcomingReviewItems(auth.userId, REVIEW_SESSION_CAP, now),
+    ]);
+    const [askableDue, askableUpcoming] = await Promise.all([
+      filterAskableReviewRows(auth.userId, due, { dropUnaskable: true }),
+      filterAskableReviewRows(auth.userId, upcoming, { dropUnaskable: true }),
+    ]);
+    const withKey = <T extends { scriptureReference?: string | null; noteId?: string | null }>(row: T) => ({
+      ...row,
+      groupKey: sessionGroupKeyFor(row),
+    });
+    const rows = composeSitting(
+      askableDue.map(withKey),
+      askableUpcoming.map(withKey),
+      REVIEW_SESSION_CAP,
+      now,
     );
     const items = await buildReviewItemViews(auth.userId, rows, { dropUnaskable: true });
     /*

--- a/server/utils/review-service.ts
+++ b/server/utils/review-service.ts
@@ -135,6 +135,7 @@ import { collectStudyThreadGraph } from './study-thread-graph';
 import { fetchStudyThreadNoteRows } from './study-thread-note-rows';
 import { pickRepNoteIdForCluster } from './study-thread-cluster-count';
 import { formatVerseAddress, lastVerseOf, neighbourVerseAddresses, nextVerseAddress } from '@/utils/verse-adjacency';
+import { partitionByBook } from '@/utils/scripture-book';
 import {
   CROSSREF_MIN_VOTES,
   VERSE_THEME_MIN_RELEVANCE,
@@ -262,6 +263,11 @@ export interface ReviewItemView {
   /** Why this row is here, in the reader's words. Null on items they added themselves. */
   sourceLabel: string | null;
   sourceAt: string | null;
+  /**
+   * The stem, when the row cannot name the subject. A quoted line from the note, or a
+   * fragment of the verse. Null on every other rung — the title already says which thing it is.
+   */
+  cue: string | null;
 }
 
 /**
@@ -354,7 +360,7 @@ function displayTitle(title: string | null | undefined): string | null {
  */
 async function loadNoteLabelPool(
   userId: string,
-): Promise<{ distinguishing: string[]; byId: Map<string, string> }> {
+): Promise<{ distinguishing: string[]; byId: Map<string, string>; bookByLabel: Map<string, string> }> {
   const rows = await db
     .select({ id: Notes.id, title: Notes.title, createdAt: Notes.createdAt })
     .from(Notes)
@@ -371,15 +377,18 @@ async function loadNoteLabelPool(
 
   const distinguishing: string[] = [];
   const byId = new Map<string, string>();
+  const bookByLabel = new Map<string, string>();
   const seen = new Set<string>();
   for (const row of rows) {
+    const passage = resolved.get(row.id)?.passage ?? null;
     const { label, distinguishing: names } = noteOptionLabel({
       id: row.id,
       title: row.title,
       createdAt: row.createdAt,
-      passage: resolved.get(row.id)?.passage ?? null,
+      passage,
     });
     byId.set(row.id, label);
+    if (passage) bookByLabel.set(label.toLowerCase(), passage);
     if (!names) continue;
     const key = label.toLowerCase();
     // Two rows reading the same is one option, not two.
@@ -387,7 +396,7 @@ async function loadNoteLabelPool(
     seen.add(key);
     distinguishing.push(label);
   }
-  return { distinguishing, byId };
+  return { distinguishing, byId, bookByLabel };
 }
 
 /**
@@ -870,11 +879,28 @@ export async function buildReviewItemViews(
       const translation = row.translation ?? 'NET';
       if (row.kind === 'chapter') return [chapterMaterialFor(row.scriptureReference, translation)];
       if (row.kind !== 'verse') return [];
-      const warm: Promise<unknown>[] = [materialFor(row.scriptureReference, translation)];
-      if (row.ladderStep === 0) warm.push(fetchVerseText(row.scriptureReference, translation));
+      const warm: Promise<unknown>[] = [
+        materialFor(row.scriptureReference, translation),
+        fetchVerseText(row.scriptureReference, translation),
+      ];
       return warm;
     }),
   );
+
+  const recognizeNoteIds = [
+    ...new Set(
+      rows
+        .filter((row) => row.kind === 'note' && row.noteId && noteRungFor(row, material) === 'note.recognize')
+        .map((row) => row.noteId as string),
+    ),
+  ];
+  const recognizeBodies = recognizeNoteIds.length
+    ? await db
+        .select({ id: Notes.id, content: Notes.content, contentEncrypted: Notes.contentEncrypted })
+        .from(Notes)
+        .where(and(eq(Notes.userId, userId), inArray(Notes.id, recognizeNoteIds)))
+    : [];
+  const recognizeBodyById = new Map(recognizeBodies.map((row) => [row.id, row]));
 
   const views: ReviewItemView[] = [];
   for (const row of rows) {
@@ -957,6 +983,29 @@ export async function buildReviewItemViews(
     );
 
     const resolvedKey = noteRung ?? key;
+    /*
+     * When the name is the answer, the row leads with the stem instead of "One of your notes".
+     * A quoted line from the middle of the note, or a fragment of the verse — unique, and not
+     * a spoiler. Opening words are barred: they are the untitled note's option label.
+     */
+    let subjectCue: string | null = cue;
+    if (resolvedKey === 'note.recognize' && row.noteId) {
+      const body = recognizeBodyById.get(row.noteId);
+      subjectCue =
+        body && !body.contentEncrypted
+          ? noteFragment(stripHtml(body.content ?? ''), `${row.id}:${row.ladderStep}`)
+          : null;
+    } else if (
+      (resolvedKey === 'verse.locate' || resolvedKey === 'verse.book') &&
+      row.scriptureReference
+    ) {
+      if (!subjectCue) {
+        const text = await fetchVerseText(row.scriptureReference, row.translation ?? 'NET');
+        subjectCue = text ? verseCue(stripHtml(text)) : null;
+      }
+    } else if (resolvedKey !== 'verse.recognize') {
+      subjectCue = null;
+    }
     const framingNodeKey = nodeKeyFor(row);
     const node = framingNodeKey ? nodeByKey.get(framingNodeKey) : undefined;
     const seed = `${row.id}:${row.ladderStep}`;
@@ -1023,6 +1072,7 @@ export async function buildReviewItemViews(
       noteWrittenAt: primary?.writtenAt?.toISOString() ?? null,
       sourceLabel: row.sourceLabel,
       sourceAt: row.sourceAt?.toISOString() ?? null,
+      cue: subjectCue,
     });
   }
   return views;
@@ -1054,6 +1104,26 @@ export async function listDueReviewItems(
         eq(ReviewItems.userId, userId),
         eq(ReviewItems.status, 'active'),
         lte(ReviewItems.dueAt, now),
+      ),
+    )
+    .orderBy(ReviewItems.dueAt)
+    .limit(limit)) as ReviewItemRow[];
+}
+
+/** Active items not yet due, soonest first — the pool a mixed sitting may pull from. */
+export async function listUpcomingReviewItems(
+  userId: string,
+  limit: number,
+  now: Date = new Date(),
+): Promise<ReviewItemRow[]> {
+  return (await db
+    .select()
+    .from(ReviewItems)
+    .where(
+      and(
+        eq(ReviewItems.userId, userId),
+        eq(ReviewItems.status, 'active'),
+        gt(ReviewItems.dueAt, now),
       ),
     )
     .orderBy(ReviewItems.dueAt)
@@ -2618,7 +2688,15 @@ export async function gradeVerseAnswer(
   }
 
   const pool = await listUserVerseReferences(userId, item.scriptureReference);
-  const exercise = buildVerseLocate(item.scriptureReference, text, pool, seed);
+  const { close, rest } = partitionByBook([item.scriptureReference], pool);
+  const exercise = buildVerseLocate(
+    item.scriptureReference,
+    text,
+    close.length ? close : pool,
+    seed,
+    null,
+    close.length ? rest : undefined,
+  );
   if (!exercise) return null;
   return {
     correct: gradeVerseLocate(exercise, answer.option!),
@@ -2683,18 +2761,29 @@ function noteOptionLabel(row: {
 async function loadNoteOptionLabels(
   userId: string,
   noteId: string,
-): Promise<{ own: string; ownDistinguishing: boolean; others: string[] }> {
-  const [pool, subject] = await Promise.all([
+): Promise<{ own: string; ownDistinguishing: boolean; others: string[]; close: string[]; rest: string[] }> {
+  const [pool, subject, passages] = await Promise.all([
     loadNoteLabelPool(userId),
     loadNoteSubjectLabels(userId, [noteId]),
+    getNotePassages(noteId),
   ]);
   const ownLabel = subject.get(noteId) ?? { label: 'A note', distinguishing: false };
   const own = ownLabel.label.toLowerCase();
+  const others = pool.distinguishing.filter((label) => label.toLowerCase() !== own);
+  const anchors = passages.map((p) => verseReferenceLabel(p));
+  const { close, rest } = partitionByBook(
+    anchors,
+    others.map((label) => pool.bookByLabel.get(label.toLowerCase()) ?? label),
+  );
+  // The pool is labels (titles or passages). Re-map close/rest back to the labels that produced them.
+  const labelFor = (value: string): string | undefined =>
+    others.find((label) => label === value || (pool.bookByLabel.get(label.toLowerCase()) ?? '') === value);
   return {
     own: ownLabel.label,
     ownDistinguishing: ownLabel.distinguishing,
-    // A distractor reading the same as the answer makes the question unanswerable, not just dull.
-    others: pool.distinguishing.filter((label) => label.toLowerCase() !== own),
+    others,
+    close: close.map((value) => labelFor(value)).filter((label): label is string => Boolean(label)),
+    rest: rest.map((value) => labelFor(value)).filter((label): label is string => Boolean(label)),
   };
 }
 
@@ -2838,7 +2927,8 @@ async function buildNoteExercise(
       fragment,
       span,
       answerLabel: labels.own,
-      poolLabels: labels.others,
+      poolLabels: labels.close.length ? labels.close : labels.others,
+      fallbackLabels: labels.close.length ? labels.rest : undefined,
       seed,
     });
     return exercise
@@ -2852,7 +2942,13 @@ async function buildNoteExercise(
     if (!acceptable.length) return null;
     // Generous pool: every acceptable answer is also barred as a distractor.
     const pool = await listUserVerseReferences(userId, '');
-    const exercise = buildNoteChoice({ acceptable, poolLabels: pool, seed });
+    const { close, rest } = partitionByBook(acceptable, pool);
+    const exercise = buildNoteChoice({
+      acceptable,
+      poolLabels: close.length ? close : pool,
+      fallbackLabels: close.length ? rest : undefined,
+      seed,
+    });
     return exercise ? { rung, exercise, fragment: null, span: null, acceptable } : null;
   }
 
@@ -2885,10 +2981,13 @@ async function buildNoteExercise(
 
     const chosen = usable[hashSeed(seed) % usable.length];
     const reference = chosen.reference!.trim();
+    const pool = await listUserVerseReferences(userId, reference);
+    const { close, rest } = partitionByBook([reference], pool);
     const exercise = buildNoteAnnotation({
       annotation: annotationTextOf(chosen),
       reference,
-      poolReferences: await listUserVerseReferences(userId, reference),
+      poolReferences: close.length ? close : pool,
+      fallbackReferences: close.length ? rest : undefined,
       seed,
     });
     return exercise
@@ -2898,9 +2997,13 @@ async function buildNoteExercise(
 
   const neighbours: string[] = await loadConnectedNoteLabels(userId, item.noteId);
   if (!neighbours.length) return null;
+  const distractors = labels.others.filter((label) => !neighbours.includes(label));
+  const close = labels.close.filter((label) => !neighbours.includes(label));
+  const rest = labels.rest.filter((label) => !neighbours.includes(label));
   const exercise = buildNoteChoice({
     acceptable: neighbours,
-    poolLabels: labels.others.filter((label) => !neighbours.includes(label)),
+    poolLabels: close.length ? close : distractors,
+    fallbackLabels: close.length ? rest : undefined,
     seed,
   });
   return exercise ? { rung, exercise, fragment: null, span: null, acceptable: neighbours } : null;
@@ -3078,13 +3181,15 @@ export async function buildReviewReveal(
         }
         if (rung.key === 'verse.locate') {
           const pool = await listUserVerseReferences(userId, item.scriptureReference);
+          const { close, rest } = partitionByBook([item.scriptureReference], pool);
           // The reader's own marked span, where one fits; the verse's middle otherwise.
           const exercise = buildVerseLocate(
             item.scriptureReference,
             text,
-            pool,
+            close.length ? close : pool,
             seed,
             readerSpanFragment(await loadReaderSpan(userId, item.scriptureReference), text),
+            close.length ? rest : undefined,
           );
           payload.locate = exercise ? { phrase: exercise.phrase, options: exercise.options } : null;
           // The verse text itself would give the answer away on this rung.

--- a/spa/src/hooks/queries/useReview.ts
+++ b/spa/src/hooks/queries/useReview.ts
@@ -50,6 +50,8 @@ export interface ReviewItemView {
   /** Why this row is here, in the reader's words. Null on items they added themselves. */
   sourceLabel: string | null;
   sourceAt: string | null;
+  /** Quoted line or verse fragment, when the row cannot name the subject. */
+  cue: string | null;
 }
 
 /**

--- a/src/utils/__tests__/review-row-subtitle.test.ts
+++ b/src/utils/__tests__/review-row-subtitle.test.ts
@@ -204,6 +204,28 @@ describe('reviewRowSubject', () => {
     ).toBe('One of your passages');
   });
 
+  it('leads with the quoted line when the name would be the answer', () => {
+    expect(
+      reviewRowSubject({
+        prompt: 'x',
+        kind: 'note',
+        noteLabel: 'Adoption',
+        ladderStep: 0,
+        promptKey: 'note.recognize',
+        cue: 'chose us before the foundation of the world',
+      }),
+    ).toBe('chose us before the foundation of the world');
+    expect(
+      reviewRowSubject({
+        prompt: 'x',
+        kind: 'verse',
+        scriptureReference: 'John 15:5',
+        promptKey: 'verse.locate',
+        cue: 'apart from me you can do nothing',
+      }),
+    ).toBe('apart from me you can do nothing');
+  });
+
   it('names the note when the resolved rung is not recognize', () => {
     // Step 0 with a walked-forward prompt used to hide the name too, so "Pick a passage
     // you cited" sat under "One of your notes" five times in a row.

--- a/src/utils/__tests__/review-session-order.test.ts
+++ b/src/utils/__tests__/review-session-order.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { interleaveSession, sessionGroupKeyFor, type SessionOrderInput } from '../review-session-order';
+import { interleaveSession, sessionGroupKeyFor, composeSitting, type SessionOrderInput } from '../review-session-order';
 
 const NOW = new Date('2026-09-03T12:00:00.000Z');
 const daysAgo = (n: number) => new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000);
+const daysFromNow = (n: number) => new Date(NOW.getTime() + n * 24 * 60 * 60 * 1000);
 
 function item(id: string, kind: string, groupKey: string, overdue: number, reviewCount = 1): SessionOrderInput {
   return { id, kind, groupKey, dueAt: daysAgo(overdue), reviewCount };
@@ -100,5 +101,53 @@ describe('rung shape', () => {
       { ...item('c', 'verse', 'psalm 23', 1), ladderStep: 1 },
     ];
     expect(ids(interleaveSession(items, NOW))).toEqual(['a', 'c', 'b']);
+  });
+});
+
+describe('composeSitting', () => {
+  it('pulls a near-due passage into a notes-only handful', () => {
+    const due = [1, 2, 3, 4, 5].map((n) => item(`n${n}`, 'note', `note-${n}`, 0));
+    const upcoming = [{ ...item('v1', 'verse', 'john 3', 0), dueAt: daysFromNow(1) }];
+    const sitting = composeSitting(due, upcoming, 5, NOW);
+    expect(sitting.some((i) => i.kind === 'verse')).toBe(true);
+    expect(sitting.some((i) => i.kind === 'note')).toBe(true);
+    expect(sitting).toHaveLength(5);
+  });
+
+  it('does not raid something due next week', () => {
+    const due = [1, 2, 3, 4, 5].map((n) => item(`n${n}`, 'note', `note-${n}`, 0));
+    const upcoming = [{ ...item('v1', 'verse', 'john 3', 0), dueAt: daysFromNow(7) }];
+    const sitting = composeSitting(due, upcoming, 5, NOW);
+    expect(sitting.every((i) => i.kind === 'note')).toBe(true);
+    expect(ids(sitting)).not.toContain('v1');
+  });
+
+  it('caps the dominant half when the other is waiting nearby', () => {
+    const due = [1, 2, 3, 4, 5].map((n) => item(`n${n}`, 'note', `note-${n}`, 0));
+    const upcoming = [1, 2, 3].map((n) => ({
+      ...item(`v${n}`, 'verse', `john ${n}`, 0),
+      dueAt: daysFromNow(1),
+    }));
+    const sitting = composeSitting(due, upcoming, 5, NOW);
+    expect(sitting.filter((i) => i.kind === 'note').length).toBeLessThanOrEqual(3);
+    expect(sitting.filter((i) => i.kind === 'verse').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('leaves an empty due pile empty, even if something is due tomorrow', () => {
+    const upcoming = [{ ...item('v1', 'verse', 'john 3', 0), dueAt: daysFromNow(1) }];
+    expect(composeSitting([], upcoming, 5, NOW)).toEqual([]);
+  });
+
+  it('leaves a mixed due pile on the due items', () => {
+    const due = [
+      item('n1', 'note', 'n-1', 0),
+      item('n2', 'note', 'n-2', 0),
+      item('v1', 'verse', 'john 3', 0),
+      item('v2', 'verse', 'romans 8', 0),
+      item('n3', 'note', 'n-3', 0),
+    ];
+    const upcoming = [{ ...item('v3', 'verse', 'psalm 23', 0), dueAt: daysFromNow(1) }];
+    const sitting = composeSitting(due, upcoming, 5, NOW);
+    expect(sitting.every((i) => due.some((d) => d.id === i.id))).toBe(true);
   });
 });

--- a/src/utils/__tests__/scripture-book.test.ts
+++ b/src/utils/__tests__/scripture-book.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { bookOfReference, partitionByBook } from '@/utils/scripture-book';
+
+describe('bookOfReference', () => {
+  it('names the book, including numbered ones', () => {
+    expect(bookOfReference('John 3:16')).toBe('john');
+    expect(bookOfReference('1 John 3:16')).toBe('1 john');
+    expect(bookOfReference('Psalm 23')).toBe('psalm');
+    expect(bookOfReference('Romans 8:1-4')).toBe('romans');
+  });
+
+  it('leaves a non-reference alone', () => {
+    expect(bookOfReference('Adoption, not slavery')).toBe('adoption, not slavery');
+    expect(bookOfReference('')).toBe('');
+  });
+});
+
+describe('partitionByBook', () => {
+  it('puts same-book references first', () => {
+    const { close, rest } = partitionByBook(
+      ['John 3:16'],
+      ['John 1:1', 'Romans 8:15', 'John 15:5', 'Ephesians 2:8'],
+    );
+    expect(close).toEqual(['John 1:1', 'John 15:5']);
+    expect(rest).toEqual(['Romans 8:15', 'Ephesians 2:8']);
+  });
+
+  it('treats several anchors as one neighbourhood', () => {
+    const { close, rest } = partitionByBook(
+      ['John 3:16', 'Romans 8:1'],
+      ['John 1:1', 'Romans 5:8', 'Psalm 23:1'],
+    );
+    expect(close).toEqual(['John 1:1', 'Romans 5:8']);
+    expect(rest).toEqual(['Psalm 23:1']);
+  });
+});

--- a/src/utils/note-ladder-exercises.ts
+++ b/src/utils/note-ladder-exercises.ts
@@ -161,6 +161,8 @@ export function buildNoteRecognize(input: {
   span?: NoteSpan | null;
   answerLabel: string;
   poolLabels: readonly string[];
+  /** Same-book / linked notes go in `poolLabels`; the rest of the library sits here. */
+  fallbackLabels?: readonly string[];
   seed: string;
 }): NoteRecognizeExercise | null {
   const fragment = input.fragment.trim();
@@ -169,6 +171,7 @@ export function buildNoteRecognize(input: {
   const choice = buildChoiceExercise({
     answers: [input.answerLabel],
     pool: input.poolLabels,
+    fallbackPool: input.fallbackLabels,
     optionCount: OPTION_COUNT,
     seed: input.seed,
   });
@@ -285,6 +288,7 @@ export function buildNoteAnnotation(input: {
   annotation: string;
   reference: string;
   poolReferences: readonly string[];
+  fallbackReferences?: readonly string[];
   seed: string;
 }): NoteRecognizeExercise | null {
   const annotation = input.annotation.replace(/\s+/g, ' ').trim();
@@ -301,6 +305,7 @@ export function buildNoteAnnotation(input: {
   const choice = buildChoiceExercise({
     answers: [reference],
     pool: input.poolReferences,
+    fallbackPool: input.fallbackReferences,
     optionCount: OPTION_COUNT,
     seed: input.seed,
   });

--- a/src/utils/review-row-subtitle.ts
+++ b/src/utils/review-row-subtitle.ts
@@ -45,6 +45,11 @@ export interface ReviewRowSubtitleInput {
   scriptureReference?: string | null;
   /** ISO date, the last resort for a note with no name and no passage. */
   noteWrittenAt?: string | null;
+  /**
+   * The stem of the question, when the subject's name *is* the answer.
+   * A quoted line from the note, or a fragment of the verse — unique, and not a spoiler.
+   */
+  cue?: string | null;
 }
 
 /** "9 Aug" / "9 Aug 2025" — formatted on the client, which is the only side that knows the zone. */
@@ -164,6 +169,10 @@ export function reviewRowSubject(
   now: Date = new Date(),
 ): string {
   if (rungIdentityIsTheAnswer(item)) {
+    // The quoted line is the question, not the answer. "One of your notes" five times
+    // was a shelf of identical rows; the fragment is how the reader tells them apart.
+    const cue = item.cue?.trim();
+    if (cue) return cue;
     return item.kind === 'verse' ? REVIEW_SUBJECT_HIDDEN_VERSE : REVIEW_SUBJECT_HIDDEN_NOTE;
   }
 

--- a/src/utils/review-session-order.ts
+++ b/src/utils/review-session-order.ts
@@ -42,6 +42,20 @@ export interface SessionOrderInput {
   ladderStep?: number;
 }
 
+/**
+ * The two halves of a sitting: scripture (verse, chapter, a marked span) and the
+ * reader's own writing. A handful of one half is a quiz; both is review.
+ */
+export function sittingHalf(kind: string): 'passage' | 'note' {
+  return kind === 'verse' || kind === 'chapter' || kind === 'highlight' ? 'passage' : 'note';
+}
+
+/** Pull a waiting item in if it is due within this many days. Tomorrow, not next month. */
+export const SITTING_NEAR_DAYS = 2;
+
+/** Leave room for this many of the other half when it is waiting nearby. */
+export const SITTING_OTHER_HALF = 2;
+
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 function daysOverdue(item: SessionOrderInput, now: Date): number {
@@ -98,4 +112,59 @@ export function interleaveSession<T extends SessionOrderInput>(items: T[], now: 
     for (const bucket of buckets(group, now)) drain(bucket, out);
   }
   return out;
+}
+
+function daysUntil(item: SessionOrderInput, now: Date): number {
+  return (item.dueAt.getTime() - now.getTime()) / MS_PER_DAY;
+}
+
+/**
+ * A handful that mixes writing and scripture, even when the due pile is one kind.
+ *
+ * Due items still lead. When they are all notes (or all verses) and the other half
+ * is due within {@link SITTING_NEAR_DAYS}, that half is pulled in and the dominant
+ * side is capped so the sitting is not five of the same thing. Items due later
+ * than that stay "coming back later" — asking something scheduled for next week
+ * is not review, it is raiding the future.
+ */
+export function composeSitting<T extends SessionOrderInput>(
+  due: readonly T[],
+  upcoming: readonly T[],
+  max: number,
+  now: Date = new Date(),
+): T[] {
+  if (due.length === 0) return [];
+
+  const near = upcoming.filter((item) => {
+    const days = daysUntil(item, now);
+    return days > 0 && days <= SITTING_NEAR_DAYS;
+  });
+
+  const available = { note: 0, passage: 0 };
+  for (const item of [...due, ...near]) available[sittingHalf(item.kind)] += 1;
+  const canMix = available.note > 0 && available.passage > 0;
+
+  const capFor = (half: 'note' | 'passage'): number => {
+    if (!canMix) return max;
+    const other = half === 'note' ? available.passage : available.note;
+    return Math.max(1, max - Math.min(SITTING_OTHER_HALF, other));
+  };
+
+  const picked: T[] = [];
+  const used = new Set<string>();
+  const count = { note: 0, passage: 0 };
+
+  const tryPick = (item: T): void => {
+    if (used.has(item.id) || picked.length >= max) return;
+    const half = sittingHalf(item.kind);
+    if (count[half] >= capFor(half)) return;
+    used.add(item.id);
+    count[half] += 1;
+    picked.push(item);
+  };
+
+  for (const item of interleaveSession([...due], now)) tryPick(item);
+  for (const item of interleaveSession(near, now)) tryPick(item);
+
+  return interleaveSession(picked, now);
 }

--- a/src/utils/scripture-book.ts
+++ b/src/utils/scripture-book.ts
@@ -1,0 +1,36 @@
+/**
+ * The book a scripture reference belongs to, so close distractors can come from
+ * the same neighbourhood rather than anywhere in the library.
+ *
+ * "John 3:16" and "John 1:1" are one book. "1 John 3:16" is another. A title with
+ * no verse number is not a reference and does not group with anything.
+ */
+export function bookOfReference(reference: string): string {
+  const trimmed = reference.trim();
+  if (!trimmed) return '';
+  return trimmed.replace(/\s+\d+([:.].*)?$/, '').trim().toLowerCase();
+}
+
+/**
+ * Split a pool into items that share a book with `anchors`, and the rest.
+ *
+ * `buildChoiceExercise` draws from `pool` before `fallbackPool`, so callers pass
+ * `close` then `rest` and the wrong answers stay in the same neighbourhood
+ * whenever the library is deep enough.
+ */
+export function partitionByBook(
+  anchors: readonly string[],
+  pool: readonly string[],
+): { close: string[]; rest: string[] } {
+  const books = new Set(anchors.map(bookOfReference).filter((book) => book.length > 0));
+  const close: string[] = [];
+  const rest: string[] = [];
+  const seen = new Set<string>();
+  for (const item of pool) {
+    const key = item.trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    (books.has(bookOfReference(item)) ? close : rest).push(item);
+  }
+  return { close, rest };
+}

--- a/src/utils/verse-ladder-exercises.ts
+++ b/src/utils/verse-ladder-exercises.ts
@@ -198,6 +198,8 @@ export function buildVerseLocate(
   seed: string,
   /** A fragment the reader marked themselves, preferred over the middle of the verse. */
   readerPhrase: string | null = null,
+  /** Same-book passages first; the canned list is always last. */
+  fallbackPool: readonly string[] = FALLBACK_REFERENCES,
 ): VerseLocateExercise | null {
   const phrase = readerPhrase ?? locatePhrase(text);
   if (!phrase) return null;
@@ -208,7 +210,7 @@ export function buildVerseLocate(
   const choice = buildChoiceExercise({
     answers: [answer],
     pool: poolReferences,
-    fallbackPool: FALLBACK_REFERENCES,
+    fallbackPool: [...fallbackPool, ...FALLBACK_REFERENCES.filter((r) => !fallbackPool.includes(r))],
     optionCount: LOCATE_OPTION_COUNT,
     seed,
   });


### PR DESCRIPTION
Follow-up to #107. Volume and uniqueness of *which items* are in. This is whether the sitting itself feels like retrieval.

## What you saw

Five expanded rows, still generic even after names came back on the non-recognize rungs: the recognize ones hid everything, the due pile was all notes, and the wrong answers could be anything in the library.

## What changed

**Named stems.** “Pick the note this is from” leads with the quoted line — the question — not “One of your notes.” Same for “where is this from?” on a verse. The name stays hidden; the fragment is how you tell the rows apart.

**Mixed halves.** A notes-only due pile pulls in a verse (or chapter) due within two days so the handful is writing *and* scripture. Does not raid next week. An empty due pile stays empty.

**Close wrong answers.** Distractors come from the same book when the library has them — other notes that cite John, other John verses — and only fall back to the rest of the account when that neighbourhood is thin. Eliminating the one you recognise among strangers is not review.

## After merge

Hard-refresh Review. Expect mixed tasks with distinct titles, and options that could actually be confused with the right one.