### PR TITLE
Review: the question you come back to is the next one, not the last one

### DIFF
--- a/server/routes/__tests__/review-routes.test.ts
+++ b/server/routes/__tests__/review-routes.test.ts
@@ -211,7 +211,13 @@ describe('the inbox stays calm', () => {
   });
 
   it('uses no guilt language anywhere in the feature', () => {
-    for (const text of [review(), service()]) {
+    /*
+     * The copy file is in here too. The vocabulary rule it opens with is the reason it exists,
+     * and it is the one file in the feature where a careless string is shipped verbatim to a
+     * reader rather than being shaped by a route first.
+     */
+    const copy = withoutComments(source('spa/src/pages/prototype/proto-review-copy.ts'));
+    for (const text of [review(), service(), copy]) {
       expect(text).not.toMatch(/overdue|behind schedule|you missed|streak broken/i);
     }
   });

--- a/spa/src/hooks/mutations/useReviewMutations.ts
+++ b/spa/src/hooks/mutations/useReviewMutations.ts
@@ -24,6 +24,8 @@ import {
   REVIEW_REMOVE_FAILED_TOAST,
   REVIEW_RESUMED_TOAST,
   REVIEW_FEEDBACK_FAILED_TOAST,
+  REVIEW_OUTCOME_FAILED_TOAST,
+  REVIEW_STEP_BACK_FAILED_TOAST,
 } from '../../pages/prototype/proto-review-copy';
 import type { ReviewItemKind, ReviewItemStatus, ReviewOutcome } from '@/utils/review-item-kinds';
 
@@ -100,8 +102,17 @@ export function useReviewOutcome() {
       }
       return { previous };
     },
-    onError: (_err, _input, context) => {
+    /*
+     * Put the queue back, and say so.
+     *
+     * The rollback was here from the start and the telling was not, which made this the quietest
+     * failure in the feature: the question stays on screen either way, so a lost answer looked
+     * exactly like a tap that had not registered. The card holds its question (see the dock) so
+     * the reader can simply answer again.
+     */
+    onError: (error, _input, context) => {
       if (context?.previous) queryClient.setQueryData(reviewSessionQueryKey, context.previous);
+      toastError(error, REVIEW_OUTCOME_FAILED_TOAST, { scope: 'review-outcome' });
     },
     onSuccess: (data, _input, context) => {
       if (data.finalized === false && context?.previous) {
@@ -168,6 +179,9 @@ export function useStepBackReview() {
       api.post<{ item: ReviewItemView }>(`/api/review/items/${encodeURIComponent(itemId)}/step-back`, {}),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: reviewQueryKey });
+    },
+    onError: (error) => {
+      toastError(error, REVIEW_STEP_BACK_FAILED_TOAST, { scope: 'review-step-back' });
     },
   });
 }

--- a/spa/src/hooks/queries/useReview.ts
+++ b/spa/src/hooks/queries/useReview.ts
@@ -99,6 +99,18 @@ export const reviewSessionQueryKey = ['review', 'session'] as const;
 export const reviewItemsQueryKey = (status?: ReviewItemStatus, view: 'full' | 'summary' = 'full') =>
   ['review', 'items', status ?? 'all', view] as const;
 
+/**
+ * One key for a reveal, built in one place.
+ *
+ * It was written out by hand at three sites and two of them were a different key: the prefetch
+ * and the session's `firstReveal` seeding wrote three elements, while `useReviewReveal` read four
+ * — the translation the rung was asked in, defaulting to `'default'`. So neither warm path ever
+ * hit the cache the card reads, and every graded question paid a full round trip and showed its
+ * loading dots with the answer already sitting in the query client under a neighbouring key.
+ */
+export const reviewRevealQueryKey = (itemId: string | null | undefined, translation?: string) =>
+  ['review', 'reveal', itemId ?? 'none', translation ?? 'default'] as const;
+
 function useReviewAccess(): boolean {
   const { has } = useHasFeature('review');
   const { isGuest } = useHarvousIdentity();
@@ -194,7 +206,7 @@ export function useReviewSession(options?: { enabled?: boolean }) {
         nextDueAt?: string | null;
       }>('/api/review/session');
       if (data.firstReveal && data.items[0]) {
-        queryClient.setQueryData(['review', 'reveal', data.items[0].id], data.firstReveal);
+        queryClient.setQueryData(reviewRevealQueryKey(data.items[0].id), data.firstReveal);
       }
       return data;
     },
