### PR TITLE
Repair the test suite main has been failing on since Sept 9

### DIFF
--- a/spa/src/pages/prototype/__tests__/prototype-note-route.test.ts
+++ b/spa/src/pages/prototype/__tests__/prototype-note-route.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { legacySpaceNoteRedirectSearch, router } from '../../../router';
+import { router } from '../../../router';
+/* Moved out of `router` in 60701df92; importing it from there resolved to `undefined` and the
+   call below failed as "not a function" rather than as a wrong answer. */
+import { legacySpaceNoteRedirectSearch } from '../../../router-search';
 
 describe('dedicated prototype note route', () => {
   it('owns /$noteId params and forever-redirects /n/$noteId (shell hosts the note page)', () => {

--- a/spa/src/pages/prototype/__tests__/review-sample-card.test.tsx
+++ b/spa/src/pages/prototype/__tests__/review-sample-card.test.tsx
@@ -60,8 +60,10 @@ describe('the sample card', () => {
     fireEvent.change(second, { target: { value: 'remains' } });
     expect(check.disabled).toBe(false);
     fireEvent.click(check);
+    /* `translation` rides along because the card now offers one — this fixture carries none, so
+       the value here is the card's own default (`sample.translation?.trim() || 'NET'`). */
     expect(mutate).toHaveBeenCalledWith(
-      { day: '2026-09-03', words: ['branches', 'remains'], attemptNumber: 1 },
+      { day: '2026-09-03', translation: 'NET', words: ['branches', 'remains'], attemptNumber: 1 },
       expect.anything(),
     );
   });

--- a/spa/src/pages/prototype/__tests__/review-section-rows.test.tsx
+++ b/spa/src/pages/prototype/__tests__/review-section-rows.test.tsx
@@ -247,35 +247,44 @@ describe('what it shows a subscriber', () => {
     };
     challenges.data = { challenges: [challenge('c1')] };
     render(<PrototypeReviewSection />);
-    // All four are notes, so only one qualifies for the closed state.
-    expect(screen.queryAllByText(/^Task /).length).toBe(1);
+    /* Two rows closed, never more than two (#114). All four are notes, so there is no passage to
+       pair one with and the fallback picks two different exercises instead — which is still two,
+       leaving the challenge its line. This asserted one back when a no-passage set collapsed to a
+       single row. */
+    expect(screen.queryAllByText(/^Task /).length).toBe(2);
     expect(screen.getByText('Strengthen Covenant')).toBeInTheDocument();
   });
 
-  it('will not guess how many are folded away before it knows', () => {
-    // The inbox reports `hasMore` as a boolean on purpose, so a closed section cannot count.
-    // Guessing printed "1 more" over two items.
+  /*
+   * The fold names what pressing it will actually open (#112) — `items.length` minus the rows
+   * already on screen, both of which the closed section is holding. It does not need the built
+   * list, which is only fetched on expand.
+   *
+   * This pair used to encode the older rule, where a closed section could not count at all and
+   * said "See all", and then a version that counted every due row off the summary. Both printed
+   * a number that did not match what opening produced, which is the failure #112 named.
+   */
+  it('names how many rows the fold will open, from what it already has', () => {
+    // `allItems` stays undefined (reset in beforeEach): nothing is expanded, so the server was
+    // never asked to build a question, and the count is right anyway.
     inbox.data = {
       items: ['a', 'b', 'c'].map((id) => reviewItem(id, `Question ${id}`)),
       hasMore: true,
     };
     render(<PrototypeReviewSection />);
-    expect(screen.getByText('See all')).toBeInTheDocument();
-    expect(screen.queryByText(/\d+ more/)).not.toBeInTheDocument();
+    // Three due, two shown closed — one more to open.
+    expect(screen.getByText('1 more')).toBeInTheDocument();
   });
 
-  /*
-   * The count comes off the summary, which every load already has — so the label can say how
-   * many rather than "See all" without anyone pressing anything first. It used to need the
-   * built list, which is only fetched on expand, so the honest label before that was "See all".
-   */
-  it('counts them from the summary, without waiting for the built list', () => {
-    // `allItems` stays undefined here (reset in beforeEach): nothing is expanded, so the server
-    // was never asked to build a question, and the count is right anyway.
+  it('does not count rows the fold will not open', () => {
+    // Both due rows are already on screen, so opening reveals nothing and there is no fold —
+    // even though the summary knows about a third. Counting the summary here said "1 more" and
+    // opened onto the same two rows.
     inbox.data = { items: ['a', 'b'].map((id) => reviewItem(id, `Question ${id}`)), hasMore: false };
     summaryItems.data = { items: ['a', 'b', 'c'].map((id) => reviewItem(id, `Question ${id}`)) };
     render(<PrototypeReviewSection />);
-    expect(screen.getByText('2 more')).toBeInTheDocument();
+    expect(screen.queryByText(/\d+ more/)).not.toBeInTheDocument();
+    expect(screen.queryByText('See all')).not.toBeInTheDocument();
   });
 
   it('says where a challenge is as a position, never as a count of what is left', () => {

--- a/spa/src/pages/prototype/__tests__/study-feed-open-highlight.test.ts
+++ b/spa/src/pages/prototype/__tests__/study-feed-open-highlight.test.ts
@@ -6,7 +6,13 @@ describe('highlightPassageRoute', () => {
     const route = highlightPassageRoute('Ecclesiastes 4:3');
     expect(route?.params).toEqual({ book: 'ecclesiastes', chapter: '4' });
     expect(route?.search.v).toBe('3');
-    expect(route?.search.ref).toBeUndefined();
+    /*
+     * Read through a widened type on purpose. The search type no longer declares `ref` at all,
+     * so `route.search.ref` stopped compiling — but deleting the assertion would remove the
+     * guard that gives this test its name, and leave nothing to fail if `ref` is ever put back
+     * carrying a value.
+     */
+    expect((route?.search as Record<string, unknown> | undefined)?.ref).toBeUndefined();
     expect(route?.search.req).toEqual(expect.any(String));
   });
 


### PR DESCRIPTION
`main`'s CI has been red since at least Sept 9 — every run from `f2bebe52d` onward. Five tests across three files, plus two typecheck-ratchet entries.

**None are flakes.** Each is a test left behind by a deliberate change, still asserting behaviour that was intentionally replaced. Splitting this out of #116 so `main` can go green independently.

| File | Why it broke |
|---|---|
| `prototype-note-route` | `legacySpaceNoteRedirectSearch` moved from `router` into `router-search` in `60701df92`. The import resolved to `undefined`, so the test failed as *"not a function"* rather than as a wrong answer. Also clears one ratchet entry. |
| `review-sample-card` | The card now sends `translation` alongside the answer, defaulting to `NET` when the sample carries none. Expected payload updated. |
| `review-section-rows` ×3 | Two superseded designs — see below. |
| `study-feed-open-highlight` | The search type no longer declares `ref`, so `search.ref` stopped compiling. |

## The two review tests worth a look

These are the only judgement calls here; the rest are mechanical.

- **#114** made the closed section show two rows, rather than collapsing a set with no passage down to one. The old assertion expected `1`.
- **#112** made "N more" count *what the fold will actually open*, instead of every due row counted off the summary. The old assertions described the counts that commit removed.

I read both commits to confirm intent before touching the assertions, rather than just making them match current output. Rather than delete the #112 pair, I rewrote them — and one now pins the specific bug that commit fixed: **a fold that promises a row and opens onto nothing.**

Similarly, `study-feed-open-highlight`'s `ref` assertion is kept behind a widened type instead of being deleted. Deleting would compile fine but would remove the guard the test is named for — nothing would fail if `ref` came back carrying a value.

## Verification

Run on this branch, on top of `main`, with none of #116's changes present:

- **5978 tests pass, 563 files.** No failures.
- **Typecheck ratchet passes** (125 errors, no regressions).

One note for anyone running this locally: a fresh worktree reports a phantom `Cannot find module './founder-letter.inline.generated'`. That file is gitignored and produced by `scripts/generate-founder-letter.js`; CI runs it as an explicit step before typechecking, and the workflow comments this exact case. Running that script clears it.

#116 contains the same commit, so this can merge first and #116 will rebase cleanly onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
