### PR TITLE
Review: trial persist, quoted stems, scripture cloze, translation

### DIFF
--- a/spa/src/hooks/mutations/useReviewMutations.ts
+++ b/spa/src/hooks/mutations/useReviewMutations.ts
@@ -35,69 +35,36 @@ export function useAddReviewItem() {
 }
 
 export interface ReviewOutcomeInput {
-  /** Which go this is, 1-based. Decides the interval, and whether a miss is final. */
   attemptNumber?: number;
   itemId: string;
   outcome: ReviewOutcome;
   attempt?: string;
-  /**
-   * The two graded rungs of the verse ladder. When present the server marks the answer and
-   * ignores `outcome` — the page has no answer key to check against, by design.
-   */
   answer?: {
     order?: number[];
     option?: string;
     promptKey?: string;
     wordIndex?: number;
     words?: string[];
-    /** The verse written back from its first letters. */
     text?: string;
+    translation?: string;
   };
 }
 
 export interface ReviewOutcomeResponse {
-  /** What the server recorded. On a graded rung this is its verdict, not what the page sent. */
   outcome?: 'recalled' | 'almost' | 'revealed';
-  /** Whether the answer was right, where the server marked one. */
   correct?: boolean;
-  /**
-   * False when a wrong answer still has a go left: nothing was written and the question stands.
-   * Absent on the ungraded rungs, which finalize immediately.
-   */
   finalized?: boolean;
   attemptsLeft?: number;
-  /** Goes used and allowed for the rung on screen, so the dock can draw them. */
   attempts?: { used: number; total: number };
-  /** The option that was right, sent only once the question is over and only where it is one. */
   correctAnswer?: string;
-  /**
-   * Which parts of the answer were right, aligned to what was submitted: the gaps, the words,
-   * the placed phrases, the words typed. Absent where one tap is the whole answer.
-   */
   parts?: boolean[];
-  /** How much of a written verse was reached. A count, naming nothing. */
   reached?: { matched: number; total: number };
-  /** This miss made it a leech: the dock offers a step back a rung instead of a fifth go. */
   leech?: boolean;
   item: ReviewItemView;
   next: { intervalDays: number; dueAt: string; recallState: string; label: string };
-  /**
-   * The verse a rung withheld while it was asking, handed back now the question is answered.
-   *
-   * Only present on the rungs that hid it — putting the words back in order, and naming the
-   * reference. Absent everywhere else, including where the verse was on screen all along.
-   */
   truth?: { verseText: string } | null;
 }
 
-/**
- * Answer an item.
- *
- * The optimistic update removes the item from the *session* list only, which is what makes
- * the next question appear immediately rather than after a round trip. The inbox and the
- * manage list are left to refetch: they are not on screen, and guessing their new contents
- * would mean reimplementing the scheduler on the client.
- */
 export function useReviewOutcome() {
   const queryClient = useQueryClient();
   return useMutation({
@@ -122,21 +89,13 @@ export function useReviewOutcome() {
       if (context?.previous) queryClient.setQueryData(reviewSessionQueryKey, context.previous);
     },
     onSuccess: (data, _input, context) => {
-      /*
-       * A wrong answer with a go left is not an answer yet. `onMutate` has already taken the item
-       * out of the session so the next question can appear instantly on the common path, so a
-       * non-final attempt has to put it back — the reader is still looking at it.
-       */
       if (data.finalized === false && context?.previous) {
         queryClient.setQueryData(reviewSessionQueryKey, context.previous);
       }
     },
     onSettled: () => {
-      // Not the session: refetching it mid-sitting would pull in items answered on another
-      // device and reshuffle the queue under the reader.
       void queryClient.invalidateQueries({ queryKey: ['review', 'inbox'] });
       void queryClient.invalidateQueries({ queryKey: ['review', 'items'] });
-      // A recall lengthens the note's resurfacing stability, which Home reads.
       void queryClient.invalidateQueries({ queryKey: ['note-fingerprints'] });
     },
   });
@@ -153,7 +112,6 @@ export function useDeferReview() {
   });
 }
 
