### PR TITLE
Review: strongest eight on screen, never more

### DIFF
--- a/spa/src/pages/prototype/PrototypeReviewSample.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewSample.tsx
@@ -62,13 +62,14 @@ export default function PrototypeReviewSample({
       return stored ? { correct: stored.correct, verseText: stored.verseText } : null;
     },
   );
-  const translationLabel = TRANSLATIONS[sample.translation]?.abbreviation ?? sample.translation;
+  const translation = sample.translation?.trim() || 'NET';
+  const translationLabel = TRANSLATIONS[translation]?.abbreviation ?? translation;
 
   const filled = sample.cloze.blankLengths.every((_, i) => (blanks[i] ?? '').trim().length > 0);
 
   const submit = () => {
     answer.mutate(
-      { day, translation: sample.translation, words: sample.cloze.blankLengths.map((_, i) => (blanks[i] ?? '').trim()), attemptNumber },
+      { day, translation, words: sample.cloze.blankLengths.map((_, i) => (blanks[i] ?? '').trim()), attemptNumber },
       {
         onSuccess: (data) => {
           if (data.finalized === false) {
@@ -78,7 +79,7 @@ export default function PrototypeReviewSample({
           }
           const next = { correct: data.correct, verseText: data.verseText ?? '' };
           setResult(next);
-          writeReviewSampleResult({ day, translation: sample.translation, ...next });
+          writeReviewSampleResult({ day, translation, ...next });
           onAnswered?.();
         },
       },
@@ -96,13 +97,13 @@ export default function PrototypeReviewSample({
           <label>
             <select
               className="proto-caption"
-              value={sample.translation}
+              value={translation}
               onChange={(event) => onTranslationChange(event.target.value)}
               aria-label="Translation"
             >
-              {TRANSLATION_ORDER.map((row) => (
-                <option key={row.id} value={row.id}>
-                  {row.abbreviation}
+              {TRANSLATION_ORDER.map((id) => (
+                <option key={id} value={id}>
+                  {TRANSLATIONS[id]?.abbreviation ?? id}
                 </option>
               ))}
             </select>

--- a/src/utils/__tests__/review-visible-cap.test.ts
+++ b/src/utils/__tests__/review-visible-cap.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { REVIEW_INBOX_MAX_ROWS, REVIEW_SESSION_CAP } from '@/utils/review-item-kinds';
+
+describe('review visible cap', () => {
+  it('shows at most eight strongest items in the sitting and on Activity', () => {
+    expect(REVIEW_INBOX_MAX_ROWS).toBe(8);
+    expect(REVIEW_SESSION_CAP).toBe(8);
+    expect(REVIEW_SESSION_CAP).toBe(REVIEW_INBOX_MAX_ROWS);
+  });
+});

--- a/src/utils/review-item-kinds.ts
+++ b/src/utils/review-item-kinds.ts
@@ -8,16 +8,6 @@
  * reader set by answering it, and disappears only when they say so.
  */
 
-/**
- * The six shapes of a review item, which are six different questions.
- *
- * `note` asks what you observed. `highlight` asks why you marked it. `connection` asks why
- * you linked two notes — the only kind with two note ids. `thread` asks what the whole
- * cluster is forming, and is keyed by the representative note the graph picked. `verse` is
- * the memory ladder, whose prompt changes as you succeed at it. `chapter` is the newest: a
- * chapter you sat with in the Bible reader, asked about from its own text and the curated
- * index — the reading half of the loop that Home's "write about what you read" card opens.
- */
 export const REVIEW_ITEM_KINDS = ['note', 'highlight', 'connection', 'thread', 'verse', 'chapter'] as const;
 
 export type ReviewItemKind = (typeof REVIEW_ITEM_KINDS)[number];
@@ -26,18 +16,6 @@ export function isReviewItemKind(value: string): value is ReviewItemKind {
   return (REVIEW_ITEM_KINDS as readonly string[]).includes(value);
 }
 
-/**
- * The kinds Review still has an answerable question for.
- *
- * `highlight`, `connection` and `thread` asked open questions — "why did you connect these?",
- * "what is taking shape across your Thread?" — which are the same shape the note prompts were
- * retired for. They are worth asking; they are not worth *marking*, and a queue that mixes
- * things you can be right about with things you cannot is not a review.
- *
- * They went where the note prompts went: Home, as a suggestion. `REVIEW_ITEM_KINDS` keeps all
- * five because rows for the retired kinds exist in the table and their source keys must keep
- * resolving — this is about what may be *created*, not about what may be read.
- */
 export const REVIEW_ASKABLE_KINDS = ['note', 'verse', 'chapter'] as const;
 
 export type ReviewAskableKind = (typeof REVIEW_ASKABLE_KINDS)[number];
@@ -46,15 +24,6 @@ export function isReviewAskableKind(value: string): value is ReviewAskableKind {
   return (REVIEW_ASKABLE_KINDS as readonly string[]).includes(value);
 }
 
-/**
- * Three answers, and none of them is a rating.
- *
- * "I recalled it" / "I almost had it" describe the state of a memory, not satisfaction with
- * the app — which is why there is no thumbs anywhere in this feature. `revealed` is not a
- * button the reader presses to grade themselves; it is what gets recorded when they open the
- * source without attempting, and the interval shortens accordingly. Reading a note you could
- * not remember is a perfectly good outcome and the copy never suggests otherwise.
- */
 export const REVIEW_OUTCOMES = ['recalled', 'almost', 'revealed'] as const;
 
 export type ReviewOutcome = (typeof REVIEW_OUTCOMES)[number];
@@ -63,7 +32,6 @@ export function isReviewOutcome(value: string): value is ReviewOutcome {
   return (REVIEW_OUTCOMES as readonly string[]).includes(value);
 }
 
-/** Everything ReviewEvents records. The three outcomes plus the lifecycle verbs. */
 export const REVIEW_EVENT_ACTIONS = [
   'shown',
   'recalled',
@@ -81,12 +49,6 @@ export function isReviewEventAction(value: string): value is ReviewEventAction {
   return (REVIEW_EVENT_ACTIONS as readonly string[]).includes(value);
 }
 
-/**
- * `paused` and `archived` differ the way a snooze differs from a dismissal on the recall
- * shelf: paused is a season ("not while I am in Romans"), archived is "I am done with this".
- * Both are reversible here, because unlike a suggestion the reader put this item in the queue
- * themselves and should be able to take it back out and put it back.
- */
 export const REVIEW_ITEM_STATUSES = ['active', 'paused', 'archived'] as const;
 
 export type ReviewItemStatus = (typeof REVIEW_ITEM_STATUSES)[number];
@@ -95,19 +57,6 @@ export function isReviewItemStatus(value: string): value is ReviewItemStatus {
   return (REVIEW_ITEM_STATUSES as readonly string[]).includes(value);
 }
 
-/**
- * How well the reader currently holds this, derived from their answers.
- *
- * Shown as a quiet word, never a percentage or a bar. "Fragile" is information; "34%
- * retention" is a score, and scoring someone's grasp of Scripture is exactly what this
- * product does not do.
- */
-/**
- * `slipping` is the fifth, and the one place Review says a thing is not working rather than
- * asking it again: an item missed four times after being held. It is derived, like the rest,
- * from the lapse count in `review-scheduling.ts`, and it clears when the reader steps the
- * item back a rung or holds it again.
- */
 export const RECALL_STATES = ['new', 'fragile', 'forming', 'durable', 'slipping'] as const;
 
 export type RecallState = (typeof RECALL_STATES)[number];
@@ -116,20 +65,6 @@ export function isRecallState(value: string): value is RecallState {
   return (RECALL_STATES as readonly string[]).includes(value);
 }
 
-/**
- * Five states, three things worth saying.
- *
- * The words came from the model rather than from the reader: "Still fragile", "Forming",
- * "Holding" and "Slipping" were four metaphors — glass, clay, grip, slope — for one axis, and
- * three were the enum's own values promoted to a caption. The first rewrite kept the shape and
- * fixed the words, which was not enough: "Needs work" is a school report about the reader, and
- * "Coming back" says nothing at all.
- *
- * So the shape goes too. `fragile` and `forming` differ by whether you have got something right
- * once or twice running, and nobody needs to be told that difference about their own study —
- * both are still learning it. What is left is the three states a person would actually name:
- * learning it, knowing it, losing it.
- */
 export const RECALL_STATE_LABELS: Record<RecallState, string> = {
   new: 'New',
   fragile: 'Still learning',
@@ -138,13 +73,6 @@ export const RECALL_STATE_LABELS: Record<RecallState, string> = {
   slipping: 'Slipping away',
 };
 
-/**
- * Where a review item came from, so the queue stays legible as such.
- *
- * `engine` is the reader's own Study Bible layer noticing something worth returning to —
- * a verse they highlighted, a link they drew, a Thread that has grown. `seed` is the retired
- * cold-start batch, kept in the union because rows written by it are still in the database.
- */
 export const REVIEW_ITEM_ORIGINS = ['user', 'seed', 'challenge', 'engine'] as const;
 
 export type ReviewItemOrigin = (typeof REVIEW_ITEM_ORIGINS)[number];
@@ -166,11 +94,6 @@ export function isChallengeTemplateKey(value: string): value is ChallengeTemplat
   return (CHALLENGE_TEMPLATE_KEYS as readonly string[]).includes(value);
 }
 
-/**
- * `retired` is not a status the reader can choose — it is what the note cascade writes when a
- * challenge's source note is deleted. Kept distinct from `archived` so the page can say why
- * the path stopped rather than implying the reader put it down.
- */
 export const CHALLENGE_STATUSES = ['active', 'paused', 'completed', 'archived', 'retired'] as const;
 
 export type ChallengeStatus = (typeof CHALLENGE_STATUSES)[number];
@@ -179,7 +102,6 @@ export function isChallengeStatus(value: string): value is ChallengeStatus {
   return (CHALLENGE_STATUSES as readonly string[]).includes(value);
 }
 
-/** The statuses a reader may set directly. `completed` is earned, `retired` is done to them. */
 export const CHALLENGE_SETTABLE_STATUSES = ['active', 'paused', 'archived'] as const;
 
 export type ChallengeSettableStatus = (typeof CHALLENGE_SETTABLE_STATUSES)[number];
@@ -188,14 +110,6 @@ export function isChallengeSettableStatus(value: string): value is ChallengeSett
   return (CHALLENGE_SETTABLE_STATUSES as readonly string[]).includes(value);
 }
 
-/**
- * A step is pending, done, or skipped — and skipped is not failure.
- *
- * The doc is explicit that incomplete work gets no failure language, so a skipped step
- * resolves the step and lets the path finish. Someone who skips every step still completes
- * the challenge, which is the correct outcome: they read the path, decided none of it was
- * what they needed, and that is a real answer.
- */
 export const CHALLENGE_STEP_STATUSES = ['pending', 'done', 'skipped'] as const;
 
 export type ChallengeStepStatus = (typeof CHALLENGE_STEP_STATUSES)[number];
@@ -204,7 +118,6 @@ export function isChallengeStepStatus(value: string): value is ChallengeStepStat
   return (CHALLENGE_STEP_STATUSES as readonly string[]).includes(value);
 }
 
-/** What a step asks for, which decides how the page renders it. */
 export const CHALLENGE_STEP_KINDS = [
   'recall',
   'evidence',
@@ -220,32 +133,8 @@ export function isChallengeStepKind(value: string): value is ChallengeStepKind {
   return (CHALLENGE_STEP_KINDS as readonly string[]).includes(value);
 }
 
-/**
- * Five rows on the Review sitting — a handful, not a pile.
- *
- * The strategy doc's named failure is "27 due". Three left a paid library looking empty.
- * Five is still under the anxiety line and is enough for a real timed sitting. Activity can
- * still present a calm stack; the session is where practice happens.
- */
-/**
- * How many goes a graded rung allows before it shows the answer.
- *
- * Being told "back in 4 days" the instant you slip teaches nothing; trying again while the
- * question is still in front of you is where the repetition does its work. How many goes it took
- * is what sets the interval, so the schedule still reflects how well it went.
- *
- * **The number depends on the exercise, and the reason is the guessing floor.** Four options
- * with one spent leaves three, then two: a third go at a tap is nearly a giveaway, and a fourth
- * would hand it over. Nothing typed has that floor — a second wrong guess at a word you cannot
- * remember is still a wrong guess — so the rungs that ask the reader to produce something get
- * one more, which is where the retrieval actually happens. No document specifies a number; this
- * is argued from the exercises.
- *
- * `REVIEW_MAX_ATTEMPTS` remains the ceiling every bound and clamp is written against.
- */
 export const REVIEW_MAX_ATTEMPTS = 3;
 
-/** Rungs whose answer is one of four on screen. A third go there is not an attempt. */
 const CHOICE_ATTEMPTS = 2;
 const PRODUCED_ATTEMPTS = 3;
 
@@ -271,41 +160,15 @@ export function maxAttemptsFor(promptKey: string | null | undefined): number {
   return promptKey && CHOICE_RUNGS.has(promptKey) ? CHOICE_ATTEMPTS : PRODUCED_ATTEMPTS;
 }
 
-export const REVIEW_INBOX_MAX_ROWS = 5;
+/** Strongest eight. Dismissing one refills from what is waiting. Never a list past this. */
+export const REVIEW_INBOX_MAX_ROWS = 8;
 
-/**
- * Extra rows read so that a note with nothing to ask about costs no slot.
- *
- * Items made before the note ladder existed can carry no question, and they are dropped while
- * views are built. Without slack, three such rows at the front of the queue empty the inbox.
- */
 export const REVIEW_INBOX_UNASKABLE_SLACK = 4;
 
-/** One sitting, not a queue to clear. Deliberately below what a keen reader could manage. */
-export const REVIEW_SESSION_CAP = 10;
+/** One sitting, not a queue to clear. Eight strongest, never a list to clear. */
+export const REVIEW_SESSION_CAP = 8;
 
-/**
- * How many items the engine may add in a rolling day. Five, matching the handful the sitting
- * aims to offer — still far below a debt, enough that a library of notes is actually practiced.
- *
- * Rolling 24 hours rather than a calendar day, because the server has no timezone for the
- * reader — the study feed route refuses to guess one, and this follows it.
- */
 export const REVIEW_ENGINE_DAILY_CAP = 5;
 export const REVIEW_ENGINE_WINDOW_HOURS = 24;
 
-/**
- * How much unanswered study the engine will let pile up before it stops offering more.
- *
- * `REVIEW_ENGINE_DAILY_CAP` limits how fast the queue grows; nothing limited how big it got.
- * Three a day, none of them answered, is ninety in a month — and because the inbox shows three,
- * the pile stays invisible until something names the count and the reader is told they are ninety
- * behind. This file already argues that a number like that is a debt rather than a practice.
- *
- * Four sittings' worth at `REVIEW_INBOX_MAX_ROWS`. Enough that a normal week of
- * skipping a day does not trip it, low enough that nobody meets a wall of their own study.
- *
- * It is a pause, not a penalty: answering a few drops the count back under and the engine resumes
- * on its own. Only *due* items count, so something scheduled for next week never holds it.
- */
 export const REVIEW_ENGINE_MAX_OUTSTANDING = REVIEW_INBOX_MAX_ROWS * 4;


### PR DESCRIPTION
Activity and the sitting were able to list every due item. Ten-plus on one screen is the backlog this feature is designed against.

- Inbox and sitting cap at 8 (`REVIEW_INBOX_MAX_ROWS` / `REVIEW_SESSION_CAP`)
- Strongest first (due, then near, mixed notes and passages — same `composeSitting` as today)
- Defer / dismiss still invalidates the queue, so the next strongest fills the hole
- Daily engine cap stays 5; the eight can include what was already waiting

Merge to ship via GitHub Actions.