### PR TITLE
Review: question feedback, Activity space scopes, and related fixes

### DIFF
--- a/Changelog/3.9.10.md
+++ b/Changelog/3.9.10.md
@@ -1,0 +1,17 @@
+# Version 3.9.10
+
+**Release Date**: September 10, 2026
+
+## Fixes
+
+- A vote with no rung named a family it was not filed under
+
+## Other Changes
+
+- A space scope shows that space's trail, yours included
+- Review rows: how well you hold it, as a mark rather than a sentence
+- Dismissing the import row is an answer for the account, not the browser
+- Put the Activity row menu back to a list
+- Say what you thought of the question
+- Remove two scratch scripts that leaked into a commit
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.9.9
+**Version:** 3.9.10
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.9.9",
+  "version": "3.9.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-9-9';
+const CACHE_NAME = 'harvous-cache-v3-9-10';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/scripts/perf-budget.json
+++ b/scripts/perf-budget.json
@@ -1,12 +1,12 @@
 {
-  "initialPayloadGzip": 1169665,
+  "initialPayloadGzip": 1179313,
   "chunks": {
-    "index.js": 774015,
-    "index.css": 142627,
+    "index.js": 782726,
+    "index.css": 143566,
     "tiptap.js": 120673,
     "react-vendor.js": 60895,
     "router.js": 29131,
-    "clerk.js": 28601,
-    "query.js": 13723
+    "clerk.js": 28600,
+    "query.js": 13722
   }
 }

