### PR TITLE
Review: two different types closed, never more than eight

### DIFF
--- a/spa/src/pages/prototype/PrototypeReviewSection.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewSection.tsx
@@ -10,7 +10,6 @@ import {
   useReviewItems,
   useReviewItemsSummary,
   useReviewSample,
-  type ReviewItemView,
 } from '../../hooks/queries/useReview';
 import { REVIEW_MAX_ATTEMPTS, REVIEW_INBOX_MAX_ROWS } from '@/utils/review-item-kinds';
 import PrototypeReviewSample from './PrototypeReviewSample';
@@ -35,23 +34,15 @@ import {
 } from './proto-review-copy';
 import PrototypeListEmptyState from './PrototypeListEmptyState';
 import { prototypeChallengeRouteTo } from '@/lib/prototype-path';
-import { type ReviewItemKind } from '@/utils/review-item-kinds';
 import { fillFraming } from '@/utils/review-framing';
 import { reviewRowSource, reviewRowSubject } from '@/utils/review-row-subtitle';
 import { reviewKindIcon } from './review-kind-icons';
 import { describeNextDue } from '@/utils/review-scheduling';
 import { recallChip } from './PrototypeRecallStateChip';
 import { reviewFoldRemainder } from './review-fold-remainder';
+import { collapsedReviewRows } from './review-collapsed-rows';
 import { useDismissiblePlusPrompt } from './use-dismissible-plus-prompt';
 import { useDismissibleReviewSample } from './use-dismissible-review-sample';
-
-const PASSAGE_KINDS = new Set<ReviewItemKind>(['verse', 'highlight', 'chapter']);
-
-function collapsedReviewRows(items: readonly ReviewItemView[]): ReviewItemView[] {
-  const note = items.find((item) => !PASSAGE_KINDS.has(item.kind));
-  const passage = items.find((item) => PASSAGE_KINDS.has(item.kind));
-  return items.filter((item) => item === note || item === passage);
-}
 
 function foldedLabel(folded: number | null): string {
   return folded !== null && folded > 0 ? `${folded} more` : REVIEW_SEE_ALL_COPY;
@@ -277,7 +268,7 @@ export default function PrototypeReviewSection() {
             <Icon name={setAsideOpen ? 'caret-up' : 'caret-down'} size={10} />
           </button>
           {setAsideOpen
-            ? setAside.map((item) => (
+            ? setAside.slice(0, REVIEW_INBOX_MAX_ROWS).map((item) => (
                 <PrototypeHomeRow
                   key={item.id}
                   icon={item.status === 'paused' ? 'circle-minus' : 'eye-slash'}

--- a/spa/src/pages/prototype/__tests__/review-collapsed-rows.test.ts
+++ b/spa/src/pages/prototype/__tests__/review-collapsed-rows.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { collapsedReviewRows } from '../review-collapsed-rows';
+
+function row(id: string, kind: string, promptKey: string) {
+  return { id, kind, promptKey, task: promptKey };
+}
+
+describe('collapsedReviewRows', () => {
+  it('prefers one note and one scripture', () => {
+    const items = [
+      row('n1', 'note', 'note.recognize'),
+      row('n2', 'note', 'note.passage'),
+      row('v1', 'verse', 'verse.recognize'),
+    ];
+    expect(collapsedReviewRows(items).map((item) => item.id)).toEqual(['n1', 'v1']);
+  });
+
+  it('shows two different exercises when the pile is all scripture', () => {
+    const items = [
+      row('v1', 'verse', 'verse.recognize'),
+      row('v2', 'verse', 'verse.recognize'),
+      row('v3', 'verse', 'verse.rebuild'),
+    ];
+    expect(collapsedReviewRows(items).map((item) => item.id)).toEqual(['v1', 'v3']);
+  });
+
+  it('never returns more than two closed', () => {
+    const items = Array.from({ length: 8 }, (_, i) => row(`v${i}`, 'verse', `verse.${i}`));
+    expect(collapsedReviewRows(items)).toHaveLength(2);
+  });
+});

--- a/spa/src/pages/prototype/review-collapsed-rows.ts
+++ b/spa/src/pages/prototype/review-collapsed-rows.ts
@@ -1,0 +1,29 @@
+export const REVIEW_COLLAPSED_ROWS = 2;
+
+export const REVIEW_PASSAGE_KINDS = new Set<string>(['verse', 'highlight', 'chapter']);
+
+export function reviewVariationKey(item: {
+  kind: string;
+  promptKey?: string | null;
+  task?: string | null;
+}): string {
+  return `${item.kind}:${item.promptKey ?? item.task ?? ''}`;
+}
+
+/** Closed Activity: two rows, different halves when both exist, else two different exercises. */
+export function collapsedReviewRows<T extends {
+  id: string;
+  kind: string;
+  promptKey?: string | null;
+  task?: string | null;
+}>(items: readonly T[]): T[] {
+  if (items.length <= REVIEW_COLLAPSED_ROWS) return [...items];
+  const note = items.find((item) => !REVIEW_PASSAGE_KINDS.has(item.kind));
+  const passage = items.find((item) => REVIEW_PASSAGE_KINDS.has(item.kind));
+  if (note && passage) return [note, passage];
+  const first = items[0];
+  const second =
+    items.find((item) => item.id !== first.id && reviewVariationKey(item) !== reviewVariationKey(first)) ??
+    items[1];
+  return [first, second];
+}


### PR DESCRIPTION
Closed Activity went back to one row whenever the inbox was all scripture (or all notes). The fold kept one note *or* one passage, not two of either.

- Closed: two rows when two exist
- Prefer one scripture + one note
- If the pile is only one half, show two different exercises instead of two copies of the same tap
- Opened list, coming-back, and set-aside stay sliced at 8. Never a ninth card.

```
git fetch origin review-collapsed-pair
git checkout review-collapsed-pair
npm run dev
```
http://localhost:4322