### PR TITLE
fix(review): let a verse open on the rung its own mark answers

### DIFF
--- a/Changelog/3.9.14.md
+++ b/Changelog/3.9.14.md
@@ -1,0 +1,7 @@
+# Version 3.9.14
+
+**Release Date**: September 12, 2026
+
+## Fixes
+
+- Let a verse open on the rung its own mark answers

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.9.13
+**Version:** 3.9.14
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.9.13",
+  "version": "3.9.14",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-9-13';
+const CACHE_NAME = 'harvous-cache-v3-9-14';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/server/utils/__tests__/review-opening-stagger.test.ts
+++ b/server/utils/__tests__/review-opening-stagger.test.ts
@@ -25,7 +25,9 @@ describe('the opening stagger', () => {
     for (const steps of [VERSE_OPENING_STEPS, CHAPTER_OPENING_STEPS, NOTE_OPENING_STEPS]) {
       expect(steps.length).toBeGreaterThan(1);
     }
-    expect([0, 1, 2, 3].map((n) => openingLadderStep('verse', n))).toEqual([...VERSE_OPENING_STEPS]);
+    expect(
+      VERSE_OPENING_STEPS.map((_, n) => openingLadderStep('verse', n)),
+    ).toEqual([...VERSE_OPENING_STEPS]);
     expect([0, 1].map((n) => openingLadderStep('chapter', n))).toEqual([...CHAPTER_OPENING_STEPS]);
     // And wraps rather than falling off the end.
     expect(openingLadderStep('verse', VERSE_OPENING_STEPS.length)).toBe(VERSE_OPENING_STEPS[0]);
@@ -57,17 +59,32 @@ describe('the opening stagger', () => {
   });
 
   it('spreads a queue across the rotation once the counter persists', () => {
-    // What a reader accumulating verse items one at a time now sees, over twelve refills.
-    const opened = Array.from({ length: 12 }, (_, existing) => openingLadderStep('verse', existing));
+    // What a reader accumulating verse items one at a time now sees, over three full rotations.
+    // Counted in rotations rather than a round number of refills, so adding an opening rung
+    // does not turn an even split into a fractional expectation.
+    const rotations = 3;
+    const refills = VERSE_OPENING_STEPS.length * rotations;
+    const opened = Array.from({ length: refills }, (_, existing) =>
+      openingLadderStep('verse', existing),
+    );
     expect(new Set(opened).size).toBe(VERSE_OPENING_STEPS.length);
     // And no single rung takes more than its share.
     for (const step of VERSE_OPENING_STEPS) {
-      expect(opened.filter((s) => s === step).length).toBe(12 / VERSE_OPENING_STEPS.length);
+      expect(opened.filter((s) => s === step).length).toBe(rotations);
     }
   });
 
   it('never opens on a rung that is how a verse is kept rather than how it is met', () => {
-    // recall (2), locate (6) and the altered word (7) are maintenance, never a first asking.
-    for (const barred of [2, 6, 7]) expect(VERSE_OPENING_STEPS).not.toContain(barred);
+    /*
+     * recall (2) and the altered word (7) are maintenance, never a first asking: both ask the
+     * reader to produce a verse they have not yet been given a reason to hold.
+     *
+     * locate (6) used to be barred with them and no longer is. Its family carries `verse.marked`,
+     * which asks the reader to find the words they highlighted themselves — the one rung where a
+     * first asking is the *best* time to ask, because the mark is what made the verse an item.
+     * See `VERSE_OPENING_STEPS` for the trade that buys, which is `verse.locate` on an unmarked
+     * verse.
+     */
+    for (const barred of [2, 7]) expect(VERSE_OPENING_STEPS).not.toContain(barred);
   });
 });