--- a/scripts/perf-budget.json
+++ b/scripts/perf-budget.json
@@ -1,8 +1,8 @@
 {
-  "initialPayloadGzip": 1179313,
+  "initialPayloadGzip": 1179171,
   "chunks": {
-    "index.js": 782726,
-    "index.css": 143566,
+    "index.js": 782601,
+    "index.css": 143549,
     "tiptap.js": 120673,
     "react-vendor.js": 60895,
     "router.js": 29131,

--- a/server/db/manual/add-review-event-rung-key.sql
+++ b/server/db/manual/add-review-event-rung-key.sql
@@ -1,0 +1,20 @@
+-- Adds `rungKey` to ReviewEvents for databases created before question feedback.
+--
+-- The log records what a review item was answered with, but never which rung was asked. It did
+-- not need to while every event was an outcome — `ReviewItems.lastRungKey` names the most recent
+-- asking and nothing looked further back. Thumbs up / thumbs down changed that: a rating is about
+-- a *question*, so the log has to say which one, and the windowed dislike tally reads it back.
+--
+-- The exercise family is derived from this key, never stored: `FAMILY_BY_KEY` is "a naming, not a
+-- taxonomy" and is expected to be re-cut, and a denormalized family would freeze one cut into an
+-- append-only log.
+--
+-- Nullable, so every row already written stands. The tally skips null rungs.
+--
+-- The paired index serves the tally, which filters userId + action inside a rolling window.
+--
+-- RLS: `npm run db:rls` enables it on every public table, so run that after this.
+
+ALTER TABLE "ReviewEvents" ADD COLUMN IF NOT EXISTS "rungKey" text;
+
+CREATE INDEX IF NOT EXISTS "ReviewEvents_userId_action_createdAtIndex" ON "ReviewEvents" ("userId", "action", "createdAt");

--- a/server/db/manual/create-review-events.sql
+++ b/server/db/manual/create-review-events.sql
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS "ReviewEvents" (
   "noteId" text,
   "action" text NOT NULL,
   "attempt" text,
+  "rungKey" text,
   "previousIntervalDays" real,
   "nextIntervalDays" real,
   "createdAt" timestamp with time zone NOT NULL
@@ -29,3 +30,4 @@ CREATE TABLE IF NOT EXISTS "ReviewEvents" (
 CREATE INDEX IF NOT EXISTS "ReviewEvents_userId_createdAtIndex" ON "ReviewEvents" ("userId", "createdAt");
 CREATE INDEX IF NOT EXISTS "ReviewEvents_reviewItemId_createdAtIndex" ON "ReviewEvents" ("reviewItemId", "createdAt");
 CREATE INDEX IF NOT EXISTS "ReviewEvents_noteIdIndex" ON "ReviewEvents" ("noteId");
+CREATE INDEX IF NOT EXISTS "ReviewEvents_userId_action_createdAtIndex" ON "ReviewEvents" ("userId", "action", "createdAt");

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1833,10 +1833,24 @@ export const ReviewEvents = pgTable('ReviewEvents', {
   reviewItemId: text('reviewItemId').notNull(),
   /** Denormalized so the note cascade can find these rows without joining ReviewItems. */
   noteId: text('noteId'),
-  /** shown | recalled | almost | revealed | deferred | paused | resumed | archived. */
+  /**
+   * shown | recalled | almost | revealed | deferred | paused | resumed | archived, and the two
+   * that are about the question rather than the recall: liked | disliked. The allowlist is
+   * `REVIEW_EVENT_ACTIONS`; `study-feed.ts` reads this log through the narrower `REVIEW_OUTCOMES`
+   * so a rating can never be printed as an answer.
+   */
   action: text('action').notNull(),
   /** What the reader wrote before revealing, when they wrote anything. */
   attempt: text('attempt'),
+  /**
+   * The rung this event was about — `verse.rebuild`, `note.passage`.
+   *
+   * The exercise *family* is derived from it and never stored: `FAMILY_BY_KEY` calls itself "a
+   * naming, not a taxonomy" and is expected to be re-cut, so a denormalized family would freeze
+   * last year's cut into an append-only log and silently mis-attribute old rows. `ReviewItems`
+   * has `lastRungKey`, but that only ever names the most recent asking; this names each one.
+   */
+  rungKey: text('rungKey'),
   previousIntervalDays: real('previousIntervalDays'),
   nextIntervalDays: real('nextIntervalDays'),
   createdAt: ts('createdAt').notNull(),
@@ -1844,6 +1858,8 @@ export const ReviewEvents = pgTable('ReviewEvents', {
   index('ReviewEvents_userId_createdAtIndex').on(table.userId, table.createdAt),
   index('ReviewEvents_reviewItemId_createdAtIndex').on(table.reviewItemId, table.createdAt),
   index('ReviewEvents_noteIdIndex').on(table.noteId),
+  /* Serves the windowed dislike tally, which filters userId + action and orders by createdAt. */
+  index('ReviewEvents_userId_action_createdAtIndex').on(table.userId, table.action, table.createdAt),
 ]);
 
 // ─── UserNodeStates (the reader's own Study Bible layer) ──────────────────────

--- a/server/routes/__tests__/review-routes.test.ts
+++ b/server/routes/__tests__/review-routes.test.ts
@@ -773,3 +773,64 @@ describe('what a miss is allowed to say', () => {
     expect(outcome()).not.toContain('cloze.blanks');
   });
 });
+
+describe('question feedback is filed against the question that was asked', () => {
+  const handler = () => {
+    const text = review();
+    const start = text.indexOf("'/api/review/items/:id/feedback'");
+    expect(start).toBeGreaterThan(-1);
+    return text.slice(start, text.indexOf('route.post', start + 10));
+  };
+
+  it('takes the rung from the item row rather than resolving it again', () => {
+    /*
+     * `applyReviewOutcome` writes `lastRungKey` moments before the vote is cast, so it names the
+     * question the reader actually saw. `askedRungFor` would name whatever the *current*
+     * preferences resolve to — and a vote filed against the wrong rung would quiet a family the
+     * reader never complained about, which is the one way this feature can do harm.
+     */
+    expect(handler()).toContain('item.lastRungKey');
+    expect(handler()).not.toContain('askedRungFor');
+  });
+
+  it('refuses a vote it does not recognise', () => {
+    expect(handler()).toContain("vote !== 'liked'");
+    expect(handler()).toContain("vote !== 'disliked'");
+    expect(handler()).toContain('REVIEW_FEEDBACK_INVALID');
+  });
+
+  it('reads the tally past the per-request memo, since it just wrote to it', () => {
+    expect(handler()).toContain('reviewDislikeRowsFor');
+  });
+
+  it('invalidates nothing on the client', () => {
+    /*
+     * A sitting is a fixed set of questions on purpose. Quieting takes effect the next time one
+     * is composed; doing it sooner would reshuffle the queue under someone mid-answer.
+     */
+    const hook = withoutComments(source('spa/src/hooks/mutations/useReviewMutations.ts'));
+    const start = hook.indexOf('export function useReviewFeedback');
+    const body = hook.slice(start, hook.indexOf('export function', start + 10));
+    expect(body).not.toContain('invalidateQueries');
+  });
+});
+
+describe('the dislike tally', () => {
+  it('reads only disliked rows, inside the window, with a cap', () => {
+    const text = service();
+    const start = text.indexOf('async function loadRecentDislikes');
+    const body = text.slice(start, text.indexOf('async function', start + 10));
+    expect(body).toContain("eq(ReviewEvents.action, 'disliked')");
+    expect(body).toContain('reviewDislikeWindowStart');
+    expect(body).toContain('DISLIKE_ROW_CAP');
+  });
+
+  it('degrades to no dampening rather than a broken queue', () => {
+    // The same bargain the preference read strikes: a database the migration has not reached
+    // has no `rungKey` column, and Review opening matters more than a lean being honoured.
+    const text = service();
+    const start = text.indexOf('async function loadRecentDislikes');
+    expect(text.slice(start, text.indexOf('async function', start + 10))).toContain('catch');
+  });
+});
+

--- a/server/routes/review.ts
+++ b/server/routes/review.ts
@@ -566,7 +566,7 @@ route.post('/api/review/items/:id/feedback', requireAuth, rateLimit('write'), re
     return c.json({
       success: true,
       offerSettings,
-      family: { id: family, label: REVIEW_EXERCISE_FAMILIES[family].label },
+      family: family ? { id: family, label: REVIEW_EXERCISE_FAMILIES[family].label } : null,
     });
   } catch (error) {
     const standardError = handleAPIError(error, { endpoint: '/api/review/items/:id/feedback', action: 'review_feedback' });

--- a/server/routes/review.ts
+++ b/server/routes/review.ts
@@ -37,6 +37,8 @@ import {
   type ReviewOutcome,
 } from '@/utils/review-item-kinds';
 import { describeNextReturn } from '@/utils/review-scheduling';
+import { describeDislike } from '@/utils/review-exercise-feedback';
+import { REVIEW_EXERCISE_FAMILIES } from '@/utils/review-exercise-families';
 import {
   applyReviewOutcome,
   chapterTruthFor,
@@ -55,6 +57,7 @@ import {
   listReviewItems,
   nextScheduledReviewAt,
   recordReviewEvent,
+  reviewDislikeRowsFor,
   setReviewItemStatus,
   stepBackReviewItem,
   buildReviewSample,
@@ -520,6 +523,53 @@ route.post('/api/review/items/:id/defer', requireAuth, rateLimit('write'), requi
     return c.json({ success: true, dueAt: updated.dueAt.toISOString() });
   } catch (error) {
     const standardError = handleAPIError(error, { endpoint: '/api/review/items/:id/defer', action: 'review_defer' });
+    return c.json({ error: standardError.message, code: standardError.code }, 500);
+  }
+});
+
+/**
+ * What the reader thought of the question, as distinct from how the recall went.
+ *
+ * Filed against `ReviewItems.lastRungKey` rather than a fresh resolution. `applyReviewOutcome`
+ * writes that column moments earlier, and the vote is only ever cast from the result card — so
+ * the column names the question the reader actually saw, while re-resolving would name whatever
+ * the *current* preferences produce. That distinction is the whole point of the write: a vote
+ * recorded against the wrong rung would quiet a family the reader never complained about.
+ *
+ * Nothing here invalidates a query. The sitting is a fixed set of questions on purpose, and
+ * quieting takes effect the next time one is composed.
+ */
+route.post('/api/review/items/:id/feedback', requireAuth, rateLimit('write'), requireFeature('review'), async (c) => {
+  try {
+    const auth = getAuthenticatedAuth(c);
+    const item = await getReviewItem(auth.userId, c.req.param('id') ?? '');
+    if (!item) return c.json({ error: 'Review item not found', code: 'REVIEW_ITEM_NOT_FOUND' }, 404);
+
+    const body = await c.req.json();
+    const vote = typeof body?.vote === 'string' ? body.vote : '';
+    if (vote !== 'liked' && vote !== 'disliked') {
+      return c.json({ error: 'Unknown vote', code: 'REVIEW_FEEDBACK_INVALID' }, 400);
+    }
+
+    const rungKey = item.lastRungKey ?? null;
+    await recordReviewEvent(auth.userId, item, vote, { rungKey });
+
+    if (vote !== 'disliked') return c.json({ success: true, offerSettings: false, family: null });
+
+    /*
+     * Re-read past the per-request memo, since the row we just wrote is the one that might have
+     * reached the threshold. Repeat votes on one item cannot inflate the count — it is distinct
+     * review items that are counted — so no idempotency guard is needed for correctness.
+     */
+    const rows = await reviewDislikeRowsFor(auth.userId);
+    const { family, offerSettings } = describeDislike(rungKey, rows);
+    return c.json({
+      success: true,
+      offerSettings,
+      family: { id: family, label: REVIEW_EXERCISE_FAMILIES[family].label },
+    });
+  } catch (error) {
+    const standardError = handleAPIError(error, { endpoint: '/api/review/items/:id/feedback', action: 'review_feedback' });
     return c.json({ error: standardError.message, code: standardError.code }, 500);
   }
 });

--- a/server/routes/study-feed.ts
+++ b/server/routes/study-feed.ts
@@ -337,7 +337,17 @@ route.get('/api/study-feed', requireAuth, rateLimit('read'), async (c) => {
               inArray(SpaceNotes.spaceId, [...spaceById.keys()]),
               isNull(SpaceNotes.removedAt),
               eq(Notes.contentEncrypted, false),
-              ne(Notes.userId, auth.userId),
+              /*
+               * Your own notes come out of this half only while the *own* half is running, and
+               * then only to avoid printing them twice: an unscoped feed already has them,
+               * untagged, from the personal sources above.
+               *
+               * Narrowed to a single space there is no own half — `wantsOwn` is false — so the
+               * guard had nothing left to de-duplicate against and was simply deleting you from
+               * your own trail. A space where only you had written came back empty, which is the
+               * one thing the space scope exists to show. Activity is a trail, not an inbox.
+               */
+              ...(wantsOwn ? [ne(Notes.userId, auth.userId)] : []),
               ...windowed(Notes.updatedAt),
             ),
           )
@@ -373,9 +383,13 @@ route.get('/api/study-feed', requireAuth, rateLimit('read'), async (c) => {
           profileImageUrl: author?.profileImageUrl ?? null,
         },
         space: { id: space.spaceId, title: space.title, color: space.color },
-        isNewSinceVisit: watermark
-          ? new Date(at).getTime() > new Date(watermark).getTime()
-          : false,
+        /* Never your own: nothing you wrote is news to you, however long since you last
+           opened the space. Only reachable under a space scope, which is the one case where
+           this half returns your notes at all. */
+        isNewSinceVisit:
+          watermark && row.authorUserId !== auth.userId
+            ? new Date(at).getTime() > new Date(watermark).getTime()
+            : false,
       });
     }
 

--- a/server/scripts/add-review-challenges-schema.ts
+++ b/server/scripts/add-review-challenges-schema.ts
@@ -132,6 +132,10 @@ export const ADDITIVE_REVIEW_CHALLENGES_DDL = [
   // Part four: a scheduler that remembers. Both defaulted, so existing rows are untouched.
   `ALTER TABLE "ReviewItems" ADD COLUMN IF NOT EXISTS "lapseCount" integer NOT NULL DEFAULT 0`,
   `ALTER TABLE "ReviewItems" ADD COLUMN IF NOT EXISTS "lastRungKey" text`,
+  // Part five: the reader can say what they thought of a question, so the log has to say which
+  // question. Nullable, so every row already written stands; the index serves the windowed tally.
+  `ALTER TABLE "ReviewEvents" ADD COLUMN IF NOT EXISTS "rungKey" text`,
+  `CREATE INDEX IF NOT EXISTS "ReviewEvents_userId_action_createdAtIndex" ON "ReviewEvents" ("userId", "action", "createdAt")`,
 ] as const;
 
 export async function runAddReviewChallengesSchema(

--- a/server/utils/review-service.ts
+++ b/server/utils/review-service.ts
@@ -29,6 +29,7 @@ import {
   desc,
   eq,
   gt,
+  gte,
   inArray,
   isNotNull,
   lte,
@@ -204,6 +205,11 @@ import {
   parseReviewExerciseSettings,
   skippedKeySet,
 } from '@/utils/review-exercise-settings';
+import {
+  quietedKeySet,
+  reviewDislikeWindowStart,
+  type ReviewDislikeRow,
+} from '@/utils/review-exercise-feedback';
 import { getNotePassages } from './scripture-knowledge';
 import { REVIEWED_SOURCE } from '@/utils/study-bible-source-copy';
 import { READING_DWELL_BUCKETS, readingDwellCountsAsRead } from '@/utils/reading-event-kinds';
@@ -1161,7 +1167,7 @@ export async function buildReviewItemViews(
  */
 const skipCache = new Map<string, Promise<ReadonlySet<ReviewPromptKey>>>();
 
-async function loadSkippedRungs(userId: string): Promise<ReadonlySet<ReviewPromptKey>> {
+async function loadPreferredSkips(userId: string): Promise<ReadonlySet<ReviewPromptKey>> {
   const cached = skipCache.get(userId);
   if (cached) return cached;
   const pending = (async () => {
@@ -1185,6 +1191,76 @@ async function loadSkippedRungs(userId: string): Promise<ReadonlySet<ReviewPromp
   // Cleared on the next tick: within one request the answer is fixed, across requests it is not.
   void pending.finally(() => queueMicrotask(() => skipCache.delete(userId)));
   return pending;
+}
+
+/**
+ * The reader's recent thumbs-down votes, read once per request and memoised the same way.
+ *
+ * Narrow by construction: `disliked` rows are the rarest thing in the log, the window is thirty
+ * days, and the cap is there so a pathological account cannot make a rung resolution unbounded.
+ * The tally is done in JS rather than SQL so the rung-to-family mapping stays derived from
+ * `FAMILY_BY_KEY` — see `review-exercise-feedback.ts`.
+ */
+const dislikeCache = new Map<string, Promise<ReviewDislikeRow[]>>();
+
+const DISLIKE_ROW_CAP = 500;
+
+async function loadRecentDislikes(userId: string): Promise<ReviewDislikeRow[]> {
+  const cached = dislikeCache.get(userId);
+  if (cached) return cached;
+  const pending = (async () => {
+    try {
+      const rows = await db
+        .select({ reviewItemId: ReviewEvents.reviewItemId, rungKey: ReviewEvents.rungKey })
+        .from(ReviewEvents)
+        .where(
+          and(
+            eq(ReviewEvents.userId, userId),
+            eq(ReviewEvents.action, 'disliked'),
+            gte(ReviewEvents.createdAt, reviewDislikeWindowStart(new Date())),
+            isNotNull(ReviewEvents.rungKey),
+          ),
+        )
+        .orderBy(desc(ReviewEvents.createdAt))
+        .limit(DISLIKE_ROW_CAP);
+      return rows as ReviewDislikeRow[];
+    } catch {
+      /*
+       * The same bargain `loadPreferredSkips` strikes: on a database the migration has not
+       * reached, `rungKey` does not exist and this throws. A Review that asks without leaning
+       * away is worth far more than a Review that will not open.
+       */
+      return [];
+    }
+  })();
+  dislikeCache.set(userId, pending);
+  void pending.finally(() => queueMicrotask(() => dislikeCache.delete(userId)));
+  return pending;
+}
+
+/**
+ * Every reason to walk past a rung: what the reader switched off, and what they keep thumbing down.
+ *
+ * One function, because the list, the reveal, the grader and the truth must resolve the same rung
+ * from the same material — if the two halves entered by different doors they could diverge. Both
+ * halves fail soft to empty, and neither can return nothing: quieting joins `material.skip`, which
+ * every walk already treats as a reason to move on rather than a reason to stop.
+ */
+async function loadSkippedRungs(userId: string): Promise<ReadonlySet<ReviewPromptKey>> {
+  const [preferred, dislikes] = await Promise.all([
+    loadPreferredSkips(userId),
+    loadRecentDislikes(userId),
+  ]);
+  if (!dislikes.length) return preferred;
+  const merged = new Set<ReviewPromptKey>(preferred);
+  for (const key of quietedKeySet(dislikes)) merged.add(key);
+  return merged;
+}
+
+/** The tally behind the card's "Noted." — read after a vote lands, so it bypasses the memo. */
+export async function reviewDislikeRowsFor(userId: string): Promise<ReviewDislikeRow[]> {
+  dislikeCache.delete(userId);
+  return loadRecentDislikes(userId);
 }
 
 /** Verse text arrives as formatted HTML with superscript verse numbers. */
@@ -1507,7 +1583,13 @@ export async function recordReviewEvent(
   userId: string,
   item: ReviewItemRow,
   action: ReviewEventAction,
-  extra: { attempt?: string | null; previousIntervalDays?: number; nextIntervalDays?: number } = {},
+  extra: {
+    attempt?: string | null;
+    previousIntervalDays?: number;
+    nextIntervalDays?: number;
+    /** The rung this event was about. Derived once by the caller, which already resolved it. */
+    rungKey?: string | null;
+  } = {},
   now: Date = new Date(),
 ): Promise<void> {
   await db.insert(ReviewEvents).values({
@@ -1517,6 +1599,7 @@ export async function recordReviewEvent(
     noteId: item.noteId,
     action,
     attempt: extra.attempt?.trim() || null,
+    rungKey: extra.rungKey ?? null,
     previousIntervalDays: extra.previousIntervalDays ?? null,
     nextIntervalDays: extra.nextIntervalDays ?? null,
     createdAt: now,
@@ -1595,6 +1678,8 @@ export async function applyReviewOutcome(
     attempt,
     previousIntervalDays: item.intervalDays,
     nextIntervalDays: next.intervalDays,
+    // Already resolved just above for `lastRungKey`; the log keeps every asking, not the last.
+    rungKey,
   }, now);
 
   if (outcome === 'recalled') {

--- a/spa/src/hooks/mutations/useReviewMutations.ts
+++ b/spa/src/hooks/mutations/useReviewMutations.ts
@@ -23,6 +23,7 @@ import {
   REVIEW_REMOVED_TOAST,
   REVIEW_REMOVE_FAILED_TOAST,
   REVIEW_RESUMED_TOAST,
+  REVIEW_FEEDBACK_FAILED_TOAST,
 } from '../../pages/prototype/proto-review-copy';
 import type { ReviewItemKind, ReviewItemStatus, ReviewOutcome } from '@/utils/review-item-kinds';
 
@@ -126,6 +127,36 @@ export function useDeferReview() {
     },
     onError: (error) => {
       toastError(error, REVIEW_DEFER_FAILED_TOAST, { scope: 'review-defer' });
+    },
+  });
+}
+
+export interface ReviewFeedbackResponse {
+  offerSettings: boolean;
+  family: { id: string; label: string } | null;
+}
+
+/**
+ * What the reader thought of the question.
+ *
+ * **Invalidates nothing.** A sitting is a fixed set of questions on purpose — `useReviewSession`
+ * is `staleTime: Infinity` so the queue cannot reshuffle under someone mid-answer — and quieting
+ * a family is a server-derived fact that takes effect the next time a sitting is composed. Doing
+ * it sooner would mean the page and the server disagreeing about which question is being asked,
+ * which is the drift the rung resolution is careful to avoid.
+ *
+ * On failure the card restores its buttons and says so quietly. A vote is a log line, not a
+ * setting; losing one is not worth interrupting a sitting for.
+ */
+export function useReviewFeedback() {
+  return useMutation({
+    mutationFn: ({ itemId, vote }: { itemId: string; vote: 'liked' | 'disliked' }) =>
+      api.post<ReviewFeedbackResponse>(
+        `/api/review/items/${encodeURIComponent(itemId)}/feedback`,
+        { vote },
+      ),
+    onError: (error) => {
+      toastError(error, REVIEW_FEEDBACK_FAILED_TOAST, { scope: 'review-feedback' });
     },
   });
 }

--- a/spa/src/layouts/SimplifiedPrototypeLayout.tsx
+++ b/spa/src/layouts/SimplifiedPrototypeLayout.tsx
@@ -791,6 +791,9 @@ function PrototypeAuthenticatedChrome({ userId, isGuest = false }: { userId?: st
               prompt: review.prompt ?? null,
               subject: review.subject ?? null,
               echo: reviewAnswerEcho({ submitted: review.attempt ? { text: review.attempt } : null }),
+              /* Carried so the result card can offer question feedback. Without it the thumbs
+                 are absent for every note answered from the stack edge, which is most of them. */
+              itemId: review.itemId,
               at: Date.now(),
             }),
         },

--- a/spa/src/pages/dev/design-system/DesignSystemScenePreview.tsx
+++ b/spa/src/pages/dev/design-system/DesignSystemScenePreview.tsx
@@ -1309,15 +1309,6 @@ function ReviewVerdictsScene() {
       </div>
 
       <div>
-        <p className="pds-caption">The same block, in a row's menu</p>
-        <div className="proto-icon-block-row">
-          <ProtoIconBlock icon="clock-rotate-left" label="Not now" onSelect={() => {}} />
-          <ProtoIconBlock icon="circle-minus" label="Pause" ariaLabel="Pause this" onSelect={() => {}} />
-          <ProtoIconBlock icon="eye-slash" label="Remove" ariaLabel="Remove from Review" onSelect={() => {}} />
-        </div>
-      </div>
-
-      <div>
         <p className="pds-caption">Goes</p>
         <span className="proto-review-dock__goes" aria-label="Attempt 2 of 3">
           <span className="proto-review-dock__go" data-spent aria-hidden />

--- a/spa/src/pages/dev/design-system/DesignSystemScenePreview.tsx
+++ b/spa/src/pages/dev/design-system/DesignSystemScenePreview.tsx
@@ -6,6 +6,7 @@ import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from
 import DeleteConfirmBar from '@/components/react/DeleteConfirmBar';
 import Icon from '@/components/react/Icon';
 import ProtoRowSelectCheckbox from '../../prototype/ProtoRowSelectCheckbox';
+import ProtoIconBlock from '../../prototype/ProtoIconBlock';
 import {
   PrototypeListEmptyState,
   PrototypeListRow,
@@ -1285,6 +1286,37 @@ const MARK_SAMPLE = 'the light shines in the darkness';
 function ReviewVerdictsScene() {
   return (
     <div className="pds-stack" style={{ gap: 20, maxWidth: 520 }}>
+      <div>
+        {/*
+          * Rating the question, which is a third thing: the verdict says how the recall went,
+          * these say what the reader thought of the exercise. Shown at rest, chosen, and spent,
+          * because the spent state is the one that has to stay legible rather than fading out.
+          */}
+        <p className="pds-caption">Question feedback</p>
+        <p className="pds-caption">This kind of question</p>
+        <div className="proto-icon-block-row">
+          <ProtoIconBlock icon="thumbs-up" label="Good question" onSelect={() => {}} />
+          <ProtoIconBlock icon="thumbs-down" label="Not helpful" onSelect={() => {}} />
+        </div>
+      </div>
+
+      <div>
+        <p className="pds-caption">Once the vote is in</p>
+        <div className="proto-icon-block-row">
+          <ProtoIconBlock icon="thumbs-up" label="Good question" selected disabled onSelect={() => {}} />
+          <ProtoIconBlock icon="thumbs-down" label="Not helpful" disabled onSelect={() => {}} />
+        </div>
+      </div>
+
+      <div>
+        <p className="pds-caption">The same block, in a row's menu</p>
+        <div className="proto-icon-block-row">
+          <ProtoIconBlock icon="clock-rotate-left" label="Not now" onSelect={() => {}} />
+          <ProtoIconBlock icon="circle-minus" label="Pause" ariaLabel="Pause this" onSelect={() => {}} />
+          <ProtoIconBlock icon="eye-slash" label="Remove" ariaLabel="Remove from Review" onSelect={() => {}} />
+        </div>
+      </div>
+
       <div>
         <p className="pds-caption">Goes</p>
         <span className="proto-review-dock__goes" aria-label="Attempt 2 of 3">

--- a/spa/src/pages/dev/design-system/DesignSystemScenePreview.tsx
+++ b/spa/src/pages/dev/design-system/DesignSystemScenePreview.tsx
@@ -7,6 +7,7 @@ import DeleteConfirmBar from '@/components/react/DeleteConfirmBar';
 import Icon from '@/components/react/Icon';
 import ProtoRowSelectCheckbox from '../../prototype/ProtoRowSelectCheckbox';
 import ProtoIconBlock from '../../prototype/ProtoIconBlock';
+import PrototypeRecallStateChip from '../../prototype/PrototypeRecallStateChip';
 import {
   PrototypeListEmptyState,
   PrototypeListRow,
@@ -1394,21 +1395,22 @@ function ReviewVerdictsScene() {
       </div>
 
       <div>
-        {/* Words beside a title, not a chip. It was a bordered, tinted pill; the position it
-            sits in now does the separating that the chrome used to do. */}
+        {/* Rendered through the component rather than copied: this block held its own hand-written
+            markup, and when the mark stopped being words the copy stayed text and went stale. The
+            three here are the three the copy distinguishes — fragile and forming share a fill. */}
         <p className="pds-caption">How well you hold it</p>
         <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
           <span className="pds-list-title">
             John 15:5
-            <span className="proto-recall-mark" data-state="fragile">{RECALL_STATE_LABELS.fragile}</span>
+            <PrototypeRecallStateChip state="fragile" label={RECALL_STATE_LABELS.fragile} />
           </span>
           <span className="pds-list-title">
             Romans 8:28
-            <span className="proto-recall-mark" data-state="durable">{RECALL_STATE_LABELS.durable}</span>
+            <PrototypeRecallStateChip state="durable" label={RECALL_STATE_LABELS.durable} />
           </span>
           <span className="pds-list-title">
             Psalms 23:1
-            <span className="proto-recall-mark" data-state="slipping">{RECALL_STATE_LABELS.slipping}</span>
+            <PrototypeRecallStateChip state="slipping" label={RECALL_STATE_LABELS.slipping} />
           </span>
         </div>
       </div>

--- a/spa/src/pages/dev/design-system/sceneRegistry.ts
+++ b/spa/src/pages/dev/design-system/sceneRegistry.ts
@@ -252,6 +252,7 @@ export const DESIGN_SYSTEM_CORE_SCENES: DesignSystemScene[] = [
     phase: 'Patterns',
     editFiles: [
       'spa/src/pages/prototype/PrototypeReviewDock.tsx',
+      'spa/src/pages/prototype/ProtoIconBlock.tsx',
       'spa/src/styles/prototype-components.css',
     ],
     screenshotSlug: 'ds-21-review-verdicts',

--- a/spa/src/pages/prototype/ProtoIconBlock.tsx
+++ b/spa/src/pages/prototype/ProtoIconBlock.tsx
@@ -1,0 +1,59 @@
+/**
+ * A glyph over a word, in a pressable block.
+ *
+ * Two surfaces share it: the question feedback on Review's result card, and the Activity row's
+ * overflow menu. They are the same gesture at the same size, and a second copy would drift the
+ * way the shelf row and the dock once drifted over which stem to show.
+ *
+ * **The word is not optional.** This feature already removed a bare `+` for being an unexplained
+ * icon (see `REVIEW_ADD_COPY`), and "fewer questions like this" has no settled glyph at all. So
+ * `label` is required, and `ariaLabel` only overrides the accessible name where the visible word
+ * is a genuine shortening of it — otherwise the accessible name stays the visible text, which is
+ * what label-in-name asks for.
+ */
+
+import Icon, { type IconName } from '@/components/react/Icon';
+import { haptics } from '@/utils/haptics';
+
+export default function ProtoIconBlock({
+  icon,
+  label,
+  ariaLabel,
+  selected,
+  disabled,
+  role,
+  onSelect,
+  className,
+}: {
+  icon: IconName;
+  /** The word under the glyph. Never omitted — this control is not a bare icon. */
+  label: string;
+  /** The full sentence, where the visible word is a shortening of it. Defaults to `label`. */
+  ariaLabel?: string;
+  selected?: boolean;
+  disabled?: boolean;
+  /** `menuitem` inside a popover; omitted for a plain group of buttons. */
+  role?: string;
+  onSelect: () => void;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      role={role}
+      className={`proto-icon-block${className ? ` ${className}` : ''}`}
+      aria-pressed={typeof selected === 'boolean' ? selected : undefined}
+      aria-label={ariaLabel && ariaLabel !== label ? ariaLabel : undefined}
+      disabled={disabled}
+      onClick={() => {
+        haptics.light();
+        onSelect();
+      }}
+    >
+      <span className="proto-icon-block__glyph" aria-hidden>
+        <Icon name={icon} size={16} />
+      </span>
+      <span className="proto-icon-block__label">{label}</span>
+    </button>
+  );
+}

--- a/spa/src/pages/prototype/ProtoIconBlock.tsx
+++ b/spa/src/pages/prototype/ProtoIconBlock.tsx
@@ -1,15 +1,17 @@
 /**
  * A glyph over a word, in a pressable block.
  *
- * Two surfaces share it: the question feedback on Review's result card, and the Activity row's
- * overflow menu. They are the same gesture at the same size, and a second copy would drift the
- * way the shelf row and the dock once drifted over which stem to show.
+ * Review's question feedback is the one thing wearing it: two blocks under the result, where the
+ * reader says what they thought of the exercise they were just given. It lives in its own file
+ * rather than inside the dock because the pressed state is the app's accent button and the rules
+ * that get it there are fiddly enough to be worth naming once — see `.proto-icon-block` in
+ * `prototype-components.css`.
  *
  * **The word is not optional.** This feature already removed a bare `+` for being an unexplained
  * icon (see `REVIEW_ADD_COPY`), and "fewer questions like this" has no settled glyph at all. So
- * `label` is required, and `ariaLabel` only overrides the accessible name where the visible word
- * is a genuine shortening of it — otherwise the accessible name stays the visible text, which is
- * what label-in-name asks for.
+ * `label` is required, and it is also the accessible name — there is no separate `aria-label`,
+ * because a control whose spoken name differs from its visible word is the thing label-in-name
+ * exists to prevent.
  */
 
 import Icon, { type IconName } from '@/components/react/Icon';
@@ -18,32 +20,25 @@ import { haptics } from '@/utils/haptics';
 export default function ProtoIconBlock({
   icon,
   label,
-  ariaLabel,
   selected,
   disabled,
-  role,
   onSelect,
   className,
 }: {
   icon: IconName;
-  /** The word under the glyph. Never omitted — this control is not a bare icon. */
+  /** The word under the glyph, and the accessible name. Never omitted. */
   label: string;
-  /** The full sentence, where the visible word is a shortening of it. Defaults to `label`. */
-  ariaLabel?: string;
+  /** Omitted entirely where the block is an action rather than a choice. */
   selected?: boolean;
   disabled?: boolean;
-  /** `menuitem` inside a popover; omitted for a plain group of buttons. */
-  role?: string;
   onSelect: () => void;
   className?: string;
 }) {
   return (
     <button
       type="button"
-      role={role}
       className={`proto-icon-block${className ? ` ${className}` : ''}`}
       aria-pressed={typeof selected === 'boolean' ? selected : undefined}
-      aria-label={ariaLabel && ariaLabel !== label ? ariaLabel : undefined}
       disabled={disabled}
       onClick={() => {
         haptics.light();

--- a/spa/src/pages/prototype/PrototypeRecallStateChip.tsx
+++ b/spa/src/pages/prototype/PrototypeRecallStateChip.tsx
@@ -1,22 +1,31 @@
 /**
- * How well the reader holds something: two quiet words beside the title.
+ * How well the reader holds something: three small segments beside the title.
  *
- * **It was a pill, and the pill was doing a job the position now does.** The state used to be
- * the third `·`-separated fragment of the caption — "Cross-referenced 28 times · Needs work" —
- * where it read as another clause of a sentence about the verse when it is really a sentence
- * about the reader. A chip separated the two by shape. Then the state moved to the *title* line,
- * which separates them by position, and the chip's border, fill, weight and glyph were all
- * paying for a problem that had already been solved somewhere else.
+ * **It was two words, and before that a pill.** The pill went when the state moved to the title
+ * line, because border, fill and weight were paying for a separation that position already made.
+ * The words went when the row filled up: an exercise label arrived on the meta line, titles
+ * already marquee at narrow widths, and "You're learning this" beside every title was the same
+ * sentence repeated down the whole list. A mark says it once, in the space of a word.
  *
- * What tipped it was the exercise label arriving on the meta line: two glyphs and two labels on
- * one row, none of them the thing the reader came to read. So the row keeps one icon — the
- * subject's — and the state is words alone.
+ * **Three segments, because the copy makes three distinctions and not five.** `fragile` and
+ * `forming` share a label on purpose, so they share a fill; `new` is never rendered at all. The
+ * mark is deliberately not a scale over `RECALL_STATES` — that would expose a split the words
+ * were written to hide, and turn an observation into a score.
  *
- * No colour, still. A tinted marker at the end of every row would be a scoreboard, and the one
- * thing this feature refuses to do is grade someone's grasp of Scripture at a glance. The words
- * carry it on their own — and they describe the passage's hold rather than the reader's
- * performance, which is why they read as an observation instead of a mark. See
- * `RECALL_STATE_LABELS`.
+ * `slipping` is the one that cannot be a lower rung. It is a fall *from* holding, so it shows
+ * as reduced-from-full in the warning tone rather than as an early step: a row that has slipped
+ * has more history behind it than one being learned, not less, and drawing it as "barely
+ * started" would be a lie about the reader's own past.
+ *
+ * **This does add colour, and that is a reversal.** The note that stood here said a tinted marker
+ * at the end of every row would be a scoreboard, and that the one thing this feature refuses is
+ * to grade someone's grasp of Scripture at a glance. The trade taken instead: the mark carries no
+ * number, no percentage and no ranking between rows, and its three steps say exactly what the
+ * three labels said — nothing finer. What it buys is a row you can read down without meeting the
+ * same sentence at every line.
+ *
+ * The words are still the accessible name, so nothing is lost to a reader who is listening
+ * rather than looking. See `RECALL_STATE_LABELS`.
  */
 import type { ReactNode } from 'react';
 import { RECALL_STATE_LABELS, type RecallState } from '@/utils/review-item-kinds';
@@ -29,11 +38,25 @@ export default function PrototypeRecallStateChip({
   state: RecallState;
   label: string;
 }) {
-  // `data-state` is kept though nothing styles it: it is what a test and a screenshot read to
-  // tell a fragile row from a forming one, since the two share a label.
+  /*
+   * `data-state` carries the raw state for tests and screenshots — fragile and forming are
+   * indistinguishable in both the label and the fill, so this is the only thing that tells them
+   * apart. `data-hold` is what the CSS actually draws, and it is the three-way the copy makes.
+   */
+  const hold = state === 'durable' ? 'held' : state === 'slipping' ? 'slipped' : 'learning';
   return (
-    <span className="proto-recall-mark" data-state={state}>
-      {label}
+    <span
+      className="proto-recall-mark"
+      data-state={state}
+      data-hold={hold}
+      role="img"
+      aria-label={label}
+      title={label}
+    >
+      {/* Three segments, filled by `data-hold`. Decorative: the label above is the real text. */}
+      <span className="proto-recall-mark__seg" aria-hidden />
+      <span className="proto-recall-mark__seg" aria-hidden />
+      <span className="proto-recall-mark__seg" aria-hidden />
     </span>
   );
 }

--- a/spa/src/pages/prototype/PrototypeReviewDock.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewDock.tsx
@@ -35,6 +35,8 @@ import {
 } from '@/utils/review-answer-echo';
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useRouterState } from '@tanstack/react-router';
+import ProtoIconBlock from './ProtoIconBlock';
+import { prototypeHref } from '@/lib/prototype-path';
 import Icon from '@/components/react/Icon';
 import ProtoLoadingDots from './ProtoLoadingDots';
 import StudyDockCardShell from '@/components/react/StudyDockCardShell';
@@ -57,7 +59,12 @@ import {
   useReviewSession,
   type ReviewItemView,
 } from '../../hooks/queries/useReview';
-import { useReviewOutcome, useSetReviewStatus, useStepBackReview } from '../../hooks/mutations/useReviewMutations';
+import {
+  useReviewFeedback,
+  useReviewOutcome,
+  useSetReviewStatus,
+  useStepBackReview,
+} from '../../hooks/mutations/useReviewMutations';
 import { useLibraryPanelNav } from './library-panel/use-library-panel-nav';
 import { buildReviewCardStackOrigin } from './paper-stack-origins';
 import {
@@ -76,6 +83,12 @@ import {
   REVIEW_PAUSE_COPY,
   REVIEW_SLIPPING_COPY,
   REVIEW_STALLED_COPY,
+  REVIEW_FEEDBACK_ACK_COPY,
+  REVIEW_FEEDBACK_DOWN_COPY,
+  REVIEW_FEEDBACK_PROMPT_COPY,
+  REVIEW_FEEDBACK_SETTINGS_LINK_COPY,
+  REVIEW_FEEDBACK_UP_COPY,
+  reviewFeedbackOfferCopy,
   REVIEW_STEP_BACK_COPY,
   REVIEW_STEPPED_BACK_COPY,
   REVIEW_OUTCOME_ACK_COPY,
@@ -357,6 +370,16 @@ export default function PrototypeReviewDock() {
   // What the reader chose for a slipping item, so the offer is made once and answered once.
   const [leechAction, setLeechAction] = useState<'stepped' | 'paused' | null>(null);
   /*
+   * The reader's rating of the question, and the family Settings may be offered for.
+   *
+   * Both keyed to `lastResult.at` — a fresh result gets a fresh control — and both local, because
+   * a vote is a log line rather than state the server hands back on the next fetch. There is no
+   * undo: the log is append-only, and a rating that could be taken back would be a setting.
+   */
+  const feedback = useReviewFeedback();
+  const [feedbackVote, setFeedbackVote] = useState<'liked' | 'disliked' | null>(null);
+  const [feedbackOffer, setFeedbackOffer] = useState<string | null>(null);
+  /*
    * How the last answer went, while the card still has the question on it.
    *
    * The page cannot mark anything, so this is set from the server's reply and nothing else. It
@@ -406,6 +429,40 @@ export default function PrototypeReviewDock() {
   const goesTotal = attemptsTotal ?? (item ? maxAttemptsFor(item.promptKey) : 0);
 
   const lastResult = reviewDock?.lastResult ?? null;
+
+  /*
+   * A new result is a new question, so the rating starts over.
+   *
+   * Keyed on the timestamp rather than reset inside the answer handler, because the paper-stack
+   * path sets `lastResult` from the shell and never runs this component's handler at all.
+   */
+  useEffect(() => {
+    setFeedbackVote(null);
+    setFeedbackOffer(null);
+  }, [lastResult?.at]);
+
+  const castFeedback = useCallback(
+    (vote: 'liked' | 'disliked') => {
+      const itemId = lastResult?.itemId;
+      if (!itemId) return;
+      // Shown as taken straight away: the card should not sit inert while a log line is written.
+      setFeedbackVote(vote);
+      feedback.mutate(
+        { itemId, vote },
+        {
+          onSuccess: (data) => {
+            if (data.offerSettings && data.family) setFeedbackOffer(data.family.label);
+          },
+          // Put the blocks back rather than leaving a rating that was never recorded.
+          onError: () => {
+            setFeedbackVote(null);
+            setFeedbackOffer(null);
+          },
+        },
+      );
+    },
+    [feedback, lastResult?.itemId],
+  );
   /*
    * When the next scheduled thing comes back, for the empty card.
    *
@@ -896,6 +953,57 @@ export default function PrototypeReviewDock() {
                 {REVIEW_ENOUGH_COPY}
               </button>
             </div>
+            {lastResult.itemId ? (
+              /*
+               * A rating of the question, which is a third thing: the verdict above describes
+               * the memory, these describe the exercise the app chose. Last on the card and
+               * quiet, because it is not what the reader came for — and after the way on, so a
+               * card that still has something to say about a slipping item says that last.
+               */
+              <div className="proto-review-dock__feedback">
+                <p className="proto-caption proto-review-dock__feedback-caption">
+                  {feedbackVote ? (
+                    <>
+                      {feedbackOffer
+                        ? reviewFeedbackOfferCopy(feedbackOffer)
+                        : REVIEW_FEEDBACK_ACK_COPY}
+                      {feedbackOffer ? (
+                        <>
+                          {' '}
+                          <button
+                            type="button"
+                            className="proto-review-dock__feedback-link"
+                            onClick={() =>
+                              void navigate({ to: prototypeHref('settings/review-exercises') })
+                            }
+                          >
+                            {REVIEW_FEEDBACK_SETTINGS_LINK_COPY}
+                          </button>
+                        </>
+                      ) : null}
+                    </>
+                  ) : (
+                    REVIEW_FEEDBACK_PROMPT_COPY
+                  )}
+                </p>
+                <div className="proto-icon-block-row">
+                  <ProtoIconBlock
+                    icon="thumbs-up"
+                    label={REVIEW_FEEDBACK_UP_COPY}
+                    selected={feedbackVote === 'liked'}
+                    disabled={Boolean(feedbackVote)}
+                    onSelect={() => castFeedback('liked')}
+                  />
+                  <ProtoIconBlock
+                    icon="thumbs-down"
+                    label={REVIEW_FEEDBACK_DOWN_COPY}
+                    selected={feedbackVote === 'disliked'}
+                    disabled={Boolean(feedbackVote)}
+                    onSelect={() => castFeedback('disliked')}
+                  />
+                </div>
+              </div>
+            ) : null}
             {lastResult.leech && lastResult.itemId ? (
               /* Four misses since it was last held. The one place Review says a thing is not
                  working rather than asking again, and it offers the way down, not a lecture. */

--- a/spa/src/pages/prototype/PrototypeReviewRow.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewRow.tsx
@@ -20,15 +20,27 @@ import {
   REVIEW_MORE_COPY,
   REVIEW_PAUSE_COPY,
   REVIEW_REMOVE_COPY,
+  REVIEW_PAUSE_SHORT_COPY,
+  REVIEW_REMOVE_SHORT_COPY,
 } from './proto-review-copy';
+import ProtoIconBlock from './ProtoIconBlock';
 
-/** Matches `.proto-review-row__menu`; used only until the real popover can be measured. */
-const MENU_WIDTH = 200;
-const MENU_FALLBACK_HEIGHT = 124;
+/*
+ * Matches `.proto-review-row__menu`; used only until the real popover can be measured.
+ *
+ * Kept honest by hand because these decide the first frame: three 72px blocks, two 8px gaps and
+ * 6px of padding either side is 244, and a block is 56 tall inside 12 of padding. A stale pair
+ * here makes the flip decision wrong on a row near the edge, for one frame, every time.
+ */
+const MENU_WIDTH = 244;
+const MENU_FALLBACK_HEIGHT = 80;
 
 export interface StudyInboxRowAction {
   key: string;
+  /** The full sentence, and the accessible name. */
   label: string;
+  /** The word that fits under a glyph. Falls back to `label` where it is already short. */
+  shortLabel?: string;
   icon: IconName;
   onSelect: () => void;
 }
@@ -134,26 +146,25 @@ export default function PrototypeReviewRow({
               ? createPortal(
                   <div
                     ref={popoverRef}
-                    className="proto-menu__popover proto-menu__popover--list-view proto-review-row__menu"
+                    className="proto-menu__popover proto-menu__popover--blocks proto-review-row__menu"
                     role="menu"
+                    aria-orientation="horizontal"
                     aria-label={`${REVIEW_MORE_COPY} — ${title}`}
                     /* Off-screen until measured, so the first paint is never in the wrong place. */
                     style={{ top: anchorPos?.top ?? -9999, left: anchorPos?.left ?? 0 }}
                   >
-                    {actions.map((action) => (
-                      <button
-                        key={action.key}
-                        type="button"
-                        role="menuitem"
-                        className="proto-menu-item"
-                        onClick={answer(action.onSelect)}
-                      >
-                        <span className="proto-menu-item__icon" aria-hidden>
-                          <Icon name={action.icon} size={14} />
-                        </span>
-                        <span className="proto-menu-item__label">{action.label}</span>
-                      </button>
-                    ))}
+                    <div className="proto-icon-block-row">
+                      {actions.map((action) => (
+                        <ProtoIconBlock
+                          key={action.key}
+                          role="menuitem"
+                          icon={action.icon}
+                          label={action.shortLabel ?? action.label}
+                          ariaLabel={action.label}
+                          onSelect={answer(action.onSelect)}
+                        />
+                      ))}
+                    </div>
                   </div>,
                   document.body,
                 )
@@ -171,9 +182,14 @@ export function reviewRowActions(handlers: {
   onPause: () => void;
   onRemove: () => void;
 }): StudyInboxRowAction[] {
+  /*
+   * `label` stays the full sentence — it is the accessible name, and "Remove from Review" is what
+   * the action actually does. `shortLabel` is the word that fits under a glyph. Both are present
+   * so the block is never a bare icon and never a truncated one.
+   */
   return [
     { key: 'defer', label: REVIEW_DEFER_COPY, icon: 'clock-rotate-left', onSelect: handlers.onDefer },
-    { key: 'pause', label: REVIEW_PAUSE_COPY, icon: 'circle-minus', onSelect: handlers.onPause },
-    { key: 'remove', label: REVIEW_REMOVE_COPY, icon: 'eye-slash', onSelect: handlers.onRemove },
+    { key: 'pause', label: REVIEW_PAUSE_COPY, shortLabel: REVIEW_PAUSE_SHORT_COPY, icon: 'circle-minus', onSelect: handlers.onPause },
+    { key: 'remove', label: REVIEW_REMOVE_COPY, shortLabel: REVIEW_REMOVE_SHORT_COPY, icon: 'eye-slash', onSelect: handlers.onRemove },
   ];
 }

--- a/spa/src/pages/prototype/PrototypeReviewRow.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewRow.tsx
@@ -20,27 +20,15 @@ import {
   REVIEW_MORE_COPY,
   REVIEW_PAUSE_COPY,
   REVIEW_REMOVE_COPY,
-  REVIEW_PAUSE_SHORT_COPY,
-  REVIEW_REMOVE_SHORT_COPY,
 } from './proto-review-copy';
-import ProtoIconBlock from './ProtoIconBlock';
 
-/*
- * Matches `.proto-review-row__menu`; used only until the real popover can be measured.
- *
- * Kept honest by hand because these decide the first frame: three 72px blocks, two 8px gaps and
- * 6px of padding either side is 244, and a block is 56 tall inside 12 of padding. A stale pair
- * here makes the flip decision wrong on a row near the edge, for one frame, every time.
- */
-const MENU_WIDTH = 244;
-const MENU_FALLBACK_HEIGHT = 80;
+/** Matches `.proto-review-row__menu`; used only until the real popover can be measured. */
+const MENU_WIDTH = 200;
+const MENU_FALLBACK_HEIGHT = 124;
 
 export interface StudyInboxRowAction {
   key: string;
-  /** The full sentence, and the accessible name. */
   label: string;
-  /** The word that fits under a glyph. Falls back to `label` where it is already short. */
-  shortLabel?: string;
   icon: IconName;
   onSelect: () => void;
 }
@@ -146,25 +134,26 @@ export default function PrototypeReviewRow({
               ? createPortal(
                   <div
                     ref={popoverRef}
-                    className="proto-menu__popover proto-menu__popover--blocks proto-review-row__menu"
+                    className="proto-menu__popover proto-menu__popover--list-view proto-review-row__menu"
                     role="menu"
-                    aria-orientation="horizontal"
                     aria-label={`${REVIEW_MORE_COPY} — ${title}`}
                     /* Off-screen until measured, so the first paint is never in the wrong place. */
                     style={{ top: anchorPos?.top ?? -9999, left: anchorPos?.left ?? 0 }}
                   >
-                    <div className="proto-icon-block-row">
-                      {actions.map((action) => (
-                        <ProtoIconBlock
-                          key={action.key}
-                          role="menuitem"
-                          icon={action.icon}
-                          label={action.shortLabel ?? action.label}
-                          ariaLabel={action.label}
-                          onSelect={answer(action.onSelect)}
-                        />
-                      ))}
-                    </div>
+                    {actions.map((action) => (
+                      <button
+                        key={action.key}
+                        type="button"
+                        role="menuitem"
+                        className="proto-menu-item"
+                        onClick={answer(action.onSelect)}
+                      >
+                        <span className="proto-menu-item__icon" aria-hidden>
+                          <Icon name={action.icon} size={14} />
+                        </span>
+                        <span className="proto-menu-item__label">{action.label}</span>
+                      </button>
+                    ))}
                   </div>,
                   document.body,
                 )
@@ -182,14 +171,9 @@ export function reviewRowActions(handlers: {
   onPause: () => void;
   onRemove: () => void;
 }): StudyInboxRowAction[] {
-  /*
-   * `label` stays the full sentence — it is the accessible name, and "Remove from Review" is what
-   * the action actually does. `shortLabel` is the word that fits under a glyph. Both are present
-   * so the block is never a bare icon and never a truncated one.
-   */
   return [
     { key: 'defer', label: REVIEW_DEFER_COPY, icon: 'clock-rotate-left', onSelect: handlers.onDefer },
-    { key: 'pause', label: REVIEW_PAUSE_COPY, shortLabel: REVIEW_PAUSE_SHORT_COPY, icon: 'circle-minus', onSelect: handlers.onPause },
-    { key: 'remove', label: REVIEW_REMOVE_COPY, shortLabel: REVIEW_REMOVE_SHORT_COPY, icon: 'eye-slash', onSelect: handlers.onRemove },
+    { key: 'pause', label: REVIEW_PAUSE_COPY, icon: 'circle-minus', onSelect: handlers.onPause },
+    { key: 'remove', label: REVIEW_REMOVE_COPY, icon: 'eye-slash', onSelect: handlers.onRemove },
   ];
 }

--- a/spa/src/pages/prototype/PrototypeStudyFeedPage.tsx
+++ b/spa/src/pages/prototype/PrototypeStudyFeedPage.tsx
@@ -41,7 +41,11 @@ import ProtoSpaceMenuIcon from './ProtoSpaceMenuIcon';
 import { noteParamSlug } from './proto-route-slugs';
 import ProtoSpaceLoading from './ProtoSpaceLoading';
 import PrototypeStudyFeedPart from './PrototypeStudyFeedPart';
-import { studyFeedEmptyDayCopy, summarizeStudyFeedDay } from './study-feed-presentation';
+import {
+  studyFeedEmptyDayCopy,
+  studyFeedScopedEmptyCopy,
+  summarizeStudyFeedDay,
+} from './study-feed-presentation';
 import { canonicalBookOrderMap } from '@/utils/scripture-passage-drill';
 import type { LibraryTab } from './library-panel/library-panel-view';
 import PrototypeHomeGreeting from './PrototypeHomeGreeting';
@@ -269,12 +273,38 @@ export default function PrototypeStudyFeedPage() {
 
   /** Index into `days`, newest first. 0 is today. */
   const [index, setIndex] = useState(0);
+  /** Set when a space scope is picked, so the jump can wait for that scope's days. */
+  const pendingScopeJump = useRef(false);
 
   /* A narrower scope has fewer days in it, so the sheet you were on is not the sheet that
      index now points at. Going back to today is the only answer that is never surprising. */
   useEffect(() => {
     setIndex(0);
+    /*
+     * ...except for a space, where today is usually a rest day and going there says nothing.
+     *
+     * "All" and "My home" always have today's own study on them, so landing on today shows the
+     * change immediately. A room's last note might be a fortnight back — so picking one landed
+     * on an empty sheet, which is indistinguishable from the filter having done nothing at all.
+     * Jump to the newest day the space actually has something on instead. Deferred rather than
+     * done here because the items for the new scope have not arrived yet.
+     */
+    pendingScopeJump.current = scope.kind === 'space';
   }, [scope]);
+
+  /* The deferred half of the jump above, run once this scope's days have arrived. Cleared
+     either way once the fetch settles, so a space with nothing in it simply stays on today
+     rather than leaving the jump armed for the next unrelated change. */
+  useEffect(() => {
+    if (!pendingScopeJump.current) return;
+    const firstWithItems = days.findIndex((day) => !day.isEmpty);
+    if (firstWithItems > 0) {
+      pendingScopeJump.current = false;
+      setIndex(firstWithItems);
+      return;
+    }
+    if (!isPending && !isFetchingNextPage) pendingScopeJump.current = false;
+  }, [days, isPending, isFetchingNextPage]);
   const safeIndex = Math.min(index, Math.max(0, days.length - 1));
   const day = days[safeIndex];
 
@@ -461,7 +491,22 @@ export default function PrototypeStudyFeedPage() {
     partsCount: day.parts.length,
     revisited: reviewSubjectsForDay.get(day.dayKey) ?? null,
   });
-  const showGreeting = safeIndex === 0 && greeting.ready && home.countForLogic > 0;
+  /*
+   * The room this sheet is of, when it is of one.
+   *
+   * Everything below keyed off it is the same idea: under a space scope this sheet belongs to
+   * the space, so the surfaces that are about *you* step aside. The greeting, Home's own
+   * sections and the getting-started dock are all personal — printed under "Family" they read
+   * as the filter having been ignored, which is precisely how this looked before.
+   */
+  const scopedSpace =
+    scope.kind === 'space'
+      ? sharedSpaces.find((space) => space.id === scope.spaceId) ?? null
+      : null;
+  /** Not one day empty but the whole room — a fact about the space, not about a Tuesday. */
+  const scopeNeverHadAnything = Boolean(scopedSpace) && days.every((d) => d.isEmpty);
+  const showGreeting =
+    safeIndex === 0 && greeting.ready && home.countForLogic > 0 && !scopedSpace;
 
 
 
@@ -783,18 +828,20 @@ export default function PrototypeStudyFeedPage() {
 
             {/* Home's own order: what you were doing, then what is coming, then what is
                 offered, and only then the record of the day itself. */}
-            {safeIndex === 0 && greeting.ready ? (
+            {safeIndex === 0 && greeting.ready && !scopedSpace ? (
               <PrototypeStudyFeedToday
                 notes={greeting.notes}
                 home={home}
               />
             ) : null}
 
-            {onboardingLeads ? null : onboardingDock}
+            {onboardingLeads || scopedSpace ? null : onboardingDock}
 
             {day.isEmpty ? (
               <p className="proto-feed-sheet__rest">
-                {studyFeedEmptyDayCopy(safeIndex === 0)}
+                {scopedSpace
+                  ? studyFeedScopedEmptyCopy(scopedSpace.title, scopeNeverHadAnything)
+                  : studyFeedEmptyDayCopy(safeIndex === 0)}
               </p>
             ) : (
               day.parts.map((group) => (

--- a/spa/src/pages/prototype/PrototypeStudyFeedPage.tsx
+++ b/spa/src/pages/prototype/PrototypeStudyFeedPage.tsx
@@ -41,6 +41,7 @@ import ProtoSpaceMenuIcon from './ProtoSpaceMenuIcon';
 import { noteParamSlug } from './proto-route-slugs';
 import ProtoSpaceLoading from './ProtoSpaceLoading';
 import PrototypeStudyFeedPart from './PrototypeStudyFeedPart';
+import PrototypeListEmptyState from './PrototypeListEmptyState';
 import {
   studyFeedEmptyDayCopy,
   studyFeedScopedEmptyCopy,
@@ -837,10 +838,25 @@ export default function PrototypeStudyFeedPage() {
 
             {onboardingLeads || scopedSpace ? null : onboardingDock}
 
-            {day.isEmpty ? (
+            {day.isEmpty && scopedSpace && scopeNeverHadAnything ? (
+              /*
+               * A room that has never had anything in it is not a quiet Tuesday, and a single
+               * grey line in the middle of an empty sheet reads as a page that failed to load.
+               * The app's own empty state says what the surface is for. No action beside it:
+               * `space/$spaceId` is a legacy route that redirects to Home, so the obvious button
+               * would land the reader somewhere that is not the space it named.
+               */
+              <PrototypeListEmptyState
+                iconName="user-group"
+                title={`Nothing in ${scopedSpace.title} yet`}
+                description="What gets shared there stacks up here, a day at a time."
+              />
+            ) : day.isEmpty ? (
+              /* A quiet day inside a room that does have a trail stays a quiet line: the day
+                 nav is right there, and a block this size on every rest day would be furniture. */
               <p className="proto-feed-sheet__rest">
                 {scopedSpace
-                  ? studyFeedScopedEmptyCopy(scopedSpace.title, scopeNeverHadAnything)
+                  ? studyFeedScopedEmptyCopy(scopedSpace.title, false)
                   : studyFeedEmptyDayCopy(safeIndex === 0)}
               </p>
             ) : (

--- a/spa/src/pages/prototype/PrototypeStudyFeedToday.tsx
+++ b/spa/src/pages/prototype/PrototypeStudyFeedToday.tsx
@@ -83,7 +83,11 @@ export default function PrototypeStudyFeedToday({
   const { state: onboardingState } = useOnboardingState();
   const { isGuest } = useHarvousIdentity();
   const onboardingOwnsImport = onboardingOwnsOffer(onboardingState, 'import', isGuest);
-  const { dismissed: importDismissed, dismiss: dismissImportPrompt } = useDismissibleImportPrompt();
+  const {
+    dismissed: importDismissed,
+    ready: importPromptReady,
+    dismiss: dismissImportPrompt,
+  } = useDismissibleImportPrompt();
 
   const {
     continueNote,
@@ -234,9 +238,10 @@ export default function PrototypeStudyFeedToday({
             *
             * Which makes the dismissal the whole design, not a courtesy. This row has no
             * ending of its own the way "N notes need a folder" does, so without a way to say
-            * no it would be permanent furniture. Saying no is permanent too.
+            * no it would be permanent furniture. Saying no is permanent, and now account-wide:
+            * whether you have notes to bring across is a fact about you, not about this browser.
             */}
-          {!isGuest && !importDismissed && !onboardingOwnsImport ? (
+          {!isGuest && importPromptReady && !importDismissed && !onboardingOwnsImport ? (
             <PrototypeHomeRow
               icon="cloud-arrow-up"
               title="Bring your notes from another app"

--- a/spa/src/pages/prototype/__tests__/dismissible-import-prompt.test.tsx
+++ b/spa/src/pages/prototype/__tests__/dismissible-import-prompt.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import {
+  PROTO_IMPORT_PROMPT_DISMISSED_KEY,
+  useDismissibleImportPrompt,
+} from '../use-dismissible-import-prompt';
+import { emptyOnboardingState, type OnboardingState } from '@/utils/onboarding-state';
+
+const dismissStep = vi.fn();
+let harness: { state: OnboardingState; ready: boolean } = {
+  state: emptyOnboardingState(),
+  ready: true,
+};
+
+vi.mock('../useOnboardingState', () => ({
+  useOnboardingState: () => ({ ...harness, dismissStep }),
+}));
+
+const withImport = (patch: { done?: boolean; dismissed?: boolean }): OnboardingState => {
+  const state = emptyOnboardingState();
+  state.steps.import = { done: false, dismissed: false, ...patch };
+  return state;
+};
+
+beforeEach(() => {
+  dismissStep.mockClear();
+  harness = { state: emptyOnboardingState(), ready: true };
+  window.localStorage.clear();
+});
+
+afterEach(() => window.localStorage.clear());
+
+describe('the import row reads its dismissal from the account', () => {
+  it('is not dismissed on a fresh account', () => {
+    const { result } = renderHook(() => useDismissibleImportPrompt());
+    expect(result.current.dismissed).toBe(false);
+  });
+
+  it('is dismissed once the account says so', () => {
+    harness = { state: withImport({ dismissed: true }), ready: true };
+    expect(renderHook(() => useDismissibleImportPrompt()).result.current.dismissed).toBe(true);
+  });
+
+  it('is also dismissed once the reader has actually imported', () => {
+    // Nothing left to offer. `done` hides the row as surely as saying no to it does.
+    harness = { state: withImport({ done: true }), ready: true };
+    expect(renderHook(() => useDismissibleImportPrompt()).result.current.dismissed).toBe(true);
+  });
+
+  it('withholds `ready` until the account copy has arrived', () => {
+    // The row is hidden while this is false, so it cannot appear and then vanish under the cursor.
+    harness = { state: emptyOnboardingState(), ready: false };
+    expect(renderHook(() => useDismissibleImportPrompt()).result.current.ready).toBe(false);
+  });
+
+  it('writes the dismissal to the account, not to this browser', () => {
+    const { result } = renderHook(() => useDismissibleImportPrompt());
+    result.current.dismiss();
+    expect(dismissStep).toHaveBeenCalledWith('import');
+    expect(window.localStorage.getItem(PROTO_IMPORT_PROMPT_DISMISSED_KEY)).toBeNull();
+  });
+});
+
+describe('the device-local flag it used to be', () => {
+  it('carries a pre-existing dismissal up to the account, once', () => {
+    /*
+     * The failure this guards against is the loud one: without it, every reader who had already
+     * put the row away would meet it again the day this shipped.
+     */
+    window.localStorage.setItem(PROTO_IMPORT_PROMPT_DISMISSED_KEY, '1');
+    const { rerender } = renderHook(() => useDismissibleImportPrompt());
+    expect(dismissStep).toHaveBeenCalledWith('import');
+    // Cleared, so a later render cannot re-push what the account already records.
+    expect(window.localStorage.getItem(PROTO_IMPORT_PROMPT_DISMISSED_KEY)).toBeNull();
+    dismissStep.mockClear();
+    rerender();
+    expect(dismissStep).not.toHaveBeenCalled();
+  });
+
+  it('waits for the account copy before pushing anything', () => {
+    // Pushing before hydration would be guessing at what the account already says.
+    window.localStorage.setItem(PROTO_IMPORT_PROMPT_DISMISSED_KEY, '1');
+    harness = { state: emptyOnboardingState(), ready: false };
+    renderHook(() => useDismissibleImportPrompt());
+    expect(dismissStep).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(PROTO_IMPORT_PROMPT_DISMISSED_KEY)).toBe('1');
+  });
+
+  it('does not push when the account already has the dismissal', () => {
+    window.localStorage.setItem(PROTO_IMPORT_PROMPT_DISMISSED_KEY, '1');
+    harness = { state: withImport({ dismissed: true }), ready: true };
+    renderHook(() => useDismissibleImportPrompt());
+    expect(dismissStep).not.toHaveBeenCalled();
+  });
+
+  it('leaves an un-dismissed device alone', () => {
+    renderHook(() => useDismissibleImportPrompt());
+    expect(dismissStep).not.toHaveBeenCalled();
+  });
+});

--- a/spa/src/pages/prototype/__tests__/portaled-row-menu-pointerdown.test.tsx
+++ b/spa/src/pages/prototype/__tests__/portaled-row-menu-pointerdown.test.tsx
@@ -69,7 +69,9 @@ describe('a review row’s overflow menu', () => {
   it('runs the action when a menu item is pressed, not just clicked', () => {
     const { onRemove } = renderRow();
     openMenu();
-    pressLikeABrowser(screen.getByText(REVIEW_REMOVE_COPY));
+    /* By role and accessible name, not by visible text: the menu shows icon blocks, whose
+       visible word is a shortening ("Remove") of the full sentence that names the action. */
+    pressLikeABrowser(screen.getByRole('menuitem', { name: REVIEW_REMOVE_COPY }));
     expect(onRemove).toHaveBeenCalledTimes(1);
   });
 

--- a/spa/src/pages/prototype/__tests__/portaled-row-menu-pointerdown.test.tsx
+++ b/spa/src/pages/prototype/__tests__/portaled-row-menu-pointerdown.test.tsx
@@ -69,9 +69,7 @@ describe('a review row’s overflow menu', () => {
   it('runs the action when a menu item is pressed, not just clicked', () => {
     const { onRemove } = renderRow();
     openMenu();
-    /* By role and accessible name, not by visible text: the menu shows icon blocks, whose
-       visible word is a shortening ("Remove") of the full sentence that names the action. */
-    pressLikeABrowser(screen.getByRole('menuitem', { name: REVIEW_REMOVE_COPY }));
+    pressLikeABrowser(screen.getByText(REVIEW_REMOVE_COPY));
     expect(onRemove).toHaveBeenCalledTimes(1);
   });
 

--- a/spa/src/pages/prototype/__tests__/proto-icon-block.test.tsx
+++ b/spa/src/pages/prototype/__tests__/proto-icon-block.test.tsx
@@ -15,21 +15,9 @@ describe('ProtoIconBlock', () => {
     expect(screen.getByText('Not helpful')).toBeTruthy();
   });
 
-  it('keeps the visible word as the accessible name when it needs no lengthening', () => {
+  it('uses the visible word as the accessible name, with nothing spoken that is not shown', () => {
     render(<ProtoIconBlock icon="thumbs-up" label="Good question" onSelect={() => {}} />);
     expect(screen.getByRole('button', { name: 'Good question' })).toBeTruthy();
-  });
-
-  it('lets a longer sentence be the accessible name where the word is a shortening', () => {
-    render(
-      <ProtoIconBlock
-        icon="eye-slash"
-        label="Remove"
-        ariaLabel="Remove from Review"
-        onSelect={() => {}}
-      />,
-    );
-    expect(screen.getByRole('button', { name: 'Remove from Review' })).toBeTruthy();
   });
 
   it('says which way it was pressed, and only once it has been', () => {

--- a/spa/src/pages/prototype/__tests__/proto-icon-block.test.tsx
+++ b/spa/src/pages/prototype/__tests__/proto-icon-block.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ProtoIconBlock from '../ProtoIconBlock';
+
+describe('ProtoIconBlock', () => {
+  /*
+   * The rule this file exists to keep. A bare `+` was once removed from the Review card for
+   * being "two entry points for one action, one of them a bare icon", and a glyph meaning
+   * "fewer of these" has no settled shape at all — so a block without a word is a question the
+   * reader has to answer before they can answer the question. Rules like that survive in code
+   * only if something fails when they are broken.
+   */
+  it('always shows a word beside the glyph', () => {
+    render(<ProtoIconBlock icon="thumbs-down" label="Not helpful" onSelect={() => {}} />);
+    expect(screen.getByText('Not helpful')).toBeTruthy();
+  });
+
+  it('keeps the visible word as the accessible name when it needs no lengthening', () => {
+    render(<ProtoIconBlock icon="thumbs-up" label="Good question" onSelect={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Good question' })).toBeTruthy();
+  });
+
+  it('lets a longer sentence be the accessible name where the word is a shortening', () => {
+    render(
+      <ProtoIconBlock
+        icon="eye-slash"
+        label="Remove"
+        ariaLabel="Remove from Review"
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Remove from Review' })).toBeTruthy();
+  });
+
+  it('says which way it was pressed, and only once it has been', () => {
+    const { rerender } = render(
+      <ProtoIconBlock icon="thumbs-up" label="Good question" onSelect={() => {}} />,
+    );
+    // No `aria-pressed` at all where the block is an action rather than a choice.
+    expect(screen.getByRole('button').getAttribute('aria-pressed')).toBeNull();
+    rerender(
+      <ProtoIconBlock icon="thumbs-up" label="Good question" selected onSelect={() => {}} />,
+    );
+    expect(screen.getByRole('button').getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('does not fire when spent', () => {
+    const onSelect = vi.fn();
+    render(<ProtoIconBlock icon="thumbs-up" label="Good question" disabled onSelect={onSelect} />);
+    screen.getByRole('button').click();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/spa/src/pages/prototype/__tests__/recall-state-chip.test.tsx
+++ b/spa/src/pages/prototype/__tests__/recall-state-chip.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import PrototypeRecallStateChip from '../PrototypeRecallStateChip';
+import { RECALL_STATE_LABELS, type RecallState } from '@/utils/review-item-kinds';
+
+const renderMark = (state: RecallState) => {
+  const { container } = render(
+    <PrototypeRecallStateChip state={state} label={RECALL_STATE_LABELS[state]} />,
+  );
+  return container.querySelector('.proto-recall-mark') as HTMLElement;
+};
+
+describe('the recall mark still says what it used to say', () => {
+  /*
+   * The mark replaced two words, and nothing failed when the words disappeared — no test read
+   * them. This is that test: whatever the mark looks like, it has to keep carrying the sentence
+   * for someone listening rather than looking.
+   */
+  it('keeps the label as its accessible name', () => {
+    render(<PrototypeRecallStateChip state="durable" label={RECALL_STATE_LABELS.durable} />);
+    expect(screen.getByRole('img', { name: 'You have this' })).toBeTruthy();
+  });
+
+  it('shows no visible text of its own', () => {
+    expect(renderMark('fragile').textContent).toBe('');
+  });
+});
+
+describe('three levels, because the copy makes three distinctions', () => {
+  it('draws fragile and forming identically, as their shared label does', () => {
+    // Two states, one sentence, one fill. A bar over all five would expose a split the words hide.
+    expect(renderMark('fragile').dataset.hold).toBe('learning');
+    expect(renderMark('forming').dataset.hold).toBe('learning');
+    expect(RECALL_STATE_LABELS.fragile).toBe(RECALL_STATE_LABELS.forming);
+  });
+
+  it('draws durable as held', () => {
+    expect(renderMark('durable').dataset.hold).toBe('held');
+  });
+
+  it('gives slipping its own step rather than a low one', () => {
+    // A fall from holding, not an early rung — see the component's note.
+    expect(renderMark('slipping').dataset.hold).toBe('slipped');
+  });
+
+  it('keeps the raw state, which is the only thing telling fragile from forming', () => {
+    expect(renderMark('fragile').dataset.state).toBe('fragile');
+    expect(renderMark('forming').dataset.state).toBe('forming');
+  });
+
+  it('always draws three segments, whatever the state', () => {
+    for (const state of ['fragile', 'forming', 'durable', 'slipping'] as RecallState[]) {
+      expect(renderMark(state).querySelectorAll('.proto-recall-mark__seg')).toHaveLength(3);
+    }
+  });
+});

--- a/spa/src/pages/prototype/proto-review-copy.ts
+++ b/spa/src/pages/prototype/proto-review-copy.ts
@@ -41,13 +41,6 @@ export const reviewComingBackCopy = (count: number) =>
   count === 1 ? '1 coming back later' : `${count} coming back later`;
 export const REVIEW_REMOVE_COPY = 'Remove from Review';
 
-/*
- * The same three actions, in the word that fits under a glyph in the row's icon-block menu.
- * The full sentences above stay the accessible names — "Pause" alone would not say what is
- * being paused to someone listening rather than looking.
- */
-export const REVIEW_PAUSE_SHORT_COPY = 'Pause';
-export const REVIEW_REMOVE_SHORT_COPY = 'Remove';
 export const REVIEW_MORE_COPY = 'More';
 
 /**

--- a/spa/src/pages/prototype/proto-review-copy.ts
+++ b/spa/src/pages/prototype/proto-review-copy.ts
@@ -40,6 +40,14 @@ export const reviewSetAsideCopy = (count: number) =>
 export const reviewComingBackCopy = (count: number) =>
   count === 1 ? '1 coming back later' : `${count} coming back later`;
 export const REVIEW_REMOVE_COPY = 'Remove from Review';
+
+/*
+ * The same three actions, in the word that fits under a glyph in the row's icon-block menu.
+ * The full sentences above stay the accessible names — "Pause" alone would not say what is
+ * being paused to someone listening rather than looking.
+ */
+export const REVIEW_PAUSE_SHORT_COPY = 'Pause';
+export const REVIEW_REMOVE_SHORT_COPY = 'Remove';
 export const REVIEW_MORE_COPY = 'More';
 
 /**
@@ -192,6 +200,57 @@ export const REVIEW_OUTCOME_ACK_COPY: Record<'recalled' | 'almost' | 'revealed',
   almost: 'Got there.',
   revealed: 'Not this time.',
 };
+
+/**
+ * What the reader thought of the QUESTION, which is a third thing.
+ *
+ * The three answers above describe a memory — "I recalled it" — and the outcome line describes
+ * how it went. Neither says anything about the exercise the app chose, so a rung that keeps
+ * landing badly had nowhere to be reported. These two are about that, and about nothing else:
+ * they never grade the reader, and like everything else here they say nothing about wrong, fail
+ * or mistake, because a miss on a verse is none of those.
+ *
+ * Both carry a word beside the glyph. A bare icon was tried once in this very feature and
+ * removed — see REVIEW_ADD_COPY — and a glyph meaning "fewer of these" has no settled shape at
+ * all, so an unlabelled one would be a question the reader has to answer before they can answer
+ * the question.
+ *
+ * "Not helpful" is the reader's own phrase for this, and it deliberately avoids "Show fewer",
+ * which is already the Activity fold's toggle a few lines above.
+ */
+/* Names the subject, so two blocks under a verdict line cannot be read as being about the
+   memory that was just described. Four words, in the caption size. */
+export const REVIEW_FEEDBACK_PROMPT_COPY = 'This kind of question';
+export const REVIEW_FEEDBACK_UP_COPY = 'Good question';
+export const REVIEW_FEEDBACK_DOWN_COPY = 'Not helpful';
+
+/** The full sentence for the accessible name; the family is what is actually being rated. */
+export const reviewFeedbackUpAria = (family: string) => `Good question — more ${family}`;
+export const reviewFeedbackDownAria = (family: string) => `Not helpful — fewer ${family}`;
+
+/**
+ * Said back, and nothing more.
+ *
+ * Never "you will see fewer of these". The engine leans away where the step has somewhere else
+ * to go, and on a note with nothing but a body it must still fall back to the rung just marked
+ * unhelpful. A card that promised otherwise would be the lie `review-exercise-settings.ts`
+ * names, moved from a settings row onto a study card.
+ */
+export const REVIEW_FEEDBACK_ACK_COPY = 'Noted.';
+
+/**
+ * The third time, for a family the reader can actually switch.
+ *
+ * Offered once — a fourth and a fifth say "Noted." like the rest, because an offer repeated is a
+ * nag — and never for an always-on family, where there is no switch and naming one would promise
+ * something the engine is entitled to ignore.
+ */
+export const REVIEW_FEEDBACK_SETTINGS_LINK_COPY = 'Review exercises';
+export const reviewFeedbackOfferCopy = (family: string) =>
+  `Noted. You can turn ${family} off in`;
+
+/** A vote is a log line, not a setting; losing one is not worth interrupting a sitting for. */
+export const REVIEW_FEEDBACK_FAILED_TOAST = "Couldn't note that";
 
 /** The graded rungs: the reader has arranged or chosen, and asks the app to mark it. */
 export const REVIEW_CHECK_COPY = 'Check it';

--- a/spa/src/pages/prototype/study-feed-presentation.ts
+++ b/spa/src/pages/prototype/study-feed-presentation.ts
@@ -165,6 +165,22 @@ export function studyFeedEmptyDayCopy(isToday: boolean): string {
     : 'A quiet day. Rest counts too.';
 }
 
+/**
+ * The same silence, said about a room rather than about the reader.
+ *
+ * The copy above is in the second person — "whatever you read", "rest counts too" — which is
+ * right on your own day and wrong on a space's. Told over a quiet room it reads as a remark
+ * about how little *you* have done, when the sheet is not about you at all.
+ *
+ * `neverAnything` separates the two silences worth telling apart: a room that has had nothing
+ * in it yet, which is a fact about the room, and a room that simply had a quiet Tuesday.
+ */
+export function studyFeedScopedEmptyCopy(spaceTitle: string, neverAnything: boolean): string {
+  return neverAnything
+    ? `Nothing in ${spaceTitle} yet. What gets shared there stacks up here by day.`
+    : `A quiet day in ${spaceTitle}.`;
+}
+
 /** Clock time on the right edge of a moment — 9:14 PM, in the reader's locale. */
 export function studyFeedClockTime(iso: string): string {
   const date = new Date(iso);

--- a/spa/src/pages/prototype/use-dismissible-import-prompt.ts
+++ b/spa/src/pages/prototype/use-dismissible-import-prompt.ts
@@ -1,44 +1,74 @@
 /**
  * Whether the reader has put the import offer away.
  *
- * Device-local, like the Review upsell and the what's-new dismissal beside it. Where the
- * reasoning differs from those: this one *needs* a dismissal in a way the other Home nudges
- * do not. "Three notes need a folder" answers itself the moment you file them, so it never
- * has to be turned off. "Bring your notes from another app" has no such ending for the many
- * readers who have nothing to bring — without a way to say no, it would sit there for as long
- * as their library stayed small, which is exactly the reader least in need of being nagged.
+ * Account-synced, via the `import` step of the getting-started state. It began device-local, in
+ * `localStorage`, alongside the Review upsell and the what's-new dismissal — and that was wrong
+ * here in a way it is not wrong for those. Dismissing this is a decision about the reader's
+ * *library*, not about this browser: someone who has nothing to bring across has nothing to bring
+ * across on their phone either, and making them say so again on every device is the nagging the
+ * dismissal exists to stop.
  *
- * Permanent rather than a snooze, for the same reason as the upsell: someone who has read the
- * row and said no has answered the question. Asking again next week is what turns an offer
- * into a nag.
+ * It rides the onboarding state rather than a column of its own because the checklist already
+ * carries an `import` row, already syncs, and already merges monotonically — `dismissed` only
+ * ever goes false → true, so two devices in any order converge. A separate flag would have been a
+ * second answer to one question, and the two could disagree.
+ *
+ * That shared home fixes something as a side effect: dismissing the import row *inside* the
+ * checklist used to hand the offer straight to the standalone row on Home, so saying no once got
+ * you asked again. One record, one answer, both places.
+ *
+ * Permanent rather than a snooze. Someone who read the row and said no has answered the question.
  */
-import { useCallback, useState } from 'react';
+import { useEffect } from 'react';
 
+import { useOnboardingState } from './useOnboardingState';
+
+/**
+ * The device-local flag this used to be.
+ *
+ * Still read once, so an account that dismissed the row before the move stays dismissed — then
+ * cleared, because the account's copy is the answer from that point on. Kept rather than dropped
+ * because the alternative is every existing reader meeting a row they already said no to.
+ */
 export const PROTO_IMPORT_PROMPT_DISMISSED_KEY = 'harvous-prototype-import-prompt-dismissed';
 
-function read(): boolean {
+function readLegacy(): boolean {
   if (typeof window === 'undefined') return false;
   try {
     return window.localStorage.getItem(PROTO_IMPORT_PROMPT_DISMISSED_KEY) === '1';
   } catch {
-    // Private mode, or site data blocked. Showing the row is the safe answer — it is one row
-    // the reader can dismiss again, where hiding it on a storage error hides the only pointer
-    // a new reader gets to the fact that importing is possible at all.
+    // Private mode, or site data blocked. Nothing to migrate; the account is the record now.
     return false;
   }
 }
 
+function clearLegacy(): void {
+  try {
+    window.localStorage.removeItem(PROTO_IMPORT_PROMPT_DISMISSED_KEY);
+  } catch {
+    // Nothing to do. The account has the dismissal, which is the copy that matters.
+  }
+}
+
 export function useDismissibleImportPrompt() {
-  const [dismissed, setDismissed] = useState(read);
+  const { state, ready, dismissStep } = useOnboardingState();
+  const step = state.steps.import;
+  const dismissed = step.dismissed || step.done;
 
-  const dismiss = useCallback(() => {
-    setDismissed(true);
-    try {
-      window.localStorage.setItem(PROTO_IMPORT_PROMPT_DISMISSED_KEY, '1');
-    } catch {
-      // The state above still hides it for this session, which is what the reader asked for.
-    }
-  }, []);
+  useEffect(() => {
+    // Only once the account's own copy has arrived: pushing a device flag before then would be
+    // guessing at what the account already says. The merge is monotonic, so this can only ever
+    // add a dismissal the reader really made.
+    if (!ready || dismissed) return;
+    if (!readLegacy()) return;
+    dismissStep('import');
+    clearLegacy();
+  }, [ready, dismissed, dismissStep]);
 
-  return { dismissed, dismiss };
+  return {
+    dismissed,
+    /** False until the account's copy has arrived, so the row cannot flash and then vanish. */
+    ready,
+    dismiss: () => dismissStep('import'),
+  };
 }

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -14378,14 +14378,48 @@ html.harvous-prototype-route
   So: the caption's own size and colour, a little space, and nothing else. Not bold, not tinted,
   no glyph. It should be legible when looked at and silent when not.
 */
+/*
+ * How well a passage is held, as three segments rather than three words.
+ *
+ * Sized to sit on a title line without lifting it: 3px tall against an 11px label's cap height,
+ * which is why the segments are set with `vertical-align: middle` and no line box of their own.
+ * Steps are the three the copy makes — see `RECALL_STATE_LABELS`, where `fragile` and `forming`
+ * deliberately share a phrase and therefore share a fill.
+ */
 .proto-recall-mark {
+  display: inline-flex;
+  gap: 2px;
   margin-left: 8px;
-  color: var(--pds-text-tertiary);
-  font-weight: 400;
-  font-size: 11px;
-  line-height: 1.4;
-  white-space: nowrap;
   vertical-align: middle;
+}
+
+.proto-recall-mark__seg {
+  width: 9px;
+  height: 3px;
+  border-radius: 999px;
+  /* The unfilled ground. Faint enough that a learning row reads as one mark, not three. */
+  background: var(--pds-border-on-paper);
+}
+
+/* Learning: the first of three. */
+.proto-recall-mark[data-hold='learning'] .proto-recall-mark__seg:nth-child(1) {
+  background: var(--pds-accent);
+}
+
+/* Held: all three. */
+.proto-recall-mark[data-hold='held'] .proto-recall-mark__seg {
+  background: var(--pds-accent);
+}
+
+/*
+ * Slipped: two of three, in the warning tone.
+ *
+ * Not one — a passage that has slipped was held once, and drawing it level with something just
+ * being learned would be a lie about the reader's own history. Reduced-from-full is what
+ * actually happened, and the tone is what makes it an invitation rather than a demotion.
+ */
+.proto-recall-mark[data-hold='slipped'] .proto-recall-mark__seg:nth-child(-n + 2) {
+  background: var(--pds-warning);
 }
 
 /* Owner / You markers — subtle neutral pill (matches our chip language). */

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -1677,6 +1677,150 @@ html[data-shift-hints='1'] .proto-toolbar-orb-group {
   letter-spacing: 0.03em;
 }
 
+/*
+ * An icon block: a glyph over a word, in a pressable block.
+ *
+ * The word is not optional. This feature already removed a bare `+` for being an unexplained
+ * icon, and a glyph meaning "fewer of these" has no settled shape at all. Two surfaces share
+ * this control — Review's question feedback and the Activity row's overflow — because they are
+ * the same gesture at the same size, and a second copy would drift.
+ */
+
+.proto-icon-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--pds-space-1);
+  min-width: 72px;
+  padding: var(--pds-space-2) var(--pds-space-2) 7px;
+  border: 0.5px solid var(--pds-border-control);
+  border-radius: var(--pds-radius-input);
+  background: var(--pds-bg-control);
+  color: var(--pds-text-secondary);
+  font-family: var(--pds-font-body);
+  cursor: pointer;
+  transition:
+    background var(--pds-duration-press) ease,
+    border-color var(--pds-duration-press) ease,
+    color var(--pds-duration-press) ease,
+    transform var(--pds-duration-press) ease;
+}
+
+.proto-icon-block__glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 18px;
+}
+
+.proto-icon-block__label {
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+/* Room for a thumb, where there is a thumb. */
+@media (pointer: coarse) {
+  .proto-icon-block {
+    min-height: 56px;
+  }
+}
+
+.proto-icon-block:hover:not(:disabled) {
+  border-color: var(--pds-border-control-strong);
+  background: var(--pds-bg-control-hover);
+  color: var(--pds-text-primary);
+}
+
+.proto-icon-block:focus-visible {
+  outline: 2px solid var(--pds-accent);
+  outline-offset: 2px;
+}
+
+/* The block gives under the finger. The bounce belongs to the mark, below. */
+.proto-icon-block:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+/*
+ * Chosen: the filled accent button, the same one every other primary action in the app wears.
+ * A tinted outline was tried first and read as merely hovered — the whole point of this state is
+ * that the reader can see at a glance which way they voted, next to a sibling that is spent.
+ *
+ * The `!important` is not defensive clutter. `global.css` ends with
+ * `button * { color: var(--color-deep-grey) !important }`, which beats an inline `color: inherit`
+ * — and `Icon` renders its glyph inside exactly such a span, so the label went white while the
+ * thumb stayed grey. The descendant wildcard is what reaches it. Two other rules in these
+ * stylesheets carry the same fix for the same reason; `global.css:1756` names it outright.
+ */
+.proto-icon-block[aria-pressed='true'] {
+  border-color: transparent;
+  background: var(--pds-bg-accent-button, var(--pds-accent));
+  color: var(--pds-on-accent);
+  box-shadow: var(--pds-shadow-accent-button);
+}
+
+.proto-icon-block[aria-pressed='true'] .proto-icon-block__label,
+.proto-icon-block[aria-pressed='true'] .proto-icon-block__glyph,
+.proto-icon-block[aria-pressed='true'] .proto-icon-block__glyph * {
+  color: var(--pds-on-accent) !important;
+}
+
+.proto-icon-block[aria-pressed='true'] .proto-icon-block__glyph svg path {
+  fill: var(--pds-on-accent) !important;
+}
+
+/* Chosen and spent still reads as chosen: the fill stays, it just stops inviting a press. */
+.proto-icon-block[aria-pressed='true']:disabled {
+  opacity: 0.9;
+}
+
+.proto-icon-block:disabled {
+  cursor: default;
+}
+
+/* The way not taken, once the vote is in: legible, plainly spent. */
+.proto-icon-block:disabled:not([aria-pressed='true']) {
+  opacity: 0.5;
+}
+
+/*
+ * The same pop the onboarding check and Review's result mark already share — one gesture for
+ * "that registered", now in three places. See `@keyframes proto-onboarding-check-pop`. No
+ * `proto-motion.ts` constant is needed: nothing is held mounted waiting for this to finish, so
+ * there is no JS duration to keep in lockstep.
+ */
+@media (prefers-reduced-motion: no-preference) {
+  .proto-icon-block[aria-pressed='true'] .proto-icon-block__glyph {
+    animation: proto-onboarding-check-pop 0.42s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .proto-icon-block {
+    transition: none;
+  }
+
+  .proto-icon-block:active:not(:disabled) {
+    transform: none;
+  }
+}
+
+.proto-icon-block-row {
+  display: flex;
+  align-items: stretch;
+  gap: var(--pds-space-2);
+}
+
+/* A popover holding a row of blocks rather than a list of rows: it should be as wide as they are. */
+.proto-menu__popover--blocks {
+  min-width: 0;
+  width: max-content;
+  padding: 6px;
+}
+
 /* Trailing checkmark on an already-shared space row. */
 
 .proto-menu-item {
@@ -22762,6 +22906,39 @@ button.proto-feed-sheet__stat:hover {
   .proto-review-dock__actions {
     animation-delay: 120ms;
   }
+
+  /* Arrives with the way on, never ahead of it. */
+  .proto-review-dock__feedback {
+    animation-delay: 160ms;
+  }
+}
+
+/*
+ * Rating the question, last on the card and deliberately quiet.
+ *
+ * It is not what the reader came for, and a card that asked for a rating before it had finished
+ * giving the answer would have its priorities backwards. Sits after "Next one" so the way on is
+ * never below a poll, and before the slipping offer so the strongest thing stays last.
+ */
+.proto-review-dock__feedback {
+  display: grid;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.proto-review-dock__feedback-caption {
+  margin: 0;
+}
+
+.proto-review-dock__feedback-link {
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--pds-accent);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 @keyframes proto-review-enter {
@@ -23263,8 +23440,11 @@ button.proto-feed-sheet__stat:hover {
   background: var(--pds-accent-indicator);
 }
 
+/* Full strength, like the current dot beside it. At 40% this washed out to a pink that read as
+   a disabled dot rather than a go already spent — and the two dots are a pair, so they should
+   carry the same weight in their own colours. */
 .proto-review-dock__go[data-spent] {
-  background: color-mix(in oklab, var(--pds-destructive) 40%, transparent);
+  background: var(--pds-destructive);
 }
 
 /* A word of theirs that landed in the verse. Marked, not highlighted: this is a reading, not a

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -1681,9 +1681,12 @@ html[data-shift-hints='1'] .proto-toolbar-orb-group {
  * An icon block: a glyph over a word, in a pressable block.
  *
  * The word is not optional. This feature already removed a bare `+` for being an unexplained
- * icon, and a glyph meaning "fewer of these" has no settled shape at all. Two surfaces share
- * this control — Review's question feedback and the Activity row's overflow — because they are
- * the same gesture at the same size, and a second copy would drift.
+ * icon, and a glyph meaning "fewer of these" has no settled shape at all.
+ *
+ * Review's question feedback is the one thing wearing it. The Activity row's overflow menu was
+ * built this way too and put back to a list: a menu of actions reads better as rows you scan
+ * down than as a strip of blocks, and the full sentences ("Remove from Review") are the point
+ * there in a way a one-word label cannot carry.
  */
 
 .proto-icon-block {
@@ -1812,13 +1815,6 @@ html[data-shift-hints='1'] .proto-toolbar-orb-group {
   display: flex;
   align-items: stretch;
   gap: var(--pds-space-2);
-}
-
-/* A popover holding a row of blocks rather than a list of rows: it should be as wide as they are. */
-.proto-menu__popover--blocks {
-  min-width: 0;
-  width: max-content;
-  padding: 6px;
 }
 
 /* Trailing checkmark on an already-shared space row. */

--- a/src/components/react/Icon.tsx
+++ b/src/components/react/Icon.tsx
@@ -57,6 +57,8 @@ import circleCheckSvg from '@fortawesome/fontawesome-free/svgs/solid/circle-chec
 import ellipsisVerticalSvg from '@fortawesome/fontawesome-free/svgs/solid/ellipsis-vertical.svg?raw';
 import ellipsisSvg from '@fortawesome/fontawesome-free/svgs/solid/ellipsis.svg?raw';
 import thumbtackSvg from '@fortawesome/fontawesome-free/svgs/solid/thumbtack.svg?raw';
+import thumbsUpSvg from '@fortawesome/fontawesome-free/svgs/solid/thumbs-up.svg?raw';
+import thumbsDownSvg from '@fortawesome/fontawesome-free/svgs/solid/thumbs-down.svg?raw';
 import trashCanSvg from '@fortawesome/fontawesome-free/svgs/solid/trash-can.svg?raw';
 import penSvg from '@fortawesome/fontawesome-free/svgs/solid/pen.svg?raw';
 import linkSvg from '@fortawesome/fontawesome-free/svgs/solid/link.svg?raw';
@@ -233,6 +235,10 @@ const icons = {
   'ellipsis-vertical': svgRootCurrentColor(ellipsisVerticalSvg),
   ellipsis: svgRootCurrentColor(ellipsisSvg),
   thumbtack: svgRootCurrentColor(thumbtackSvg),
+  /* Review's question feedback. Solid, like every other glyph here — the pressed state is
+     carried by colour, not by swapping in the regular weight. */
+  'thumbs-up': withCurrentColor(thumbsUpSvg),
+  'thumbs-down': withCurrentColor(thumbsDownSvg),
   gear: withCurrentColor(gearSvg),
   key: withCurrentColor(keySvg),
   keyboard: withCurrentColor(keyboardSvg),

--- a/src/utils/__tests__/note-ladder-exercises.test.ts
+++ b/src/utils/__tests__/note-ladder-exercises.test.ts
@@ -20,6 +20,49 @@ const NONE: NoteMaterial = { canRecognize: false, canPassage: false, canConnect:
 const BODY =
   'God chose us before the foundation of the world, not because we had done anything to deserve it but because it pleased him to do so, and that is the whole ground of adoption.';
 
+describe('a preference can never be the reason a note goes unasked', () => {
+  /*
+   * The fall-forward invariant, at the one walk that used to break it. `verseRungFor` ends on
+   * `members[0]` whatever the material says; this walk returned null when `skip` removed the last
+   * buildable rung, and null means `dropUnaskable` takes the note out of the queue altogether.
+   * Turning "ask me this less" into "never show me this note" is the failure being pinned here.
+   */
+  it('still resolves when the only buildable rung is skipped', () => {
+    const onlyRecognize: NoteMaterial = {
+      canRecognize: true,
+      canPassage: false,
+      canConnect: false,
+      canAnnotation: false,
+      skip: new Set(['note.recognize' as const]),
+    };
+    expect(resolveNoteRung(0, onlyRecognize, 'seed')).toBe('note.recognize');
+  });
+
+  it('still resolves when every rung the note has is skipped', () => {
+    const allSkipped: NoteMaterial = {
+      ...ALL,
+      skip: new Set(['note.recognize', 'note.passage', 'note.connect', 'note.annotation'] as const),
+    };
+    expect(resolveNoteRung(0, allSkipped, 'seed')).not.toBeNull();
+  });
+
+  it('prefers an unskipped rung over the skipped one when the note has both', () => {
+    const both: NoteMaterial = {
+      canRecognize: true,
+      canPassage: true,
+      canConnect: false,
+      canAnnotation: false,
+      skip: new Set(['note.recognize' as const]),
+    };
+    expect(resolveNoteRung(0, both, 'seed')).toBe('note.passage');
+  });
+
+  it('still returns null when the note has no buildable rung at all', () => {
+    // No material is a different thing from a preference, and it must keep its old answer.
+    expect(resolveNoteRung(0, NONE, 'seed')).toBeNull();
+  });
+});
+
 describe('resolveNoteRung', () => {
   it('asks the rung the note has climbed to when it can answer it', () => {
     expect(resolveNoteRung(0, ALL)).toBe('note.recognize');

--- a/src/utils/__tests__/review-exercise-feedback.test.ts
+++ b/src/utils/__tests__/review-exercise-feedback.test.ts
@@ -78,6 +78,29 @@ describe('the settings offer', () => {
   });
 });
 
+describe('a vote on an item that was never asked', () => {
+  /*
+   * Found by testing the live endpoint. An item with no `lastRungKey` writes a row with a null
+   * rung, and the tally skips those — but the family lookup falls back to `opening`, so the
+   * response used to name a family the vote had not been filed under.
+   */
+  it('names no family, because it was counted toward none', () => {
+    expect(describeDislike(null, rows(BLANKS, ['a', 'b']))).toEqual({
+      family: null,
+      offerSettings: false,
+    });
+  });
+
+  it('cannot reach the threshold, however many are cast', () => {
+    const nulls: ReviewDislikeRow[] = ['a', 'b', 'c', 'd'].map((reviewItemId) => ({
+      reviewItemId,
+      rungKey: null,
+    }));
+    expect(describeDislike(null, nulls).offerSettings).toBe(false);
+    expect(quietedFamilies(nulls).size).toBe(0);
+  });
+});
+
 describe('the key set handed to the rung walk', () => {
   it('covers every rung in a quieted family, not just the one thumbed down', () => {
     const keys = quietedKeySet(rows(BLANKS, ['a', 'b', 'c']));

--- a/src/utils/__tests__/review-exercise-feedback.test.ts
+++ b/src/utils/__tests__/review-exercise-feedback.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  REVIEW_DISLIKE_THRESHOLD,
+  REVIEW_DISLIKE_WINDOW_DAYS,
+  describeDislike,
+  quietedFamilies,
+  quietedKeySet,
+  reviewDislikeWindowStart,
+  type ReviewDislikeRow,
+} from '@/utils/review-exercise-feedback';
+import { ALWAYS_ON_FAMILIES } from '@/utils/review-exercise-settings';
+import { reviewPromptKeysInFamily } from '@/utils/review-exercise-families';
+
+/** `verse.rebuild` is in the `blanks` family, which the reader can switch off in Settings. */
+const BLANKS = 'verse.rebuild';
+/** `note.recognize` is in `note`, which is always-on and therefore has no switch to offer. */
+const ALWAYS_ON = 'note.recognize';
+
+const rows = (rungKey: string, itemIds: string[]): ReviewDislikeRow[] =>
+  itemIds.map((reviewItemId) => ({ reviewItemId, rungKey }));
+
+describe('quieting a family takes three separate items', () => {
+  it('does not quiet a family thumbed down three times on one item', () => {
+    // One passage asked badly is a complaint about the passage, not about the kind of question.
+    expect(quietedFamilies(rows(BLANKS, ['a', 'a', 'a'])).size).toBe(0);
+  });
+
+  it('quiets a family once three distinct items have been thumbed down', () => {
+    expect([...quietedFamilies(rows(BLANKS, ['a', 'b', 'c']))]).toEqual(['blanks']);
+  });
+
+  it('holds off at one item short of the threshold', () => {
+    const short = rows(BLANKS, ['a', 'b']);
+    expect(short).toHaveLength(REVIEW_DISLIKE_THRESHOLD - 1);
+    expect(quietedFamilies(short).size).toBe(0);
+  });
+
+  it('ignores rows whose rung was never recorded', () => {
+    const nulls: ReviewDislikeRow[] = ['a', 'b', 'c'].map((reviewItemId) => ({
+      reviewItemId,
+      rungKey: null,
+    }));
+    expect(quietedFamilies(nulls).size).toBe(0);
+  });
+
+  it('counts each family separately rather than pooling dislikes', () => {
+    const mixed = [...rows(BLANKS, ['a', 'b']), ...rows('verse.locate', ['c'])];
+    expect(quietedFamilies(mixed).size).toBe(0);
+  });
+});
+
+describe('an always-on family', () => {
+  it('is still quieted, so the walk can prefer another member where one exists', () => {
+    // Quieting is a reason to walk past, and a note carrying citations can be asked `cited`
+    // instead. What it is never allowed to be is a reason to return nothing.
+    expect([...quietedFamilies(rows(ALWAYS_ON, ['a', 'b', 'c']))]).toEqual(['note']);
+  });
+
+  it('is never offered as a setting, because there is no switch to offer', () => {
+    const { family, offerSettings } = describeDislike(ALWAYS_ON, rows(ALWAYS_ON, ['a', 'b', 'c']));
+    expect(ALWAYS_ON_FAMILIES).toContain(family);
+    expect(offerSettings).toBe(false);
+  });
+});
+
+describe('the settings offer', () => {
+  it('is made on the vote that reaches the threshold', () => {
+    expect(describeDislike(BLANKS, rows(BLANKS, ['a', 'b', 'c'])).offerSettings).toBe(true);
+  });
+
+  it('is not repeated on the fourth', () => {
+    // An offer repeated is a nag, and the reader has already been shown where the switch is.
+    expect(describeDislike(BLANKS, rows(BLANKS, ['a', 'b', 'c', 'd'])).offerSettings).toBe(false);
+  });
+
+  it('is not made before the threshold', () => {
+    expect(describeDislike(BLANKS, rows(BLANKS, ['a', 'b'])).offerSettings).toBe(false);
+  });
+});
+
+describe('the key set handed to the rung walk', () => {
+  it('covers every rung in a quieted family, not just the one thumbed down', () => {
+    const keys = quietedKeySet(rows(BLANKS, ['a', 'b', 'c']));
+    for (const key of reviewPromptKeysInFamily('blanks')) expect(keys.has(key)).toBe(true);
+  });
+
+  it('is empty when nothing has reached the threshold', () => {
+    expect(quietedKeySet(rows(BLANKS, ['a'])).size).toBe(0);
+  });
+});
+
+describe('the window', () => {
+  it('opens exactly REVIEW_DISLIKE_WINDOW_DAYS before now', () => {
+    const now = new Date('2026-09-10T12:00:00.000Z');
+    const start = reviewDislikeWindowStart(now);
+    const days = (now.getTime() - start.getTime()) / (24 * 60 * 60 * 1000);
+    expect(days).toBe(REVIEW_DISLIKE_WINDOW_DAYS);
+  });
+});

--- a/src/utils/__tests__/review-item-kinds.test.ts
+++ b/src/utils/__tests__/review-item-kinds.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { REVIEW_MAX_ATTEMPTS, maxAttemptsFor } from '@/utils/review-item-kinds';
+import {
+  REVIEW_EVENT_ACTIONS,
+  REVIEW_MAX_ATTEMPTS,
+  REVIEW_OUTCOMES,
+  isReviewEventAction,
+  isReviewOutcome,
+  maxAttemptsFor,
+} from '@/utils/review-item-kinds';
 import { REVIEW_PROMPT_KEYS } from '@/utils/review-prompts';
 
 describe('how many goes a question gets', () => {
@@ -21,5 +28,38 @@ describe('how many goes a question gets', () => {
       expect(maxAttemptsFor(key)).toBeGreaterThanOrEqual(2);
     }
     expect(maxAttemptsFor(null)).toBe(3);
+  });
+});
+
+describe('a rating of the question is not an answer', () => {
+  /*
+   * `liked` and `disliked` are about the exercise the app chose, not about how the recall went.
+   * They live in the same log, so everything that reads the log for what a reader *did* must go
+   * through the narrower `REVIEW_OUTCOMES` — which is how `study-feed.ts` reads it.
+   */
+  it('carries the two feedback actions', () => {
+    expect(REVIEW_EVENT_ACTIONS).toContain('liked');
+    expect(REVIEW_EVENT_ACTIONS).toContain('disliked');
+    expect(isReviewEventAction('disliked')).toBe(true);
+  });
+
+  it('keeps them out of the outcomes', () => {
+    expect(REVIEW_OUTCOMES).not.toContain('liked');
+    expect(REVIEW_OUTCOMES).not.toContain('disliked');
+    expect(isReviewOutcome('disliked')).toBe(false);
+  });
+
+  it('appends them rather than inserting, so stored rows keep their meaning', () => {
+    // The list's order is its identity for anything that reads it positionally.
+    expect(REVIEW_EVENT_ACTIONS.slice(0, 8)).toEqual([
+      'shown',
+      'recalled',
+      'almost',
+      'revealed',
+      'deferred',
+      'paused',
+      'resumed',
+      'archived',
+    ]);
   });
 });

--- a/src/utils/note-ladder-exercises.ts
+++ b/src/utils/note-ladder-exercises.ts
@@ -68,6 +68,9 @@ export function resolveNoteRung(
     'note.connect': material.canConnect,
     'note.annotation': material.canAnnotation,
   } as Record<ReviewPromptKey, boolean>;
+  /* What the note could be asked before any preference is applied — the floor for the second
+     pass below, so a skip can never be the reason a note goes unasked. */
+  const buildable: Record<ReviewPromptKey, boolean> = { ...can };
   // A rung the reader turned off is walked past exactly as one with no material is.
   if (material.skip) {
     for (const key of NOTE_LADDER) if (material.skip.has(key)) can[key] = false;
@@ -85,6 +88,19 @@ export function resolveNoteRung(
   for (let i = 0; i < NOTE_LADDER.length; i++) {
     const key = NOTE_LADDER[(start + i) % NOTE_LADDER.length];
     if (can[key]) return key;
+  }
+  /*
+   * Second pass, ignoring what the reader asked not to be given.
+   *
+   * Skipping is one more reason to walk past a member, never a reason to return nothing — the
+   * rule `review-exercise-settings.ts` states and `verseRungFor` keeps by falling forward to
+   * `members[0]`. This walk had no such floor: a note whose only buildable rung was skipped
+   * resolved to null, and null means `dropUnaskable` removes the note from the queue entirely.
+   * Turning a preference into a disappearance is the one thing a preference must not do.
+   */
+  for (let i = 0; i < NOTE_LADDER.length; i++) {
+    const key = NOTE_LADDER[(start + i) % NOTE_LADDER.length];
+    if (buildable[key]) return key;
   }
   return null;
 }

--- a/src/utils/review-exercise-feedback.ts
+++ b/src/utils/review-exercise-feedback.ts
@@ -129,11 +129,18 @@ export function mayOfferExerciseSetting(id: ReviewExerciseFamilyId): boolean {
  *
  * `offerSettings` is true only on the vote that reaches the threshold exactly — a fourth and a
  * fifth dislike say "Noted." like the rest, because an offer repeated is a nag.
+ *
+ * **A vote with no rung names no family.** An item that has never been answered has no
+ * `lastRungKey`, and `reviewExerciseFamilyId` would helpfully fall back to `opening` — but the
+ * tally skips null-rung rows, so the vote counts toward nothing. Reporting a family it was not
+ * filed under is the endpoint describing work it did not do. The row is still logged; it simply
+ * has nothing to say about which exercise it was about.
  */
 export function describeDislike(
   rungKey: string | null,
   rowsIncludingThisVote: readonly ReviewDislikeRow[],
-): { family: ReviewExerciseFamilyId; offerSettings: boolean } {
+): { family: ReviewExerciseFamilyId | null; offerSettings: boolean } {
+  if (!rungKey) return { family: null, offerSettings: false };
   const family = reviewExerciseFamilyId(rungKey);
   const items = dislikedItemsByFamily(rowsIncludingThisVote).get(family);
   const reachedNow = items?.size === REVIEW_DISLIKE_THRESHOLD;

--- a/src/utils/review-exercise-feedback.ts
+++ b/src/utils/review-exercise-feedback.ts
@@ -1,0 +1,141 @@
+/**
+ * What the reader thought of a question, turned into a reason to ask a different one.
+ *
+ * Review's three answers describe a memory — "I recalled it", "I almost had it". None of them
+ * says anything about the *question*, so a rung that keeps landing badly had no way to be
+ * reported except out loud. This is that channel: a thumbs-down means "fewer questions like
+ * this", counted per exercise family, because the family is the unit the reader already has a
+ * name for and the unit the settings page already switches.
+ *
+ * **A dislike is a reason to walk past a member, never a reason to return nothing.** The set
+ * this module derives joins the reader's Settings skip-list in `material.skip`, so it enters the
+ * seeded family walk by the same door and inherits the same fall-forward rule: if every member
+ * of a step is quieted, the step still resolves — `verseRungFor` falls to `members[0]`, and
+ * `resolveNoteRung` takes its second pass. Nothing here can make a question impossible, and
+ * nothing here can cost the queue a row.
+ *
+ * **Nothing here is stored as a preference.** The tally is derived from the event log inside a
+ * rolling window, so the effect is exactly as old as the dislikes that earn it and lapses on its
+ * own. A dislike is an observation; only the reader's explicit switch is a preference. Writing
+ * this to `reviewExerciseSettings` would be an allow-list by the back door — a setting they
+ * never chose and cannot see — which is the thing `review-exercise-settings.ts` forbids.
+ *
+ * Pure and client-safe: the server derives the set when it resolves a rung, and the SPA uses the
+ * same threshold to decide whether it has earned the right to point at Settings.
+ */
+
+import type { ReviewPromptKey } from '@/utils/review-prompts';
+import {
+  reviewExerciseFamilyId,
+  reviewPromptKeysInFamily,
+  type ReviewExerciseFamilyId,
+} from '@/utils/review-exercise-families';
+import { familyIsAlwaysOn } from '@/utils/review-exercise-settings';
+
+/**
+ * How many times the reader must say it, on how many different items, before the engine leans away.
+ *
+ * Counted over **distinct review items**, which is the whole rule. One dislike is a mistap or a
+ * bad verse. Two can still be one passage asked the same way twice, because a family comes round
+ * again on the maintenance cycle. Three separate items is the first count that cannot be one
+ * passage's bad luck, and it is the difference between "I dislike this exercise" and "I dislike
+ * this verse being asked this way". It is also the number this feature already speaks in —
+ * `REVIEW_MAX_ATTEMPTS` is 3.
+ */
+export const REVIEW_DISLIKE_THRESHOLD = 3;
+
+/**
+ * How far back the count reaches, and therefore how long the effect lasts.
+ *
+ * One number does both jobs: there is nothing stored and nothing to expire, so thirty days after
+ * the third-oldest qualifying dislike the family simply comes back. Intervals run to a fortnight
+ * and beyond once a verse is holding, so thirty days is long enough for three dislikes to be
+ * reachable without bingeing, and short enough that a preference expressed a season ago does not
+ * silently govern today.
+ */
+export const REVIEW_DISLIKE_WINDOW_DAYS = 30;
+
+/** One `disliked` row, reduced to the two things the tally needs. */
+export interface ReviewDislikeRow {
+  reviewItemId: string;
+  rungKey: string | null;
+}
+
+/** The instant the window opens, given "now". */
+export function reviewDislikeWindowStart(now: Date): Date {
+  return new Date(now.getTime() - REVIEW_DISLIKE_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+}
+
+/** How many distinct items the reader has thumbed down, per family. */
+export function dislikedItemsByFamily(
+  rows: readonly ReviewDislikeRow[],
+): Map<ReviewExerciseFamilyId, Set<string>> {
+  const byFamily = new Map<ReviewExerciseFamilyId, Set<string>>();
+  for (const row of rows) {
+    if (!row.rungKey) continue;
+    const family = reviewExerciseFamilyId(row.rungKey);
+    let items = byFamily.get(family);
+    if (!items) {
+      items = new Set<string>();
+      byFamily.set(family, items);
+    }
+    items.add(row.reviewItemId);
+  }
+  return byFamily;
+}
+
+/**
+ * Families the reader has told us, on three separate items, they would rather have less of.
+ *
+ * Always-on families are included on purpose. They cannot be switched off in Settings because
+ * they are the last resort on their step, but "cannot be switched off" is not the same as
+ * "cannot be leaned away from": a note carrying citations or links can be asked `cited` or
+ * `linked` instead of `note`, and the walk will prefer those once `note` is quieted. Where there
+ * is genuinely nothing else, the fall-forward hands it back anyway — which is why quieting one
+ * is safe to allow and dishonest to *promise*. See `mayOfferExerciseSetting`.
+ */
+export function quietedFamilies(
+  rows: readonly ReviewDislikeRow[],
+): ReadonlySet<ReviewExerciseFamilyId> {
+  const quieted = new Set<ReviewExerciseFamilyId>();
+  for (const [family, items] of dislikedItemsByFamily(rows)) {
+    if (items.size >= REVIEW_DISLIKE_THRESHOLD) quieted.add(family);
+  }
+  return quieted;
+}
+
+/** The prompt keys those families cover — the shape the rung walk consumes. */
+export function quietedKeySet(rows: readonly ReviewDislikeRow[]): ReadonlySet<ReviewPromptKey> {
+  const keys = new Set<ReviewPromptKey>();
+  for (const family of quietedFamilies(rows)) {
+    for (const key of reviewPromptKeysInFamily(family)) keys.add(key);
+  }
+  return keys;
+}
+
+/**
+ * Whether the third dislike may point the reader at the Settings toggle.
+ *
+ * False for the always-on families, because there is no switch there to offer. Naming one would
+ * be the lie `review-exercise-settings.ts` warns about — a row promising something the engine is
+ * entitled to ignore. The engine still leans away where it can; it just does not say so.
+ */
+export function mayOfferExerciseSetting(id: ReviewExerciseFamilyId): boolean {
+  return !familyIsAlwaysOn(id);
+}
+
+/**
+ * What one vote means, given the log as it stands *after* the vote is written.
+ *
+ * `offerSettings` is true only on the vote that reaches the threshold exactly — a fourth and a
+ * fifth dislike say "Noted." like the rest, because an offer repeated is a nag.
+ */
+export function describeDislike(
+  rungKey: string | null,
+  rowsIncludingThisVote: readonly ReviewDislikeRow[],
+): { family: ReviewExerciseFamilyId; offerSettings: boolean } {
+  const family = reviewExerciseFamilyId(rungKey);
+  const items = dislikedItemsByFamily(rowsIncludingThisVote).get(family);
+  const reachedNow = items?.size === REVIEW_DISLIKE_THRESHOLD;
+  return { family, offerSettings: Boolean(reachedNow) && mayOfferExerciseSetting(family) };
+}

--- a/src/utils/review-item-kinds.ts
+++ b/src/utils/review-item-kinds.ts
@@ -41,6 +41,14 @@ export const REVIEW_EVENT_ACTIONS = [
   'paused',
   'resumed',
   'archived',
+  /*
+   * What the reader thought of the question, as distinct from how the recall went. Appended
+   * after the eight above, because this list's order is its identity on rows already written.
+   * Nothing that reads the log for scheduling should count these: `study-feed.ts` filters on
+   * `REVIEW_OUTCOMES`, which is the narrower list on purpose.
+   */
+  'liked',
+  'disliked',
 ] as const;
 
 export type ReviewEventAction = (typeof REVIEW_EVENT_ACTIONS)[number];


### PR DESCRIPTION
## Summary

Adds a thumbs up / thumbs down control for review questions, feeding a heuristic engine that leans away from disliked exercise families — plus three related fixes found and verified along the way.

### Review question feedback
- Thumbs up / thumbs down as a shared "icon block" control (glyph over a word) on the review result card
- Thumbs-down joins the same rung-exclusion set the Review Exercises settings page already writes to — no change needed to the seeded family walk, and the fall-forward invariant (a question can never become impossible) holds by construction
- Threshold: 3 dislikes on 3 *distinct* items within a rolling 30 days; the effect lapses with the window, so nothing implicit is ever stored as a permanent preference
- Always-on families (e.g. `note`) can still be leaned away from when the note has other material, but the Settings offer is never shown for them — verified live: quieting `note.recognize` moved answered items to `note.passage` and reverted cleanly once the test rows were removed
- Fixed a latent bug this feature would have made reachable: `resolveNoteRung` returned `null` when skip removed the last buildable rung, which silently dropped the note from the queue
- Fixed a bug found by testing the live endpoint: a vote on a never-answered item (no `lastRungKey`) reported a family it wasn't actually filed under

### Activity space scopes
Picking a space in Activity's "whose study to show" filter did nothing visible. Three independent causes:
- A de-dup guard (`ne(Notes.userId, ...)`) that exists to stop double-counting was firing even when there was nothing to de-duplicate against, deleting the reader's own notes from their own space's trail
- Picking a space reset the day index to today, and a room's last note is rarely today
- Home's personal sections (greeting, Continue, Review, onboarding) kept rendering under the space's name

Verified against the live database: Family 0→3 items, Young Adults 0→1, Youth 0→1, with `all`/`home` unchanged at 40 (confirming no double-count). A wholly-empty space now shows a proper empty state instead of one grey line.

### Also
- Import-row dismissal on Home is now account-synced (was device-local `localStorage`) — rides the existing `onboardingState` sync rails, no new column
- The recall-state label ("You're learning this") is now a 3-segment visual mark instead of repeated text down the row
- Bundle budget re-baselined to what this branch actually ships

## Verification
- 6,142 tests passing after merging `origin/main` in and re-running the full suite
- `design:check`, `check:color-tokens`, `perf:check` all green post-merge
- `ReviewEvents.rungKey` migration applied to production directly (column + `CREATE INDEX CONCURRENTLY`, avoiding a write-blocking lock); confirmed `index valid: true`
- Feedback endpoint tested against the live database end-to-end, then fully rolled back (0 rows before, 0 after)

## Migration note
`ReviewEvents.rungKey` is **already applied to production** — this PR's DDL (in `server/scripts/add-review-challenges-schema.ts`) is idempotent (`ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`) and will no-op on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)