### PR TITLE
fix(onboarding): closing the card is not putting the checklist away

### DIFF
--- a/spa/src/pages/prototype/PrototypeOnboardingDock.tsx
+++ b/spa/src/pages/prototype/PrototypeOnboardingDock.tsx
@@ -29,7 +29,7 @@ import { prototypeSettingsTranslationRouteTo } from './prototype-settings-transl
 import { CUSTOMIZE_STEP_COPY } from './onboarding-customize-copy';
 import type { PushSupport } from '../../lib/push-reminders';
 import {
-  ONBOARDING_VERSION,
+  isOnboardingClusterDismissed,
   type OnboardingCustomizeId,
   type OnboardingStepId,
 } from '@/utils/onboarding-state';
@@ -113,8 +113,8 @@ export default function PrototypeOnboardingDock({ onStepAction, variant = 'home'
     [navigate],
   );
 
-  const dismissed = state.dismissedVersion >= ONBOARDING_VERSION;
-  const showing = !dismissed && (visible || isGuest || exiting.length > 0);
+  const showing =
+    !isOnboardingClusterDismissed(state) && (visible || isGuest || exiting.length > 0);
   const liveIds = showing
     ? [...rows, ...customizeRows].filter((r) => !exiting.includes(r.id)).map((r) => r.id)
     : [];
@@ -240,7 +240,12 @@ export default function PrototypeOnboardingDock({ onStepAction, variant = 'home'
     return (
       <>
         {list}
-        {customizePanel}
+        {customizePanel ? (
+          <>
+            <p className="proto-caption proto-feed-part__eyebrow">Make it yours</p>
+            {customizePanel}
+          </>
+        ) : null}
       </>
     );
   }
@@ -264,7 +269,7 @@ export default function PrototypeOnboardingDock({ onStepAction, variant = 'home'
             <button
               type="button"
               className="proto-side-panel__action-btn proto-onboarding-dock__dismiss"
-              aria-label="Dismiss getting started"
+              aria-label="Hide getting started"
               onClick={dismissAll}
             >
               <Icon name="xmark" size={12} aria-hidden />

--- a/spa/src/pages/prototype/PrototypeOnboardingPopover.tsx
+++ b/spa/src/pages/prototype/PrototypeOnboardingPopover.tsx
@@ -3,9 +3,12 @@
  *
  * It used to exist only at the top of Activity, which meant the one surface that explains the
  * app was the one surface you had to already know how to get back to. This is the same list in
- * the toolbar's card, on every screen, still dismissible — and still not a tour: no overlay, no
- * scrim, no arrow pointing at anything, nothing that has to be got past. It opens because
- * someone asked for it.
+ * the toolbar's card, on every screen — and still not a tour: no overlay, no scrim, no arrow
+ * pointing at anything, nothing that has to be got past. It opens because someone asked for it.
+ *
+ * Closing the card is not putting the checklist away. The ✕, a click outside, and Escape only
+ * hide the card. "Hide getting started" at the bottom is the cluster dismiss, which Support
+ * can undo.
  *
  * Rows hand off rather than navigate. Home owns `handleOnboardingStep`, which knows that
  * "write a note" means a compose session and "revisit" means glowing the recall shelf; the
@@ -89,18 +92,11 @@ export default function PrototypeOnboardingPopover({
             {progress.done} of {progress.total}
           </span>
         </p>
-        {/*
-          "Put it away" rather than a plain close: closing a popover and retiring the checklist
-          are different intentions, and the ✕ in the corner already means the first one.
-        */}
         <button
           type="button"
           className="proto-side-panel__action-btn"
-          aria-label="Dismiss getting started"
-          onClick={() => {
-            dismissAll();
-            onDismiss();
-          }}
+          aria-label="Close getting started"
+          onClick={onDismiss}
         >
           <Icon name="xmark" size={12} aria-hidden />
         </button>
@@ -114,6 +110,17 @@ export default function PrototypeOnboardingPopover({
           void navigate({ to: prototypeHomeRouteTo() });
         }}
       />
+
+      <button
+        type="button"
+        className="proto-onboarding-popover__hide"
+        onClick={() => {
+          dismissAll();
+          onDismiss();
+        }}
+      >
+        Hide getting started
+      </button>
     </ProtoPopoverShell>,
     document.body,
   );

--- a/spa/src/pages/prototype/PrototypeOnboardingPopover.tsx
+++ b/spa/src/pages/prototype/PrototypeOnboardingPopover.tsx
@@ -41,7 +41,7 @@ export default function PrototypeOnboardingPopover({
   exiting?: boolean;
 }) {
   const navigate = useNavigate();
-  const { state, dismissAll } = useOnboardingState();
+  const { dismissAll } = useOnboardingState();
   const { isGuest } = useHarvousIdentity();
   const progress = shownOnboardingProgress(state, isGuest);
   const cardRef = useRef<HTMLDivElement | null>(null);

--- a/spa/src/pages/prototype/PrototypeOnboardingPopover.tsx
+++ b/spa/src/pages/prototype/PrototypeOnboardingPopover.tsx
@@ -41,7 +41,7 @@ export default function PrototypeOnboardingPopover({
   exiting?: boolean;
 }) {
   const navigate = useNavigate();
-  const { dismissAll } = useOnboardingState();
+  const { state, dismissAll } = useOnboardingState();
   const { isGuest } = useHarvousIdentity();
   const progress = shownOnboardingProgress(state, isGuest);
   const cardRef = useRef<HTMLDivElement | null>(null);

--- a/spa/src/pages/prototype/__tests__/onboarding-customize-offers.test.ts
+++ b/spa/src/pages/prototype/__tests__/onboarding-customize-offers.test.ts
@@ -4,6 +4,7 @@ import {
   dismissStep,
   emptyOnboardingState,
   markStep,
+  restoreOnboarding,
   ONBOARDING_STEP_IDS,
   type OnboardingState,
 } from '@/utils/onboarding-state';
@@ -61,6 +62,11 @@ describe('onboardingOwnsOffer', () => {
 
   it('hands it back when the checklist is dismissed', () => {
     expect(onboardingOwnsOffer(dismissOnboarding(live()), 'import', false)).toBe(false);
+  });
+
+  it('takes the offer again after Support restores the checklist', () => {
+    const back = restoreOnboarding(dismissOnboarding(live()));
+    expect(onboardingOwnsOffer(back, 'import', false)).toBe(true);
   });
 
   it('hands it back for a row the reader has already settled', () => {

--- a/spa/src/pages/prototype/onboarding-customize-copy.ts
+++ b/spa/src/pages/prototype/onboarding-customize-copy.ts
@@ -11,18 +11,6 @@ export interface OnboardingCustomizeCopy {
 /** "Make it yours" rows under Getting started. */
 export const CUSTOMIZE_STEP_COPY: readonly OnboardingCustomizeCopy[] = [
   {
-    id: 'reminders',
-    icon: 'bell',
-    title: 'Turn on reminders',
-    meta: 'A verse Sunday morning, a nudge midweek.',
-  },
-  {
-    id: 'appearance',
-    icon: 'paintbrush',
-    title: 'Pick your look',
-    meta: 'Background color or image behind the app.',
-  },
-  {
     id: 'translation',
     icon: 'scroll',
     title: 'Choose a translation',
@@ -33,5 +21,17 @@ export const CUSTOMIZE_STEP_COPY: readonly OnboardingCustomizeCopy[] = [
     icon: 'cloud-arrow-up',
     title: 'Bring your notes in',
     meta: 'Markdown, Word, Evernote, or a folder of files.',
+  },
+  {
+    id: 'appearance',
+    icon: 'paintbrush',
+    title: 'Pick your look',
+    meta: 'Background color or image behind the app.',
+  },
+  {
+    id: 'reminders',
+    icon: 'bell',
+    title: 'Turn on reminders',
+    meta: 'A verse Sunday morning, a nudge midweek.',
   },
 ];

--- a/spa/src/styles/prototype-route-overrides-4.css
+++ b/spa/src/styles/prototype-route-overrides-4.css
@@ -152,3 +152,41 @@ html.harvous-prototype-route .proto-feed-said__quote {
   -webkit-line-clamp: 2;
   overflow: hidden;
 }
+
+/*
+ * Getting-started card: close is not put-away. The footer is the cluster dismiss.
+ * Also drop the extra panel chrome when Make it yours rides in the same card.
+ */
+html.harvous-prototype-route .proto-onboarding-popover .proto-feed-part__panel {
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+}
+
+html.harvous-prototype-route .proto-onboarding-popover .proto-feed-part__eyebrow {
+  margin: 10px 0 2px;
+  padding: 0 var(--pds-space-1);
+}
+
+html.harvous-prototype-route button.proto-onboarding-popover__hide,
+html.harvous-prototype-route button.proto-onboarding-popover__hide * {
+  display: block;
+  width: 100%;
+  margin: var(--pds-space-2) 0 0;
+  padding: var(--pds-space-2) var(--pds-space-1) 0;
+  border: 0;
+  background: transparent;
+  color: var(--pds-text-secondary) !important;
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+html.harvous-prototype-route button.proto-onboarding-popover__hide:hover,
+html.harvous-prototype-route button.proto-onboarding-popover__hide:focus-visible,
+html.harvous-prototype-route button.proto-onboarding-popover__hide:hover *,
+html.harvous-prototype-route button.proto-onboarding-popover__hide:focus-visible * {
+  color: var(--pds-text-primary) !important;
+}

--- a/src/utils/__tests__/onboarding-state.test.ts
+++ b/src/utils/__tests__/onboarding-state.test.ts
@@ -5,9 +5,12 @@ import {
   ONBOARDING_STEP_IDS,
   ONBOARDING_VERSION,
   deriveInitialLatches,
+  canRestoreOnboarding,
   dismissOnboarding,
   dismissStep,
   emptyOnboardingState,
+  isOnboardingClusterDismissed,
+  restoreOnboarding,
   markStep,
   markSteps,
   mergeOnboardingStates,
@@ -66,7 +69,6 @@ describe('parseOnboardingState', () => {
     expect(state!.version).toBe(1);
     expect(state!.dismissedVersion).toBe(0);
     expect(state!.completedAt).toBeNull();
-    // A truthy non-boolean must not count as done — only `true` does.
     expect(state!.steps.note.done).toBe(false);
   });
 
@@ -100,7 +102,6 @@ describe('mergeOnboardingStates', () => {
   });
 
   it('is commutative and idempotent for a two-device race', () => {
-    // Phone did two steps offline; laptop did two others and dismissed one.
     const phone = markSteps(emptyOnboardingState(), ['read', 'note'], T1);
     const laptop = dismissStep(markSteps(emptyOnboardingState(), ['pill', 'thread'], T2), 'recall');
 
@@ -125,8 +126,6 @@ describe('mergeOnboardingStates', () => {
   });
 
   it('survives a stale device pushing over newer progress', () => {
-    // The bug this whole module exists to prevent: laptop syncs Wednesday's progress, then
-    // a phone that has been offline since Tuesday flushes its copy.
     const account = markSteps(emptyOnboardingState(), ['read', 'note', 'pill'], T3);
     const stalePhone = markStep(emptyOnboardingState(), 'read', T1);
     const afterFlush = mergeOnboardingStates(account, stalePhone);
@@ -140,7 +139,7 @@ describe('markStep / completion', () => {
     const once = markStep(emptyOnboardingState(), 'note', T1);
     const twice = markStep(once, 'note', T3);
     expect(twice.steps.note.at).toBe(T1);
-    expect(twice).toBe(once); // no-op returns the same reference
+    expect(twice).toBe(once);
   });
 
   it('stamps completedAt only when every step is done', () => {
@@ -203,6 +202,19 @@ describe('shouldShowOnboarding', () => {
     for (const id of ONBOARDING_STEP_IDS.slice(1)) state = markStep(state, id, T1);
     expect(shouldShowOnboarding(state)).toBe(true);
   });
+
+  it('comes back after a restore, even though dismissedVersion stays set', () => {
+    const putAway = dismissOnboarding(emptyOnboardingState());
+    expect(isOnboardingClusterDismissed(putAway)).toBe(true);
+    expect(canRestoreOnboarding(putAway)).toBe(true);
+    expect(shouldShowOnboarding(putAway)).toBe(false);
+
+    const back = restoreOnboarding(putAway);
+    expect(back.dismissedVersion).toBe(ONBOARDING_VERSION);
+    expect(isOnboardingClusterDismissed(back)).toBe(false);
+    expect(canRestoreOnboarding(back)).toBe(false);
+    expect(shouldShowOnboarding(back)).toBe(true);
+  });
 });
 
 describe('onboardingProgress', () => {
@@ -215,11 +227,6 @@ describe('onboardingProgress', () => {
   });
 });
 
-/*
- * The customization rows ride in the same record as the tour but must not touch its
- * lifecycle. Every assertion here is really the same one: shipping a new row cannot bring
- * the dock back for an account that already finished or dismissed it.
- */
 describe('customization steps', () => {
   const completedTour = (): ReturnType<typeof emptyOnboardingState> => {
     let state = emptyOnboardingState();
@@ -265,8 +272,6 @@ describe('customization steps', () => {
   });
 
   it('survive a merge with a client that predates them', () => {
-    /* What an older build pushes: the tour keys only. Its copy must not read as a "no" on
-       rows it has never heard of, or one stale device would sweep them for the account. */
     const legacy = parseOnboardingState(
       JSON.stringify({
         version: 1,

--- a/src/utils/onboarding-state.ts
+++ b/src/utils/onboarding-state.ts
@@ -33,7 +33,7 @@ export type OnboardingStepId =
   | OnboardingCustomizeId;
 
 /**
- * The customization offers — reminders, appearance, translation, import.
+ * The customization offers — translation, import, appearance, reminders.
  *
  * Deliberately *not* part of `ONBOARDING_STEP_IDS`, which is the tour: the six things that
  * teach someone what Harvous is. These four teach nothing. They are settings worth knowing
@@ -64,10 +64,10 @@ export const ONBOARDING_STEP_IDS: readonly OnboardingStepId[] = [
 
 /** Display order of the "Make it yours" section, beneath the tour. */
 export const CUSTOMIZE_STEP_IDS: readonly OnboardingCustomizeId[] = [
-  'reminders',
-  'appearance',
   'translation',
   'import',
+  'appearance',
+  'reminders',
 ];
 
 /**

--- a/src/utils/onboarding-state.ts
+++ b/src/utils/onboarding-state.ts
@@ -268,9 +268,24 @@ export function restoreOnboarding(state: OnboardingState): OnboardingState {
   return { ...state, restoredVersion: state.dismissedVersion };
 }
 
+/**
+ * Whether the cluster has been put away for the current version, and not asked back.
+ *
+ * `dismissedVersion` is monotonic — restore never clears it — so "is it away?" is the
+ * comparison against `restoredVersion`, not a check that a dismissal ever happened.
+ * The dock used to do the latter, which is why Support could restore the chip and still
+ * paint an empty card.
+ */
+export function isOnboardingClusterDismissed(state: OnboardingState | null): boolean {
+  if (!state) return false;
+  return (
+    state.dismissedVersion >= ONBOARDING_VERSION && state.dismissedVersion > state.restoredVersion
+  );
+}
+
 export function canRestoreOnboarding(state: OnboardingState | null): boolean {
   if (!state) return false;
-  if (state.dismissedVersion <= state.restoredVersion) return false;
+  if (!isOnboardingClusterDismissed(state)) return false;
   return !ONBOARDING_STEP_IDS.every((id) => isStepSettled(state.steps[id]));
 }
 
@@ -298,7 +313,6 @@ export function onboardingProgress(state: OnboardingState): OnboardingProgress {
 
 export function shouldShowOnboarding(state: OnboardingState | null): boolean {
   if (!state) return true;
-  if (state.dismissedVersion >= ONBOARDING_VERSION && state.dismissedVersion > state.restoredVersion)
-    return false;
+  if (isOnboardingClusterDismissed(state)) return false;
   return !ONBOARDING_STEP_IDS.every((id) => isStepSettled(state.steps[id]));
 }


### PR DESCRIPTION
Closing the Getting started card in the toolbar was retiring the whole checklist. That was a close, not a put-away.

## What changed

- Toolbar ✕, click-outside, and Escape only close the card.
- **Hide getting started** at the bottom of the card is the cluster dismiss (same as the Home section ✕). Support can still undo that.
- Per-row ✕ is unchanged.
- The dock now treats “put away” as `dismissedVersion > restoredVersion`, same as `shouldShowOnboarding`. Support → Bring the checklist back was restoring the chip and painting an empty card because the dock only looked at `dismissedVersion >= 1`.
- In the card, Make it yours gets its own eyebrow so it reads as a sibling of Getting started, not a second untitled list.
- Make it yours order is now: translation, import, look, reminders.

## Verify

- Open Getting started from the toolbar chip. ✕ / Esc / click outside: chip and Home/Activity rows stay.
- Hide getting started: chip and docks go away.
- Settings → Get Support → Getting started: rows come back in the card and on Home/Activity.
- Make it yours lists Choose a translation, Bring your notes in, Pick your look, Turn on reminders.