--- a/src/utils/__tests__/review-prompts.test.ts
+++ b/src/utils/__tests__/review-prompts.test.ts
@@ -566,13 +566,15 @@ describe('reviewSeed', () => {
 });
 
 describe('openingLadderStep', () => {
-  it('staggers new verses across recognize, rebuild, next and context', () => {
-    expect(VERSE_OPENING_STEPS).toEqual([0, 1, 3, 4]);
-    expect([0, 1, 2, 3].map((n) => openingLadderStep('verse', n))).toEqual([0, 1, 3, 4]);
-    expect(openingLadderStep('verse', 4)).toBe(0);
-    // Never recall (2), locate (6) or altered (7) on a first asking.
+  it('staggers new verses across recognize, rebuild, next, context and locate', () => {
+    expect(VERSE_OPENING_STEPS).toEqual([0, 1, 3, 4, 6]);
+    expect([0, 1, 2, 3, 4].map((n) => openingLadderStep('verse', n))).toEqual([0, 1, 3, 4, 6]);
+    expect(openingLadderStep('verse', 5)).toBe(0);
+    // Still never recall (2) or altered (7) on a first asking: both ask the reader to produce
+    // what they have not been given a reason to hold. Step 6 is in because `verse.marked` asks
+    // them to find their own highlight, which is not a demand on memory.
     expect(VERSE_OPENING_STEPS).not.toContain(2);
-    expect(VERSE_OPENING_STEPS).not.toContain(6);
+    expect(VERSE_OPENING_STEPS).not.toContain(7);
   });
 
   it('walks new notes across recognize, passage, connect, annotation', () => {

--- a/src/utils/review-prompts.ts
+++ b/src/utils/review-prompts.ts
@@ -336,13 +336,29 @@ export const VERSE_LADDER_MAX_STEP = VERSE_LADDER.length - 1;
  * First-sitting rungs the engine may open on, so a handful of new verses is not five
  * "pick how it begins".
  *
- * Recognize, rebuild (blanks), next/before, then the context step — what the verse is connected
- * to, by the reader or by the index. Never recall or locate on a first asking: those are how a
- * verse is kept, not how it is met.
+ * Recognize, rebuild (blanks), next/before, the context step — what the verse is connected to,
+ * by the reader or by the index — and the locate step, where the reader's own mark can be the
+ * answer.
+ *
+ * **Step 6 is here on purpose, and it argues with the rest of the list.** The rule used to read
+ * "never recall or locate on a first asking: those are how a verse is kept, not how it is met",
+ * and for `verse.recall` (2) and the altered word (7) it still holds — both ask the reader to
+ * produce something they have not yet been given a reason to hold. Step 6 is different because
+ * of who is in its family. `verse.marked` asks the reader to find the words *they* highlighted,
+ * which is not a demand on memory at all, and it was unreachable until an item had been recalled
+ * cleanly twice from step 4 — so the readers most likely to want it, the ones with years of
+ * marked-up Scripture, were the ones least likely ever to reach it.
+ *
+ * The cost is `verse.locate`, the family's default: a verse with nothing marked that opens here
+ * is asked which passage the line is from on a first asking, which is precisely what the old
+ * rule barred. The draw softens it rather than removing it — once the reader's own reference
+ * pool is deep enough to bar `verse.book` (see `LOCATE_MIN_RIVALS`), a verse carrying a marked
+ * span reaches `verse.marked` on two of the three seeds, so the verses that open here with
+ * something to find are usually asked to find it.
  *
  * Notes walk the four rungs so a handful of new notes is not five "pick the note this is from".
  */
-export const VERSE_OPENING_STEPS = [0, 1, 3, 4] as const;
+export const VERSE_OPENING_STEPS = [0, 1, 3, 4, 6] as const;
 export const CHAPTER_OPENING_STEPS = [0, 1] as const;
 export const NOTE_OPENING_STEPS = [0, 1, 2, 3] as const;
 


### PR DESCRIPTION
## What

`verse.marked` — "find the words you highlighted in this verse" — sat on ladder step 6, which was
reachable only after two clean recalls from step 4. It could never be a first asking, so the
readers with the most marked-up Scripture were the least likely ever to be asked their own
highlight back to them.

Adds step 6 to `VERSE_OPENING_STEPS`: `[0, 1, 3, 4]` → `[0, 1, 3, 4, 6]`.

## The trade

Step 6's family default is `verse.locate` ("where is this line from?"), which the old rule
explicitly barred from a first asking. A verse with nothing marked that opens on step 6 now gets
asked that. The seeded draw softens it — once the reader's own reference pool is deep enough to
bar `verse.book` (`LOCATE_MIN_RIVALS`), a verse carrying a marked span reaches `verse.marked` on
two of three seeds — but it's a real cost, written out in the docblock rather than glossed over.

Side effect: `otherOpeningStep` (the stalled-item step-back) also draws from this list, so a
stuck item can now be routed sideways to step 6 as an escape.

## Also in this session (not in this diff)

Ran `study-bible:backfill --reset --production` for the three accounts under discussion — it had
never been run against production, so ~104 of 137 accounts had zero rows in `UserNodeStates` and
were invisible to the review engine regardless of how much they'd studied. That's a data
operation against the live DB, not a code change, so there's nothing here to review for it — noted
for the record since it's what prompted this fix.

## Verification

- `npx vitest run` — 570 files, 6086 tests passed
- `tsc --noEmit` clean on touched files
- Re-ran review-scoped suites after rebasing onto `main` (which had merged #118 in the meantime,
  touching `review-service.ts` / `review-item-kinds.ts` but not `review-prompts.ts`) — still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