-/** A leech steps back a rung, at the reader's request. Refused by the server on anything else. */
 export function useStepBackReview() {
   const queryClient = useQueryClient();
   return useMutation({
@@ -179,8 +137,6 @@ export function useSetReviewStatus() {
   });
 }
 
-
-/** Answer the sample. Writes nothing on the server, so there is nothing to invalidate. */
 export interface ReviewSampleAnswerResponse {
   correct: boolean;
   finalized: boolean;
@@ -191,7 +147,16 @@ export interface ReviewSampleAnswerResponse {
 
 export function useAnswerReviewSample() {
   return useMutation({
-    mutationFn: ({ day, words, attemptNumber }: { day: string; words: string[]; attemptNumber: number }) =>
-      api.post<ReviewSampleAnswerResponse>('/api/review/sample/answer', { day, words, attemptNumber }),
+    mutationFn: ({
+      day,
+      words,
+      attemptNumber,
+      translation,
+    }: {
+      day: string;
+      words: string[];
+      attemptNumber: number;
+      translation?: string;
+    }) => api.post<ReviewSampleAnswerResponse>('/api/review/sample/answer', { day, words, attemptNumber, translation }),
   });
 }

--- a/spa/src/hooks/queries/useReview.ts
+++ b/spa/src/hooks/queries/useReview.ts
@@ -25,9 +25,7 @@ export interface ReviewItemView {
   id: string;
   kind: ReviewItemKind;
   prompt: string;
-  /** The instruction with the subject removed — the row's meta line. */
   task: string;
-  /** Why this is here or what it connects to, as a template; render with `fillFraming`. */
   framing: ReviewFramingSpec | null;
   promptKey: string;
   recallState: RecallState;
@@ -38,29 +36,18 @@ export interface ReviewItemView {
   ladderStep: number;
   noteTitle: string | null;
   secondaryNoteTitle: string | null;
-  /** Title, else the first passage the note cites — the short answer to "which note?". */
   noteLabel: string | null;
-  /** The note's own opening words, shown on the row's context line. */
   noteContext: string | null;
-  /** Last resort for a note with neither, formatted client-side where the zone is known. */
   noteWrittenAt: string | null;
   scriptureReference: string | null;
   noteId: string | null;
   challengeId: string | null;
-  /** Why this row is here, in the reader's words. Null on items they added themselves. */
   sourceLabel: string | null;
   sourceAt: string | null;
-  /** Quoted line or verse fragment, when the row cannot name the subject. */
   cue: string | null;
+  translation?: string | null;
 }
 
-/**
- * The same queue, without a question built for any row — see `useReviewItemsSummary`.
- *
- * Everything here is a column on the stored item, so the server can answer with one list query
- * (plus one batched read to drop notes it can ask nothing about, which is what keeps this list's
- * membership identical to the full one's).
- */
 export interface ReviewItemSummary {
   id: string;
   kind: ReviewItemKind;
@@ -73,22 +60,10 @@ export interface ReviewItemSummary {
 
 export interface ReviewInboxResponse {
   items: ReviewItemView[];
-  /** A boolean, never a count — see the route's docblock. */
   hasMore: boolean;
-  /**
-   * Why the queue is empty, when it is empty and the engine has not started yet.
-   *
-   * Null both when there is something to show and when the engine is running and simply has
-   * nothing due today. Those two are not the same absence: the first is a queue, the second is
-   * a rest day, and only the third — never having started — leaves someone unable to tell the
-   * feature from a broken one.
-   */
   coldStart: {
-    /** Pieces of study already past every gate. */
     ready: number;
-    /** How many are needed before Review begins. */
     needed: number;
-    /** ISO date the gate opens on time alone, or null when more study is needed first. */
     opensAt: string | null;
   } | null;
 }
@@ -97,36 +72,19 @@ export interface ReviewRevealResponse {
   note?: { id: string; title: string | null; content: string } | null;
   secondaryNote?: { id: string; title: string | null; content: string } | null;
   verseText?: string | null;
-  /**
-   * The verse split at its gaps: `blankLengths.length + 1` pieces of visible text, and how wide
-   * each gap was. The tokens and the missing words stay on the server.
-   */
   cloze?: { segments: string[]; blankLengths: number[] } | null;
-  /** The ordering rung's phrases, shuffled. The order they belong in stays on the server. */
   sequence?: { phrases: string[] } | null;
-  /** The locate rung's fragment and four references. Which one is right stays on the server. */
   locate?: { phrase: string; options: string[] } | null;
-  /** A note rung's own material and four options. Which is right stays on the server. */
   noteChoice?: {
     fragment: string | null;
-    /** The marked span with its run-up, when the stem is one the reader highlighted. */
     span?: { before: string; quote: string; after: string } | null;
     options: string[];
   } | null;
-  /** Four openings on "what comes after this?". The next verse's reference is never sent. */
   next?: { options: string[] } | null;
-  /** The altered verse. Which word was changed stays on the server. */
   altered?: { tokens: string[] } | null;
-  /**
-   * The context-step rungs: which note cites this, which theme, who, which cross-reference.
-   * Four options; `opening` when they are the first words of passages and should trail off.
-   */
   choice?: { options: string[]; opening: boolean } | null;
-  /** First letters of every word, and how many words. The verse itself is never sent. */
   initials?: { initials: string; wordCount: number } | null;
-  /** How many words to name. Nothing about which. */
   keywords?: { count: number } | null;
-  /** Two openings from the same chapter; which comes first stays on the server. */
   before?: { options: string[] } | null;
   thread?: { title: string | null; members: { id: string; title: string | null }[] } | null;
 }
@@ -137,51 +95,18 @@ export const reviewSessionQueryKey = ['review', 'session'] as const;
 export const reviewItemsQueryKey = (status?: ReviewItemStatus, view: 'full' | 'summary' = 'full') =>
   ['review', 'items', status ?? 'all', view] as const;
 
-/*
- * Called unconditionally, then combined — never `authReady && useAccess()`.
- *
- * `&&` short-circuits, so the access hook is skipped while auth is still resolving and called
- * once it settles. That changes the number of hooks between two renders of the same component,
- * which is a Rules of Hooks violation, and React tears the tree down with an error that names
- * neither this file nor the real cause.
- *
- * It only fires on the false-to-true auth transition, so every signed-out path looks fine —
- * which is exactly how it reached a signed-in browser. Keep the call on its own line.
- */
-/**
- * Holds the key and is a real account — the half of the gate that is not session readiness.
- *
- * Session readiness is deliberately *not* folded in here. `check:auth-gated-queries` reads
- * each hook on its own and wants `useAuthReady()` visible at the call site, and it is right
- * to: burying the gate one call deep is exactly how fourteen hooks lost it before, and a
- * reader skimming a query cannot see a gate that lives in another function.
- */
 function useReviewAccess(): boolean {
   const { has } = useHasFeature('review');
   const { isGuest } = useHarvousIdentity();
   return has && !isGuest;
 }
 
-/** True when Review is worth asking the server about at all. */
 export function useReviewEnabled(): boolean {
   const authReady = useAuthReady();
   const access = useReviewAccess();
   return authReady && access;
 }
 
-/**
- * True once we know whether Review runs for this account — not whether it does.
- *
- * The distinction is what Home's presentation gate needs. Every query below is disabled without
- * the entitlement, and a disabled query keeps `status: 'pending'` forever in React Query v5, so
- * "is it still loading" cannot tell a free account (never will load) from a subscriber whose
- * entitlement has not answered yet (about to). Gating on the first and not the second is what
- * lets Home paint once *and* paint with Review already in it.
- *
- * A guest is settled immediately: they have no account to hold a key, so the answer is a
- * structural no rather than a pending one, and `useHasFeature` would leave `ready` false forever
- * for them because the subscription query never runs at all.
- */
 export function useReviewAccessSettled(): boolean {
   const { ready } = useHasFeature('review');
   const { isGuest } = useHarvousIdentity();
@@ -201,7 +126,6 @@ export function useReviewInbox() {
   });
   return {
     ...query,
-    /** Settled once we know whether it should run — and then only once it has. */
     isSettled:
       accessSettled && isQuerySettled(query.isPending, query.data != null, query.isEnabled),
   };
@@ -214,8 +138,6 @@ export function useReviewItems(status?: ReviewItemStatus, options?: { enabled?: 
   const enabled = authReady && access;
   const query = useQuery({
     queryKey: reviewItemsQueryKey(status),
-    // The caller's `enabled` narrows, never widens: the dock only wants this list when the
-    // session cannot answer, and no caller may bypass the auth/entitlement gate.
     enabled: enabled && options?.enabled !== false,
     queryFn: () =>
       api.get<{ items: ReviewItemView[] }>(
@@ -225,30 +147,11 @@ export function useReviewItems(status?: ReviewItemStatus, options?: { enabled?: 
   });
   return {
     ...query,
-    /*
-     * See `useReviewAccessSettled`. This one matters to Home beyond its own rows: the `active`
-     * list is what the suggestion handoff reads to step Home's resurfacing cards aside for a
-     * passage Review has already taken up, so arriving late does not add a section — it *removes*
-     * cards from a deck someone is already reading.
-     */
     isSettled:
       accessSettled && isQuerySettled(query.isPending, query.data != null, query.isEnabled),
   };
 }
 
-/**
- * The same queue, counted rather than built.
- *
- * Home reads the active list on every load and renders none of it — the suggestion handoff wants
- * kinds and references, the Review section wants counts, and the rows it shows come from
- * `useReviewInbox`. Asking for the full shape meant the server assembled a question per item, at
- * 3.4s for eighteen of them, on the critical path of Home's first paint.
- *
- * A hook of its own rather than an option on `useReviewItems`, because the payload is a different
- * type and a union return would push that choice out to every call site. Its own query key too,
- * so the two shapes cannot overwrite each other in the cache; both still sit under the `review`
- * prefix every mutation invalidates.
- */
 export function useReviewItemsSummary(status?: ReviewItemStatus, options?: { enabled?: boolean }) {
   const authReady = useAuthReady();
   const access = useReviewAccess();
@@ -267,19 +170,11 @@ export function useReviewItemsSummary(status?: ReviewItemStatus, options?: { ena
   });
   return {
     ...query,
-    /** See `useReviewAccessSettled`. This is the flag Home's presentation gate waits on. */
     isSettled:
       accessSettled && isQuerySettled(query.isPending, query.data != null, query.isEnabled),
   };
 }
 
-/**
- * A sitting's worth of questions.
- *
- * `staleTime: Infinity` and no refetch on focus: the session is a fixed set once it starts.
- * Tabbing away mid-answer and coming back to a reshuffled queue would lose the reader's place
- * in the one place where losing it costs them an answer they had already thought of.
- */
 export function useReviewSession(options?: { enabled?: boolean }) {
   const authReady = useAuthReady();
   const access = useReviewAccess();
@@ -292,14 +187,8 @@ export function useReviewSession(options?: { enabled?: boolean }) {
       const data = await api.get<{
         items: ReviewItemView[];
         firstReveal?: ReviewRevealResponse;
-        /** Only sent when nothing is due: when the next scheduled thing comes back. */
         nextDueAt?: string | null;
       }>('/api/review/session');
-      /*
-       * The first question's exercise came with the question, so seed the cache the dock is
-       * about to read rather than letting it ask again. Without this the page renders a prompt
-       * with no options and fills them in a round trip later.
-       */
       if (data.firstReveal && data.items[0]) {
         queryClient.setQueryData(['review', 'reveal', data.items[0].id], data.firstReveal);
       }
@@ -310,19 +199,6 @@ export function useReviewSession(options?: { enabled?: boolean }) {
   });
 }
 
-/**
- * The answer behind the question, fetched only when asked for.
- *
- * Disabled until `enabled` flips, which is what makes the reveal a deliberate act rather than
- * something already sitting in the page while the question is on screen.
- */
-/**
- * Fetch the *next* question's exercise while the reader answers this one.
- *
- * The first question's arrives with the session, so the only remaining wait was between one
- * answer and the next — which is exactly when there is idle time to spend. Same cache key the
- * dock reads, so by the time the card turns over the exercise is already there.
- */
 export function usePrefetchReviewReveal(itemId: string | null | undefined) {
   const queryClient = useQueryClient();
   const authReady = useAuthReady();
@@ -338,30 +214,32 @@ export function usePrefetchReviewReveal(itemId: string | null | undefined) {
   }, [itemId, authReady, access, queryClient]);
 }
 
-export function useReviewReveal(itemId: string | null, options?: { enabled?: boolean }) {
+export function useReviewReveal(itemId: string | null, options?: { enabled?: boolean; translation?: string }) {
   const authReady = useAuthReady();
   const access = useReviewAccess();
   const featureEnabled = authReady && access;
+  const translation = options?.translation;
   return useQuery({
-    queryKey: ['review', 'reveal', itemId ?? 'none'] as const,
+    queryKey: ['review', 'reveal', itemId ?? 'none', translation ?? 'default'] as const,
     enabled: featureEnabled && Boolean(itemId) && options?.enabled === true,
-    queryFn: () => api.get<ReviewRevealResponse>(`/api/review/items/${encodeURIComponent(itemId!)}/reveal`),
+    queryFn: () =>
+      api.get<ReviewRevealResponse>(
+        `/api/review/items/${encodeURIComponent(itemId!)}/reveal${
+          translation ? `?translation=${encodeURIComponent(translation)}` : ''
+        }`,
+      ),
     staleTime: 5 * 60_000,
   });
 }
 
-
-// ─── The sample, for an account without Review ─────────────────────────────────
-
 export interface ReviewSampleView {
   reference: string;
-  /** Whose verse it is: the reader's own study, or a well-known one because nothing of theirs fit. */
   source: 'yours' | 'well-known';
   cloze: { segments: string[]; blankLengths: number[] };
   blankCount: number;
+  translation?: string;
 }
 
-/** The reader's local calendar day, which is the seed's half the server cannot know. */
 export function reviewSampleDayKey(now: Date = new Date()): string {
   const y = now.getFullYear();
   const m = String(now.getMonth() + 1).padStart(2, '0');
@@ -369,21 +247,20 @@ export function reviewSampleDayKey(now: Date = new Date()): string {
   return `${y}-${m}-${d}`;
 }
 
-/**
- * Fetched only for a signed-in account *without* the feature: a subscriber has the real
- * thing, and a guest has no account to attach an upgrade to. Auth-gated like every query
- * here, and off until the entitlement is known so nobody is shown a sample for a beat
- * before their real queue.
- */
-export function useReviewSample(options: { enabled: boolean }) {
+export function useReviewSample(options: { enabled: boolean; translation?: string }) {
   const authReady = useAuthReady();
   const access = useReviewAccess();
   const day = reviewSampleDayKey();
+  const translation = options.translation;
   return useQuery({
-    queryKey: ['review', 'sample', day] as const,
+    queryKey: ['review', 'sample', day, translation ?? 'default'] as const,
     enabled: authReady && !access && options.enabled,
     queryFn: () =>
-      api.get<{ sample: ReviewSampleView | null }>(`/api/review/sample?day=${encodeURIComponent(day)}`),
+      api.get<{ sample: ReviewSampleView | null }>(
+        `/api/review/sample?day=${encodeURIComponent(day)}${
+          translation ? `&translation=${encodeURIComponent(translation)}` : ''
+        }`,
+      ),
     staleTime: 5 * 60_000,
   });
 }

--- a/spa/src/pages/prototype/PrototypeReviewSample.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewSample.tsx
@@ -16,8 +16,10 @@
  * subscription with.
  */
 import { Fragment, useState } from 'react';
+import { TRANSLATION_ORDER, TRANSLATIONS } from '@/data/translations';
 import { useAnswerReviewSample } from '../../hooks/mutations/useReviewMutations';
 import type { ReviewSampleView } from '../../hooks/queries/useReview';
+import { readReviewSampleResult, writeReviewSampleResult } from './use-dismissible-review-sample';
 import Icon from '@/components/react/Icon';
 import {
   REVIEW_CHECK_COPY,
@@ -39,12 +41,14 @@ export default function PrototypeReviewSample({
   onSeePlus,
   onNotNow,
   onAnswered,
+  onTranslationChange,
 }: {
   sample: ReviewSampleView;
   day: string;
   maxAttempts: number;
   onSeePlus: () => void;
   onNotNow: () => void;
+  onTranslationChange?: (translation: string) => void;
   /** So the section can drop its own offer row once this card is carrying one. */
   onAnswered?: () => void;
 }) {
@@ -52,13 +56,19 @@ export default function PrototypeReviewSample({
   const [blanks, setBlanks] = useState<string[]>([]);
   const [attemptNumber, setAttemptNumber] = useState(1);
   const [missed, setMissed] = useState(false);
-  const [result, setResult] = useState<{ correct: boolean; verseText: string } | null>(null);
+  const [result, setResult] = useState<{ correct: boolean; verseText: string } | null>(
+    () => {
+      const stored = readReviewSampleResult(day);
+      return stored ? { correct: stored.correct, verseText: stored.verseText } : null;
+    },
+  );
+  const translationLabel = TRANSLATIONS[sample.translation]?.abbreviation ?? sample.translation;
 
   const filled = sample.cloze.blankLengths.every((_, i) => (blanks[i] ?? '').trim().length > 0);
 
   const submit = () => {
     answer.mutate(
-      { day, words: sample.cloze.blankLengths.map((_, i) => (blanks[i] ?? '').trim()), attemptNumber },
+      { day, translation: sample.translation, words: sample.cloze.blankLengths.map((_, i) => (blanks[i] ?? '').trim()), attemptNumber },
       {
         onSuccess: (data) => {
           if (data.finalized === false) {
@@ -66,7 +76,9 @@ export default function PrototypeReviewSample({
             setAttemptNumber((n) => Math.min(maxAttempts, n + 1));
             return;
           }
-          setResult({ correct: data.correct, verseText: data.verseText ?? '' });
+          const next = { correct: data.correct, verseText: data.verseText ?? '' };
+          setResult(next);
+          writeReviewSampleResult({ day, translation: sample.translation, ...next });
           onAnswered?.();
         },
       },
@@ -79,6 +91,25 @@ export default function PrototypeReviewSample({
         {sample.source === 'yours' ? REVIEW_SAMPLE_EYEBROW_YOURS : REVIEW_SAMPLE_EYEBROW_WELL_KNOWN}
         {' · '}
         {sample.reference}
+        {' · '}
+        {onTranslationChange && !result ? (
+          <label>
+            <select
+              className="proto-caption"
+              value={sample.translation}
+              onChange={(event) => onTranslationChange(event.target.value)}
+              aria-label="Translation"
+            >
+              {TRANSLATION_ORDER.map((row) => (
+                <option key={row.id} value={row.id}>
+                  {row.abbreviation}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : (
+          translationLabel
+        )}
       </p>
       {result ? (
         <div className="proto-review-dock__result">
@@ -99,11 +130,6 @@ export default function PrototypeReviewSample({
               </span>
             </p>
           </div>
-          {/*
-            * The offer, now that there is something it refers to. Both ways out: a card with
-            * only "See Plus" on it is a toll gate, and the reader has just done the one thing
-            * that makes the answer to it obvious either way.
-            */}
           <p className="proto-review-dock__result-text">{REVIEW_SAMPLE_AFTER}</p>
           <div className="proto-review-dock__actions">
             <button

--- a/spa/src/pages/prototype/use-dismissible-review-sample.ts
+++ b/spa/src/pages/prototype/use-dismissible-review-sample.ts
@@ -18,6 +18,36 @@
 import { useCallback, useState } from 'react';
 
 export const PROTO_REVIEW_SAMPLE_DISMISSED_KEY = 'harvous-prototype-review-sample-dismissed';
+export const PROTO_REVIEW_SAMPLE_RESULT_KEY = 'harvous-prototype-review-sample-result';
+
+export interface ReviewSampleResult {
+  day: string;
+  correct: boolean;
+  verseText: string;
+  translation?: string;
+}
+
+export function readReviewSampleResult(day: string): ReviewSampleResult | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(PROTO_REVIEW_SAMPLE_RESULT_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as ReviewSampleResult;
+    if (parsed?.day !== day || typeof parsed.verseText !== 'string') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function writeReviewSampleResult(result: ReviewSampleResult): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(PROTO_REVIEW_SAMPLE_RESULT_KEY, JSON.stringify(result));
+  } catch {
+    // Session state in the card still holds for this visit.
+  }
+}
 
 function read(): boolean {
   if (typeof window === 'undefined') return false;

--- a/src/utils/__tests__/review-row-subtitle.test.ts
+++ b/src/utils/__tests__/review-row-subtitle.test.ts
@@ -29,7 +29,6 @@ describe('reviewRowSubtitle', () => {
   });
 
   it('stays quiet when the question already names it', () => {
-    // "What did you observe in My journey?" does not need "My journey" underneath.
     expect(
       reviewRowSubtitle(
         { prompt: 'Before opening it, what did you observe in My journey?', noteLabel: 'My journey' },
@@ -57,8 +56,6 @@ describe('reviewRowSubtitle', () => {
   });
 
   it('places a note in time only when nothing else names it at all', () => {
-    // The regression this file exists for: a row about "Untitled Note 4" said "this note"
-    // and nothing more, and the reader could not tell which note it meant.
     expect(
       reviewRowSubtitle(
         {
@@ -135,11 +132,6 @@ describe('reviewRowSource', () => {
 });
 
 describe('which rungs hide the identity line', () => {
-  /*
-   * The first cut suppressed the subtitle on every graded rung, which read as "What did you link
-   * this to?" above nothing at all — a question with a right answer, about a note the reader was
-   * never told the name of. A right answer is not a reason to withhold the question.
-   */
   const note = {
     prompt: 'What did you link this to?',
     kind: 'note',
@@ -160,7 +152,6 @@ describe('which rungs hide the identity line', () => {
   it('hides the reference on "where is this from?" and nowhere else on the verse ladder', () => {
     const verse = { prompt: 'Where is this from?', kind: 'verse', scriptureReference: 'John 15:5' };
     expect(reviewRowSubtitle({ ...verse, ladderStep: VERSE_LOCATE_STEP })).toBeNull();
-    // Putting the words back in order is not made easier by knowing the address.
     expect(reviewRowSubtitle({ ...verse, prompt: 'Put these back in order', ladderStep: VERSE_SEQUENCE_STEP })).toBe(
       'John 15:5',
     );
@@ -178,10 +169,6 @@ describe('reviewRowSubject', () => {
   });
 
   it('says only what kind of thing it is where the subject is the answer', () => {
-    /*
-     * "Pick the note this line is from" printed above the note's own name is not a question.
-     * Same for "Say where this is from" above the reference.
-     */
     expect(
       reviewRowSubject({ prompt: 'x', kind: 'note', noteLabel: 'Adoption', ladderStep: 0 }),
     ).toBe('One of your notes');
@@ -214,7 +201,7 @@ describe('reviewRowSubject', () => {
         promptKey: 'note.recognize',
         cue: 'chose us before the foundation of the world',
       }),
-    ).toBe('chose us before the foundation of the world');
+    ).toBe('“chose us before the foundation of the world”');
     expect(
       reviewRowSubject({
         prompt: 'x',
@@ -223,12 +210,10 @@ describe('reviewRowSubject', () => {
         promptKey: 'verse.locate',
         cue: 'apart from me you can do nothing',
       }),
-    ).toBe('apart from me you can do nothing');
+    ).toBe('“apart from me you can do nothing”');
   });
 
   it('names the note when the resolved rung is not recognize', () => {
-    // Step 0 with a walked-forward prompt used to hide the name too, so "Pick a passage
-    // you cited" sat under "One of your notes" five times in a row.
     expect(
       reviewRowSubject({
         prompt: 'x',
@@ -250,7 +235,6 @@ describe('reviewRowSubject', () => {
   });
 
   it('falls back to when it was written, and never to nothing', () => {
-    // Day and month order is the runtime's, not ours — `writtenAtLabel` formats by locale.
     const written = reviewRowSubject(
       { prompt: 'x', kind: 'note', noteWrittenAt: '2026-08-09T10:00:00Z', ladderStep: 1 },
       NOW,
@@ -262,7 +246,6 @@ describe('reviewRowSubject', () => {
   });
 
   it('drops a verse reason that names the verse on the rung asking for it', () => {
-    // "Marked Romans 1:7 in a note" beneath "Say where this is from" is the answer.
     const item = { sourceLabel: 'Marked John 15:5 in a note', kind: 'verse' };
     expect(reviewRowSource({ ...item, ladderStep: VERSE_LOCATE_STEP }, null)).toBeNull();
     expect(reviewRowSource({ ...item, ladderStep: 1 }, null)).toBe('Marked John 15:5 in a note');
@@ -276,7 +259,6 @@ describe('a chapter row', () => {
     for (const step of [0, 1, 2]) {
       expect(rungIdentityIsTheAnswer({ kind: 'chapter', ladderStep: step })).toBe(false);
     }
-    // The prompt already names it, so nothing is repeated underneath.
     expect(reviewRowSubtitle({ ...item, ladderStep: 0 })).toBeNull();
   });
 });
@@ -294,10 +276,6 @@ describe('reviewRowRecallLabel', () => {
   });
 
   it('leaves it to the framing line where that already said it', () => {
-    /*
-     * A durable item with no reader or curated fact to show read "Pick what comes next · You
-     * have this one. Keep it. · You have this" — one thing said twice in two registers.
-     */
     expect(
       reviewRowRecallLabel({ recallState: 'durable', framing: { template: 'holding' } }, labels),
     ).toBeNull();

--- a/src/utils/review-row-subtitle.ts
+++ b/src/utils/review-row-subtitle.ts
@@ -1,58 +1,23 @@
 import { NOTE_WRITTEN_SOURCE } from '@/utils/study-bible-source-copy';
 import { NOTE_RECOGNIZE_STEP, verseRungFor } from '@/utils/review-prompts';
 
-/**
- * The line under a review question that says *which* thing is being asked about.
- *
- * One implementation for all three places a review item is shown — the Review section on
- * Activity, the Review page, and the dock — because they had drifted into three different
- * answers to the same question, and one of those answers was "nothing at all".
- *
- * What went wrong, and the rule that comes out of it: a row read "What in the text itself led
- * you to write this note?" with no other identifier, because the note's title was the server's
- * auto-generated "Untitled Note 4" and display strips those. The prompt fell back to "this
- * note" and the subtitle was suppressed for being redundant with a title that did not exist.
- * The reader had a question about a note they could not name.
- *
- * So: the subtitle is only ever suppressed when the question *actually contains* the identity,
- * and there is always an identity to fall back to.
- *
- * What it shows, in order:
- *
- * 1. **The note's own opening words** (`noteContext`), which is the line the scripture row has
- *    always had — the reference on top, a fragment of the verse beneath. A note deserves the
- *    same, and this is the most context per character available without opening it.
- * 2. Its title or the passage it cites, when there is no body to quote and the question has
- *    not already named it.
- * 3. The date it was written. Last resort and only that: it says when, not what, and "Written
- *    Jul 10" turned out to be no more use than saying nothing.
- */
-
 const WRITTEN_PREFIX = 'Written ';
 
 export interface ReviewRowSubtitleInput {
   prompt: string;
-  /** Needed to know whether this row's question is one with a right answer. */
   kind?: string | null;
   ladderStep?: number | null;
-  /** The resolved rung. A step alone can only name the family default. */
   promptKey?: string | null;
-  /** Server-resolved: title, else the note's opening line, else the passage it cites. */
   noteLabel?: string | null;
-  /** The note's own opening words. Preferred over everything else — it is the context line. */
   noteContext?: string | null;
   noteTitle?: string | null;
   scriptureReference?: string | null;
-  /** ISO date, the last resort for a note with no name and no passage. */
+  /** Abbreviation of the translation this passage was asked in. */
+  translation?: string | null;
   noteWrittenAt?: string | null;
-  /**
-   * The stem of the question, when the subject's name *is* the answer.
-   * A quoted line from the note, or a fragment of the verse — unique, and not a spoiler.
-   */
   cue?: string | null;
 }
 
-/** "9 Aug" / "9 Aug 2025" — formatted on the client, which is the only side that knows the zone. */
 export function writtenAtLabel(iso: string, now: Date = new Date()): string | null {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return null;
@@ -64,27 +29,12 @@ export function writtenAtLabel(iso: string, now: Date = new Date()): string | nu
   });
 }
 
-/**
- * The identity line, or null when the question already carries it.
- *
- * `now` is injectable so the year-eliding date is testable.
- */
 export function reviewRowSubtitle(
   item: ReviewRowSubtitleInput,
   now: Date = new Date(),
 ): string | null {
-  /*
-   * Nothing at all when the identity line *is* the answer — "Where is this from?" with
-   * "John 15:5" underneath is not a question, and neither is "Which of your notes says this?"
-   * above the note's name.
-   *
-   * Only those two rungs. Suppressing it for every graded rung was too much: "What did you link
-   * this to?" with nothing beneath it does not say which note is being asked about, so the
-   * reader cannot answer it either. A right answer is not a reason to withhold the question.
-   */
   if (rungIdentityIsTheAnswer(item)) return null;
 
-  // The note's own words win outright: the question above names the note, this shows it.
   const context = item.noteContext?.trim();
   if (context) return context;
 
@@ -92,12 +42,9 @@ export function reviewRowSubtitle(
     item.noteLabel?.trim() || item.noteTitle?.trim() || item.scriptureReference?.trim() || null;
 
   if (identity) {
-    // Suppressed only when the question really does name it — "what did you observe in My
-    // journey?" does not need "My journey" repeated directly underneath.
     return item.prompt.includes(identity) ? null : identity;
   }
 
-  // Nothing names this note, so place it in time rather than leaving the row anonymous.
   if (item.noteWrittenAt) {
     const written = writtenAtLabel(item.noteWrittenAt, now);
     if (written) return `${WRITTEN_PREFIX}${written}`;
@@ -105,41 +52,17 @@ export function reviewRowSubtitle(
   return null;
 }
 
-/**
- * The "why is this here" line, dropped when the identity line already said it.
- *
- * "You wrote this" earns its place on a row that would otherwise say nothing about where the
- * question came from. Beside the note's own sentence it says nothing at all — the reader can
- * see whose words those are — and beside "Written 10 Jul" it is the same fact twice.
- *
- * Every other reason survives, because each says something the context line does not: "Marked
- * Romans 1:7 in a note", "You linked these notes", "You opened this again".
- */
 export function reviewRowSource(
   item: { sourceLabel?: string | null; kind?: string | null; ladderStep?: number | null },
   subtitle: string | null,
 ): string | null {
   const source = item.sourceLabel?.trim() || null;
   if (!source) return null;
-  /*
-   * A verse's reason names the verse — "Marked Romans 1:7 in a note" — and on the rung that asks
-   * where a fragment is from, that is the answer printed under the question. The identity line is
-   * already suppressed there; the reason has to go with it.
-   */
   if (item.kind === 'verse' && rungIdentityIsTheAnswer(item)) return null;
   if (!subtitle) return source;
   return source === NOTE_WRITTEN_SOURCE ? null : source;
 }
 
-/**
- * How well the reader holds this, for the row's meta line — or nothing.
- *
- * Two suppressions. "New" says nothing useful on a row that is by definition being asked for
- * the first time. And where the framing line already speaks to the state, the row printed it
- * twice: a durable item with no reader or curated fact to show read
- * "Pick what comes next · You have this one. Keep it. · You have this", which is the app saying
- * one thing in two registers and trusting neither.
- */
 export function reviewRowRecallLabel(
   item: { recallState?: string | null; framing?: { template: string } | null },
   labels: Record<string, string>,
@@ -150,71 +73,53 @@ export function reviewRowRecallLabel(
   return labels[state] ?? null;
 }
 
-/** When the subject is the answer, the row says which *kind* of thing it is and no more. */
 export const REVIEW_SUBJECT_HIDDEN_NOTE = 'One of your notes';
 export const REVIEW_SUBJECT_HIDDEN_VERSE = 'One of your passages';
 
-/**
- * What the row leads with: the thing being reviewed, not the question about it.
- *
- * Home has always read this way — "A passage you keep returning to · Across 5 of your notes" —
- * and Review had it inverted, with the question as the title and the subject demoted underneath,
- * so a shelf of rows read as questions about nothing in particular.
- *
- * On the two rungs whose answer *is* the subject, this says only what kind of thing it is. Naming
- * it there would print the answer on the row.
- */
+/** The stem of a recognize/locate row: a quoted line, never a bare run-on. */
+export function formatReviewCue(cue: string | null | undefined): string | null {
+  const trimmed = cue?.trim();
+  if (!trimmed) return null;
+  const inner = trimmed.replace(/^[“”"'‘’]+/, '').replace(/[“”"'‘’]+$/, '').trim();
+  if (!inner) return null;
+  return `“${inner}”`;
+}
+
 export function reviewRowSubject(
   item: ReviewRowSubtitleInput & { kind?: string | null },
   now: Date = new Date(),
 ): string {
   if (rungIdentityIsTheAnswer(item)) {
-    // The quoted line is the question, not the answer. "One of your notes" five times
-    // was a shelf of identical rows; the fragment is how the reader tells them apart.
-    const cue = item.cue?.trim();
+    const cue = formatReviewCue(item.cue);
     if (cue) return cue;
     return item.kind === 'verse' ? REVIEW_SUBJECT_HIDDEN_VERSE : REVIEW_SUBJECT_HIDDEN_NOTE;
   }
 
   const reference = item.scriptureReference?.trim();
-  // A passage or a chapter leads with its address — "John 15:5", "John 3".
-  if ((item.kind === 'verse' || item.kind === 'chapter') && reference) return reference;
+  if ((item.kind === 'verse' || item.kind === 'chapter') && reference) {
+    const version = item.translation?.trim();
+    return version ? `${reference} · ${version}` : reference;
+  }
 
   const named = item.noteLabel?.trim() || item.noteTitle?.trim() || reference;
   if (named) return named;
 
-  // Last resort, and only that: it says when, not what.
   const written = item.noteWrittenAt ? writtenAtLabel(item.noteWrittenAt, now) : null;
   if (written) return `${WRITTEN_PREFIX}${written}`;
 
   return REVIEW_SUBJECT_HIDDEN_NOTE;
 }
 
-/**
- * Is this row's question one the app marks?
- *
- * Every note rung is a multiple choice. Two verse rungs are: put the phrases back in order, and
- * say which passage a fragment came from. On all of them the row's usual context line would
- * give the answer away before the reader opened the card.
- */
 export function rungIdentityIsTheAnswer(item: {
   kind?: string | null;
   ladderStep?: number | null;
-  /** The resolved rung, when the caller has it. A step alone can only name the family default. */
   promptKey?: string | null;
 }): boolean {
-  // "Which of your notes says this?" — the note's identity is the whole answer.
-  // The resolved prompt wins: a note still on step 0 may be asked a passage or a
-  // link instead, and hiding its name there left a shelf of identical rows.
   if (item.kind === 'note') {
     if (item.promptKey) return item.promptKey === 'note.recognize';
     return item.ladderStep === NOTE_RECOGNIZE_STEP;
   }
-  // A chapter is named in every one of its prompts and is never the answer to any of them.
   if (item.kind !== 'verse') return false;
-  // "Where is this from?" — so is the reference. The server's resolved rung wins: with families a
-  // step can wear several rungs, and only the one that was actually asked is the truth.
   const key = item.promptKey ?? verseRungFor(item.ladderStep ?? 0).key;
-  // The reference, or the book: either names the answer.
   return key === 'verse.locate' || key === 'verse.book';
 }


### PR DESCRIPTION
The sitting that was still a quiz of one kind, plus the trial card that forgot itself.

**Trial**
- Not now puts the completed sample away (cached query data used to keep it on screen).
- Get Plus then back keeps the completed sitting for the day.
- Translation abbreviation + switcher, same idea as a scripture dock. Sample uses the account default instead of hardcoded NET.

**Stems**
- Recognize rows quote a short clause, not a 12-word run-on that crosses a sentence.
- Verse rows can show `John 15:5 · ESV`.

**Paid sitting** (landing on this branch)
- New verses open on fill-in-the-blank, then the connect/theme family.
- A note that cites scripture is asked to fill the missing words from that passage, not only to pick which reference it cited.
- The paid dock gets the same translation control on cloze cards.

Merge to ship via the existing Cloudflare + Fly auto-deploy.