@@ -210,7 +222,7 @@ export function usePrefetchReviewReveal(itemId: string | null | undefined) {
   useEffect(() => {
     if (!itemId || !authReady || !access) return;
     void queryClient.prefetchQuery({
-      queryKey: ['review', 'reveal', itemId] as const,
+      queryKey: reviewRevealQueryKey(itemId),
       queryFn: () =>
         api.get<ReviewRevealResponse>(`/api/review/items/${encodeURIComponent(itemId)}/reveal`),
       staleTime: 5 * 60_000,
@@ -224,7 +236,7 @@ export function useReviewReveal(itemId: string | null, options?: { enabled?: boo
   const featureEnabled = authReady && access;
   const translation = options?.translation;
   return useQuery({
-    queryKey: ['review', 'reveal', itemId ?? 'none', translation ?? 'default'] as const,
+    queryKey: reviewRevealQueryKey(itemId, translation),
     enabled: featureEnabled && Boolean(itemId) && options?.enabled === true,
     queryFn: () =>
       api.get<ReviewRevealResponse>(

--- a/spa/src/layouts/SimplifiedPrototypeLayout.tsx
+++ b/spa/src/layouts/SimplifiedPrototypeLayout.tsx
@@ -794,8 +794,26 @@ function PrototypeAuthenticatedChrome({ userId, isGuest = false }: { userId?: st
               /* Carried so the result card can offer question feedback. Without it the thumbs
                  are absent for every note answered from the stack edge, which is most of them. */
               itemId: review.itemId,
+              /*
+               * And the slipping offer, which this path dropped.
+               *
+               * A note missed four times running is exactly the case "Make it easier" exists
+               * for, and notes are what the stack edge answers — so the one rung that most
+               * needed the offer was the one rung that could never receive it.
+               */
+              leech: data.leech === true,
+              stalled: data.stalled === true,
               at: Date.now(),
             }),
+          /*
+           * The stack is gone and the answer did not land, so put the dock back on the item.
+           *
+           * `clearPaperStack` runs unconditionally below — it is what advances the queue — and
+           * without this a failed answer left the reader with no stack, no result and no
+           * question: the one place in Review where a lost request could lose the item too.
+           * The toast comes from the mutation.
+           */
+          onError: () => setReviewDockItem(review.itemId),
         },
       );
       // The dock goes back to "whatever is next"; an answered item is rescheduled rather than

--- a/spa/src/pages/prototype/PrototypeReviewDock.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewDock.tsx
@@ -40,7 +40,12 @@ import { prototypeHref } from '@/lib/prototype-path';
 import Icon from '@/components/react/Icon';
 import ProtoLoadingDots from './ProtoLoadingDots';
 import StudyDockCardShell from '@/components/react/StudyDockCardShell';
-import { canJudgeRecall, resolveReviewDockItem } from '@/utils/review-dock-state';
+import {
+  canJudgeRecall,
+  resolveReviewDockItem,
+  shouldReleaseHeldItem,
+  sittingIsStale,
+} from '@/utils/review-dock-state';
 import { reviewRowSubtitle } from '@/utils/review-row-subtitle';
 import { noteParamSlug } from './proto-route-slugs';
 import { prototypeNoteRouteTo } from '@/lib/prototype-path';
@@ -76,6 +81,8 @@ import {
   REVIEW_ALMOST_COPY,
   REVIEW_ATTEMPT_PLACEHOLDER,
   REVIEW_LOADING_LABEL,
+  REVIEW_REVEAL_FAILED_COPY,
+  REVIEW_REVEAL_RETRY_COPY,
   REVIEW_RECALLED_COPY,
   REVIEW_REVEALED_ACK_COPY,
   REVIEW_CHECK_COPY,
@@ -506,6 +513,56 @@ export default function PrototypeReviewDock() {
     setVerdict(null);
     setAttemptsTotal(null);
   }, [item?.id]);
+
+  /*
+   * Let go of the pinned question once it is no longer the one being looked at.
+   *
+   * The pin was cleared in exactly one place — the "Next one" button — so every other way out
+   * of a result kept it: leaving from the result card and tapping a different row rendered the
+   * question that had just been answered while the pointer named the new one, and answering it
+   * again re-recorded an outcome against an item that was already rescheduled. The rule is
+   * `shouldReleaseHeldItem`, kept pure next door because the interesting cases are timing ones.
+   */
+  useEffect(() => {
+    if (
+      shouldReleaseHeldItem({
+        heldId: heldItem?.id ?? null,
+        requestedId: reviewDock?.itemId,
+        hasResult: Boolean(lastResult),
+        hasVerdict: Boolean(verdict),
+        pending: outcome.isPending,
+        dockOpen: open,
+      })
+    ) {
+      setHeldItem(null);
+    }
+  }, [heldItem?.id, reviewDock?.itemId, lastResult, verdict, outcome.isPending, open]);
+
+  /*
+   * A sitting belongs to the open dock, not to the tab.
+   *
+   * The count is of what the reader did just now; carrying it across a close and a reopen would
+   * make the closing line describe two sittings as one.
+   */
+  useEffect(() => {
+    if (!open) setSitting({ answered: 0, holding: 0 });
+  }, [open]);
+
+  /*
+   * A sitting that has been sitting there is re-composed as the dock opens.
+   *
+   * `useReviewSession` is `staleTime: Infinity` so the queue cannot reshuffle under someone
+   * mid-answer, which is right for the minutes a sitting lasts and wrong for the hours a tab
+   * stays open: the morning's dock was serving yesterday's questions against yesterday's clock.
+   * Checked only on the open edge, never while the dock is in use, so the freeze still holds
+   * exactly where it was written to.
+   */
+  const wasOpen = useRef(false);
+  useEffect(() => {
+    const opening = open && !wasOpen.current;
+    wasOpen.current = open;
+    if (opening && sittingIsStale(sessionQuery.dataUpdatedAt)) void sessionQuery.refetch();
+  }, [open, sessionQuery]);
 
   /*
    * Keep the dock's pointer on an item that still exists.
@@ -1468,6 +1525,28 @@ export default function PrototypeReviewDock() {
                 onClick={() => answer('almost', { text: attempt, promptKey: item.promptKey })}
               >
                 {REVIEW_CHECK_COPY}
+              </button>
+            </div>
+          </>
+        ) : isGradedRung && reveal.isError ? (
+          /*
+           * The reveal *is* the question on a graded rung, so a failed one is a question with no
+           * body. Without this the chain fell past every exercise branch to the free-text
+           * fallback — the same wrong-exercise flash the loading branch below was written to
+           * prevent, except permanent, and with a "check the verse" button that would record an
+           * answer to a question the reader was never shown.
+           */
+          <>
+            <p className="proto-review-dock__prompt">{item.prompt}</p>
+            {subtitle ? <p className="proto-review-dock__subject">{subtitle}</p> : null}
+            <p className="proto-review-dock__caption">{REVIEW_REVEAL_FAILED_COPY}</p>
+            <div className="proto-review-dock__actions">
+              <button
+                type="button"
+                className="proto-settings-btn proto-settings-btn--compact"
+                onClick={() => void reveal.refetch()}
+              >
+                {REVIEW_REVEAL_RETRY_COPY}
               </button>
             </div>
           </>

--- a/spa/src/pages/prototype/__tests__/review-dock-held-item.test.ts
+++ b/spa/src/pages/prototype/__tests__/review-dock-held-item.test.ts
@@ -1,0 +1,109 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The dock's two cache-and-pointer contracts, asserted against the source.
+ *
+ * Both are timing bugs in a component that is always mounted, never unmounts, and is fed by two
+ * query caches — the class of thing a render test can be made to pass without saying anything
+ * true about the real sequence. The decisions themselves are pure and tested directly in
+ * `src/utils/__tests__/review-dock-state.test.ts`; what is left to pin is that the component
+ * actually asks, and that nobody re-spells a query key by hand.
+ */
+const source = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const withoutComments = (text: string) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+const dock = () => withoutComments(source('spa/src/pages/prototype/PrototypeReviewDock.tsx'));
+const queries = () => withoutComments(source('spa/src/hooks/queries/useReview.ts'));
+const layout = () => withoutComments(source('spa/src/layouts/SimplifiedPrototypeLayout.tsx'));
+
+describe('the dock lets go of an answered question', () => {
+  /*
+   * The bug: `heldItem` pins the answered question so the result has something under it, and it
+   * was cleared in exactly one place — the "Next one" button. Leave from the result card, come
+   * back, tap a different row, and the card rendered the question that had already been answered
+   * while the pointer named the new one. Answering it again re-POSTed an outcome for an item the
+   * server had already rescheduled.
+   */
+  it('asks the shared rule rather than clearing the pin at one call site', () => {
+    const text = dock();
+    expect(text).toContain('shouldReleaseHeldItem');
+    expect(text).toContain('setHeldItem(null)');
+    // Every input the rule needs, so a future edit cannot quietly drop one and change the answer.
+    const call = text.slice(text.indexOf('shouldReleaseHeldItem({'));
+    for (const field of ['heldId', 'requestedId', 'hasResult', 'hasVerdict', 'pending', 'dockOpen']) {
+      expect(call.slice(0, 400)).toContain(field);
+    }
+  });
+
+  it('counts a sitting per open dock, not per tab', () => {
+    expect(dock()).toMatch(/if \(!open\) setSitting\(/);
+  });
+
+  it('re-composes a sitting left open across hours or a midnight', () => {
+    const text = dock();
+    expect(text).toContain('sittingIsStale');
+    expect(text).toContain('sessionQuery.refetch()');
+    // Only on the open edge. Refetching while the dock is in use is the reshuffle the
+    // `staleTime: Infinity` on the session exists to prevent.
+    expect(text).toMatch(/opening && sittingIsStale/);
+  });
+});
+
+describe('a reveal has one cache key', () => {
+  /*
+   * The prefetch and the session's `firstReveal` seeding wrote three elements; `useReviewReveal`
+   * read four. Neither warm path ever hit, so every graded question paid a round trip and showed
+   * its loading dots with the answer already in the cache under a neighbouring key.
+   */
+  it('is spelled in exactly one place', () => {
+    const text = queries();
+    expect(text).toContain('export const reviewRevealQueryKey');
+    const literals = text.match(/\['review', 'reveal'/g) ?? [];
+    expect(literals).toHaveLength(1);
+  });
+
+  it('is what the prefetch, the seeding and the query all use', () => {
+    // Three call sites, one per path that touches a reveal: the session seeding a first
+    // reveal, the prefetch warming the next one, and the query the card actually reads.
+    const text = queries();
+    expect(text.match(/reviewRevealQueryKey\(/g) ?? []).toHaveLength(3);
+  });
+});
+
+describe('a lost answer is never silent', () => {
+  it('tells the reader and keeps the question up', () => {
+    const mutations = withoutComments(source('spa/src/hooks/mutations/useReviewMutations.ts'));
+    const outcome = mutations.slice(mutations.indexOf('export function useReviewOutcome'));
+    expect(outcome.slice(0, 1600)).toContain('REVIEW_OUTCOME_FAILED_TOAST');
+    // The rollback stays: the queue must go back before anything is said about it.
+    expect(outcome.slice(0, 1600)).toContain('setQueryData(reviewSessionQueryKey, context.previous)');
+  });
+
+  it('does not lose the item when the stack edge answer fails', () => {
+    /*
+     * `clearPaperStack()` runs unconditionally — it is what advances the queue — so without an
+     * `onError` a failed answer left no stack, no result and no question.
+     */
+    const verdict = layout().slice(layout().indexOf('const handleReviewVerdict'));
+    expect(verdict.slice(0, 2500)).toContain('onError: () => setReviewDockItem(review.itemId)');
+  });
+
+  it('carries the slipping offer through the stack edge', () => {
+    // Notes are what the stack edge answers, so the rung that most needed "Make it easier" was
+    // the one rung that could never receive it.
+    const verdict = layout().slice(layout().indexOf('const handleReviewVerdict'));
+    expect(verdict.slice(0, 2500)).toMatch(/leech: data\.leech === true/);
+    expect(verdict.slice(0, 2500)).toMatch(/stalled: data\.stalled === true/);
+  });
+
+  it('shows a failed reveal as a failed reveal', () => {
+    // Not as the free-text fallback, which offers to record an answer to a question the reader
+    // was never shown.
+    const text = dock();
+    expect(text).toContain('isGradedRung && reveal.isError');
+    expect(text.indexOf('reveal.isError')).toBeLessThan(text.indexOf('reveal.isPending'));
+  });
+});

--- a/spa/src/pages/prototype/proto-review-copy.ts
+++ b/spa/src/pages/prototype/proto-review-copy.ts
@@ -72,6 +72,20 @@ export const REVIEW_PAUSE_FAILED_TOAST = "Couldn't change that — try again";
 export const REVIEW_DEFER_FAILED_TOAST = "Couldn't put that off — try again";
 
 /**
+ * And for the answer itself, which had none.
+ *
+ * The worst of the silent failures: the question stayed on screen exactly as it was, so a lost
+ * answer and an unregistered tap looked the same. The card keeps the question up and says this,
+ * rather than advancing to a result that was never recorded.
+ */
+export const REVIEW_OUTCOME_FAILED_TOAST = "Couldn't save that answer — try once more";
+export const REVIEW_STEP_BACK_FAILED_TOAST = "Couldn't change how this is asked — try again";
+
+/** The reveal is the question on a graded rung, so failing to load it is a question with no body. */
+export const REVIEW_REVEAL_FAILED_COPY = "This one didn't load.";
+export const REVIEW_REVEAL_RETRY_COPY = 'Try again';
+
+/**
  * The section heading on Activity.
  *
  * It was "Study Inbox" for its first week and the word was wrong twice over. An inbox is

--- a/src/utils/__tests__/review-dock-state.test.ts
+++ b/src/utils/__tests__/review-dock-state.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { canJudgeRecall, resolveReviewDockItem } from '../review-dock-state';
+import {
+  SITTING_STALE_MS,
+  canJudgeRecall,
+  resolveReviewDockItem,
+  shouldReleaseHeldItem,
+  sittingIsStale,
+} from '../review-dock-state';
 
 const item = (id: string) => ({ id });
 
@@ -39,5 +45,88 @@ describe('canJudgeRecall', () => {
     // to declare a mental state before checking it is the survey the strategy doc rules out.
     expect(canJudgeRecall({ attempt: '' })).toBe(false);
     expect(canJudgeRecall({ attempt: '   ' })).toBe(false);
+  });
+});
+
+describe('shouldReleaseHeldItem', () => {
+  const held = {
+    heldId: 'a',
+    requestedId: 'a' as string | null | undefined,
+    hasResult: true,
+    hasVerdict: true,
+    pending: false,
+    dockOpen: true,
+  };
+
+  it('holds the answered question under its own result', () => {
+    expect(shouldReleaseHeldItem(held)).toBe(false);
+  });
+
+  it('never lets go while the answer is in flight', () => {
+    // The flash the pin exists to prevent: the session drops the item optimistically, so
+    // releasing mid-request resolves the queue to the next question and back again.
+    expect(shouldReleaseHeldItem({ ...held, pending: true, hasResult: false, hasVerdict: false })).toBe(
+      false,
+    );
+    expect(shouldReleaseHeldItem({ ...held, pending: true, dockOpen: false })).toBe(false);
+    expect(shouldReleaseHeldItem({ ...held, pending: true, requestedId: 'b' })).toBe(false);
+  });
+
+  it('lets go when a different question is asked for by name', () => {
+    /*
+     * The reported bug. Answer A, leave without pressing "Next one", come back and tap row B:
+     * the pointer said B and the card rendered A, and answering it again re-recorded an
+     * outcome for an item that had already been rescheduled.
+     */
+    expect(shouldReleaseHeldItem({ ...held, requestedId: 'b', hasResult: false })).toBe(true);
+  });
+
+  it('lets go when the dock closes', () => {
+    expect(shouldReleaseHeldItem({ ...held, dockOpen: false })).toBe(true);
+  });
+
+  it('lets go when the result was dismissed by some other path', () => {
+    // `openReviewDock` nulls the result without touching the pin — a generic "Review" entry
+    // point rather than a row tap, so there is no new id to compare against.
+    expect(shouldReleaseHeldItem({ ...held, hasResult: false, hasVerdict: false })).toBe(true);
+  });
+
+  it('keeps the question up through a non-final miss', () => {
+    // A verdict with no result is "wrong, but not out of goes". Same question, still up.
+    expect(shouldReleaseHeldItem({ ...held, hasResult: false, hasVerdict: true })).toBe(false);
+  });
+
+  it('has nothing to do when nothing is pinned', () => {
+    expect(shouldReleaseHeldItem({ ...held, heldId: null, dockOpen: false })).toBe(false);
+  });
+
+  it('does not yank the result away when the same row is tapped again', () => {
+    // Re-opening on the question you just answered is not a request for a different one.
+    expect(shouldReleaseHeldItem({ ...held, requestedId: 'a', hasVerdict: false })).toBe(false);
+  });
+});
+
+describe('sittingIsStale', () => {
+  const noon = Date.parse('2026-09-11T12:00:00Z');
+
+  it('keeps a sitting fetched moments ago', () => {
+    expect(sittingIsStale(noon - 60_000, noon)).toBe(false);
+  });
+
+  it('retires one left sitting for hours', () => {
+    expect(sittingIsStale(noon - SITTING_STALE_MS, noon)).toBe(true);
+  });
+
+  it('retires one from a previous day even if the hours do not add up', () => {
+    // A tab left open across midnight: two hours old, and yesterday's queue all the same.
+    const justBeforeMidnight = Date.parse('2026-09-10T23:30:00');
+    const justAfter = Date.parse('2026-09-11T01:00:00');
+    expect(justAfter - justBeforeMidnight).toBeLessThan(SITTING_STALE_MS);
+    expect(sittingIsStale(justBeforeMidnight, justAfter)).toBe(true);
+  });
+
+  it('says nothing about a sitting that has never been fetched', () => {
+    expect(sittingIsStale(null, noon)).toBe(false);
+    expect(sittingIsStale(0, noon)).toBe(false);
   });
 });

--- a/src/utils/review-dock-state.ts
+++ b/src/utils/review-dock-state.ts
@@ -52,3 +52,63 @@ export function resolveReviewDockItem<T extends ReviewDockItemLike>(
 export function canJudgeRecall(state: { attempt: string }): boolean {
   return state.attempt.trim().length > 0;
 }
+
+/**
+ * Whether the dock should let go of the question it pinned.
+ *
+ * `heldItem` exists so an answered question stays under its own result — the mutation drops the
+ * item from the session optimistically, so without the pin the card swaps to the next question
+ * for a beat and then swaps back. It was cleared in exactly one place, the "Next one" button,
+ * and every other way out of a result left it set: leaving from the result card and tapping a
+ * different row rendered the *old* exercise while the dock's pointer named the new one, and
+ * answering it again re-recorded an outcome for an item that had already been rescheduled.
+ *
+ * The four clauses, in order, because the order is the rule:
+ *
+ * - Nothing pinned, nothing to release.
+ * - **Never while the answer is in flight.** This is the whole reason the pin exists; releasing
+ *   here is the flash it was written to prevent.
+ * - A closed dock keeps nothing. Reopening starts from the queue.
+ * - **A different item was asked for by name.** Unambiguous: a row was tapped, and it was not
+ *   this one.
+ * - Otherwise release only once the card is showing neither a result nor a verdict. A verdict
+ *   with no result is the non-final miss — same question, still up, holding against the refetch
+ *   the attempt kicked off — and that hold is deliberate.
+ */
+export function shouldReleaseHeldItem(state: {
+  heldId: string | null;
+  /** The dock's own pointer: what was last asked for by name. */
+  requestedId: string | null | undefined;
+  hasResult: boolean;
+  /** A marked answer on screen, including the non-final miss. */
+  hasVerdict: boolean;
+  pending: boolean;
+  dockOpen: boolean;
+}): boolean {
+  if (!state.heldId) return false;
+  if (state.pending) return false;
+  if (!state.dockOpen) return true;
+  if (state.requestedId && state.requestedId !== state.heldId) return true;
+  return !state.hasResult && !state.hasVerdict;
+}
+
+/** Four hours, or a new day, whichever comes first — see {@link sittingIsStale}. */
+export const SITTING_STALE_MS = 4 * 60 * 60 * 1000;
+
+/**
+ * Whether a sitting fetched at `fetchedAt` is too old to be handed to someone reopening the dock.
+ *
+ * A sitting is `staleTime: Infinity` on purpose: refetching mid-answer would reshuffle the queue
+ * under the reader. That is right for the minutes a sitting lasts and wrong for the hours a tab
+ * stays open — leave Harvous open overnight and the morning's dock serves yesterday's questions,
+ * scheduled against yesterday's clock.
+ *
+ * A calendar-day change counts as well as the elapsed hours, because "a new day" is what a reader
+ * means by a new sitting, and an evening sitting reopened after midnight is four hours away from
+ * being one. Checked only as the dock opens, never while it is being used.
+ */
+export function sittingIsStale(fetchedAt: number | null | undefined, now: number = Date.now()): boolean {
+  if (!fetchedAt) return false;
+  if (now - fetchedAt >= SITTING_STALE_MS) return true;
+  return new Date(fetchedAt).toDateString() !== new Date(now).toDateString();
+}


### PR DESCRIPTION
First of four PRs from a review of the Review exercises. This one is correctness only — no behaviour the reader asked for changes, five things that were quietly broken stop being broken.

## The reported bug

Answer a question, leave the dock without pressing "Next one", come back and tap a different row → the card shows **the question you already answered**. Answering it again re-POSTs an outcome for an item the server has already rescheduled.

`heldItem` pins the answered question so the result card has something under it (the outcome mutation drops the item from the session optimistically, so without the pin the card swaps to the next question and back). It was cleared in exactly one place — the "Next one" `onClick` — so every other exit from a result kept it, and `item = heldItem ?? queued` resolved to the stale one while `reviewDock.itemId` named the new one. A silent split-brain.

The fix is `shouldReleaseHeldItem` in `review-dock-state.ts`, pure because every interesting case is a timing one:

| Situation | Release? |
|---|---|
| Answer in flight | **No** — this is the flash the pin exists to prevent |
| Verdict, no result (non-final miss) | **No** — same question, still up |
| Dock closed | Yes |
| A different item asked for by name | Yes |
| Result dismissed some other way | Yes |

## Four more found on the same path

1. **A reveal had two cache keys.** `usePrefetchReviewReveal` and the session's `firstReveal` seeding wrote `['review','reveal',id]`; `useReviewReveal` read `['review','reveal',id,translation ?? 'default']`. *Neither* warm path ever hit — every graded question paid a full round trip and showed its loading dots with the answer already sitting in the query client under a neighbouring key. Now one exported `reviewRevealQueryKey`, with a test that it is spelled once.
2. **Answering had no error state.** `useReviewOutcome.onError` rolled the cache back and said nothing. Since the question stays on screen either way, a lost answer was indistinguishable from a tap that did not register — the quietest failure in the feature, on a paid one.
3. **The paper-stack path could lose the item.** `clearPaperStack()` runs unconditionally (it is what advances the queue), so a failed answer left no stack, no result and no question. It also never forwarded `leech`/`stalled`, and notes are precisely what that path answers — so the rung that most needed "Make it easier" was the one rung that could never be offered it.
4. **A failed reveal rendered the wrong exercise.** `reveal.isError` was unhandled, so the branch chain fell past every exercise to the free-text fallback — a textarea and a "Check the verse" button offering to record an answer to a question the reader was never shown. This is the same wrong-exercise flash the loading branch was written to prevent, except permanent.

## Also

A sitting now belongs to the open dock rather than the tab (the counter never reset), and is re-composed when the dock is reopened after four hours or across a midnight. The `staleTime: Infinity` freeze is deliberate and still holds exactly where it was written to — the staleness check runs on the open edge only, never while the dock is in use, so the queue still cannot reshuffle mid-answer.

## Verification

- `npx vitest run` — 575 files, 6163 tests. One unrelated flake in `sync-manager.test.ts` under full-suite parallel load; passes in isolation both with and without this branch (verified against a clean stash).
- `tsc --noEmit` clean on every touched file.
- `npm run build:spa && npm run perf:check` — passed, 1152.3 KB gzipped, no regressions.
- New: `review-dock-held-item.test.ts` (source-read contracts, house style for the always-mounted dock) and 12 new cases in `review-dock-state.test.ts` covering the repro trace directly.

Next up: the dock band reserving its own height, then the difficulty ramp, then result-card context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
