### PR TITLE
Review: the page underneath knows how tall the study dock is

### DIFF
--- a/spa/src/pages/prototype/PrototypeEditorChromeBar.tsx
+++ b/spa/src/pages/prototype/PrototypeEditorChromeBar.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef } from 'react';
 import { useProtoShell } from '../../layouts/proto-shell-context';
+import { observeStudyDockBandHeight } from '@/utils/study-dock-layout';
 import PrototypeReviewDock from './PrototypeReviewDock';
 
 /**
@@ -39,9 +41,20 @@ export default function PrototypeEditorChromeBar({
   const mode = bottomBarActive ? editorChromeMode : 'hidden';
   const collapsed = mode === 'hidden' || mode === 'noteActions';
 
+  /*
+   * Publish how much of the screen the band is covering, so the page beneath can reserve it.
+   *
+   * Bound here because this is the one place the band is mounted, and it is mounted on every
+   * route. The comparable effects in `SimplifiedPrototypeLayout` sit behind an `isNoteRoute`
+   * check, which is why an expanded dock in the Bible reader hid the end of the chapter: on
+   * that route nothing was measuring anything.
+   */
+  const layerRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => observeStudyDockBandHeight(layerRef.current), []);
+
   return (
     <div className="proto-shell__editor-chrome-row" data-mode={mode}>
-      <div className="proto-shell__study-dock-layer" aria-live="polite">
+      <div className="proto-shell__study-dock-layer" ref={layerRef} aria-live="polite">
         {/* Before the carousel, so on a note the question sits above the note's own docks
             rather than being pushed off the end of a row it does not belong to. */}
         <div className="proto-shell__study-dock-layer__slot proto-shell__study-dock-layer__slot--review">

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -9913,7 +9913,13 @@ button.proto-appearance-hero__card {
 .proto-sync-chip {
   position: fixed;
   left: calc(var(--pds-shell-frame-inset, 14px) + max(16px, env(safe-area-inset-left)));
-  bottom: calc(var(--pds-shell-frame-inset, 14px) + 16px + env(safe-area-inset-bottom));
+  /* Lifted clear of the study dock band. These two are the only bottom-anchored things
+     outside the band — fixed to the body rather than living in it — so the reserve the
+     scrollers take does not move them, and an open dock would sit on top of them. */
+  bottom: calc(
+    var(--pds-shell-frame-inset, 14px) + 16px + env(safe-area-inset-bottom) +
+      var(--proto-study-dock-band-height, 0px)
+  );
   z-index: 1000020;
   display: inline-flex;
   align-items: center;
@@ -11514,7 +11520,13 @@ html.harvous-prototype-route
      centre otherwise, which is what the auth and public shells get. */
   left: var(--proto-toast-center, 50%);
   transform: translateX(-50%);
-  bottom: calc(var(--pds-shell-frame-inset, 14px) + 16px + env(safe-area-inset-bottom));
+  /* Lifted clear of the study dock band. These two are the only bottom-anchored things
+     outside the band — fixed to the body rather than living in it — so the reserve the
+     scrollers take does not move them, and an open dock would sit on top of them. */
+  bottom: calc(
+    var(--pds-shell-frame-inset, 14px) + 16px + env(safe-area-inset-bottom) +
+      var(--proto-study-dock-band-height, 0px)
+  );
   z-index: 1000021;
   display: inline-flex;
   align-items: center;
@@ -18477,7 +18489,11 @@ html.harvous-prototype-route button[class*="proto-"].proto-settings-danger__btn:
      the reader's paper has nothing to clear and its own 48px of top padding inside, so the
      lip only added a band of dead space above the chapter — most visible stacked, where it
      opened a gap between the peeking edge and the paper right under it. */
-  padding: 0;
+  /* No top lip (see above); the bottom is room for the study dock band, which floats over the
+     chapter with no layout height of its own — so the last verses sat behind an expanded card
+     and could not be scrolled to. Zero when nothing is open. */
+  padding: 0 0 var(--proto-study-dock-band-height, 0px);
+  scroll-padding-bottom: var(--proto-study-dock-band-height, 0px);
   /* Named query container for the narrow overrides below. Safe: this element's width comes
      from its flex parent, never from its own contents, so containment changes no layout. */
   container-type: inline-size;
@@ -18556,7 +18572,14 @@ html.harvous-prototype-route button[class*="proto-"].proto-settings-danger__btn:
  * base, every gallery fixture — keeps the flush top the comment argued for.
  */
 .pds-reader-stack {
-  padding-block: var(--pds-space-5);
+  padding-top: var(--pds-space-5);
+  /*
+   * Written out rather than left as `padding-block`, because the shorthand also set the bottom
+   * and this class lands on the same element as `.pds-reader__scroll` — so the stack's air
+   * silently replaced the room reserved there for the study dock band, and only on chapters
+   * that happen to have a pile. Both states now end with the band cleared.
+   */
+  padding-bottom: calc(var(--pds-space-5) + var(--proto-study-dock-band-height, 0px));
 }
 
 .pds-reader-stack__edges {
@@ -22187,12 +22210,14 @@ html.harvous-prototype-route .proto-appearance-hero__specimen[data-font='dyslexi
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
+  scroll-padding-bottom: var(--proto-study-dock-band-height, 0px);
   display: flex;
   flex-direction: column;
   gap: var(--pds-space-5);
   /* Padding inside the scroller, so the last row travels through the fade rather than ending
-     inside it. */
-  padding-bottom: var(--pds-space-5);
+     inside it — plus room for the study dock band, which floats over this with no layout
+     height of its own. One declaration: a second would simply overwrite the first. */
+  padding-bottom: calc(var(--pds-space-5) + var(--proto-study-dock-band-height, 0px));
   --proto-feed-fade: 14px;
   /*
    * Bottom always; top only once there is something under it.

--- a/spa/src/styles/prototype-editor.css
+++ b/spa/src/styles/prototype-editor.css
@@ -49,7 +49,16 @@
   overflow-y: auto;
   overflow-x: hidden;
   /* Keep the caret clear of the format toolbar when typing near the bottom. */
-  scroll-padding-bottom: 24px;
+  scroll-padding-bottom: calc(24px + var(--proto-study-dock-band-height, 0px));
+  /*
+   * And room at the end for whatever the study dock band is covering.
+   *
+   * On the scroller rather than on the paper: the paper's bottom padding is restated by three
+   * narrow-viewport overrides, and a reserve added to one of them is a reserve missing from the
+   * others. Here it is one declaration, and it is scrollable room after the sheet — which is
+   * what was actually missing, since the band is absolutely positioned and takes no height.
+   */
+  padding-bottom: var(--proto-study-dock-band-height, 0px);
   display: flex;
   flex-direction: column;
   container-type: inline-size;
@@ -59,7 +68,7 @@
 /* When the format bar floats over the paper (overlay, not in-flow), give the caret extra
    bottom clearance so typing near the end isn't hidden behind the bar. */
 .proto-shell:has(.proto-editor-bottom-bar[data-mode='format']) .proto-editor-scroll {
-  scroll-padding-bottom: 64px;
+  scroll-padding-bottom: calc(64px + var(--proto-study-dock-band-height, 0px));
 }
 
 /* SubtleContentMount (variant="fade") wraps the card — make its inner div a flex

--- a/spa/src/styles/prototype-shell.css
+++ b/spa/src/styles/prototype-shell.css
@@ -597,6 +597,10 @@ html.harvous-prototype-route .proto-shell__detail-toolbar-cell::after {
   min-height: 0;
   overflow: auto;
   font-family: var(--pds-font-body);
+  /* Room at the end of Home, Activity and everything else for the study dock band, which
+     floats over this pane with no layout height of its own. Zero when no dock is open. */
+  scroll-padding-bottom: var(--proto-study-dock-band-height, 0px);
+  padding-bottom: var(--proto-study-dock-band-height, 0px);
 }
 
 /* ─── Mobile drawer ──────────────────────────────────────────────────────── */

--- a/src/utils/__tests__/study-dock-band-height.test.ts
+++ b/src/utils/__tests__/study-dock-band-height.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  STUDY_DOCK_BAND_HEIGHT_VAR,
+  observeStudyDockBandHeight,
+  syncStudyDockBandHeight,
+} from '../study-dock-layout';
+
+/**
+ * How much of the screen the study dock band is covering.
+ *
+ * The band is `position: absolute; bottom: 100%` in a grid row that collapses to nothing, so it
+ * takes zero layout height and floats over the page. Nothing underneath knew it was there, and
+ * the last part of every scrollable surface — most visibly the end of a chapter in the reader —
+ * sat behind an expanded card with no way to scroll to it.
+ */
+function mockRect(el: HTMLElement, height: number) {
+  el.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      width: 800,
+      height,
+      top: 0,
+      left: 0,
+      right: 800,
+      bottom: height,
+      toJSON: () => ({}),
+    }) as DOMRect;
+}
+
+function buildBand(slotHeights: number[], { paddingTop = 16, rowGap = 8 } = {}) {
+  document.body.innerHTML = '';
+  const layer = document.createElement('div');
+  layer.className = 'proto-shell__study-dock-layer';
+  // The layer's own rect is the space it *may* use — it is flex-end over a fixed area with
+  // padding for the card's shadow — so the measurement sums the slots instead.
+  mockRect(layer, 600);
+  for (const height of slotHeights) {
+    const slot = document.createElement('div');
+    slot.className = 'proto-shell__study-dock-layer__slot';
+    mockRect(slot, height);
+    layer.appendChild(slot);
+  }
+  document.body.appendChild(layer);
+
+  vi.spyOn(window, 'getComputedStyle').mockImplementation(
+    () => ({ rowGap: `${rowGap}px`, paddingTop: `${paddingTop}px` }) as CSSStyleDeclaration,
+  );
+  return layer;
+}
+
+const readVar = () => document.documentElement.style.getPropertyValue(STUDY_DOCK_BAND_HEIGHT_VAR);
+
+afterEach(() => {
+  document.documentElement.style.removeProperty(STUDY_DOCK_BAND_HEIGHT_VAR);
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('syncStudyDockBandHeight', () => {
+  it('publishes one open dock plus the band padding', () => {
+    buildBand([120, 0]);
+    expect(syncStudyDockBandHeight()).toBe(136);
+    expect(readVar()).toBe('136px');
+  });
+
+  it('adds the gap between two open docks, and only between them', () => {
+    // A question above a highlight on the same note: 120 + 90 + one 8px gap + 16px padding.
+    buildBand([120, 90]);
+    expect(syncStudyDockBandHeight()).toBe(234);
+  });
+
+  it('reserves nothing at all when the band is empty', () => {
+    /*
+     * The whole point of summing the slots. The layer's own rect is 600px of space it is
+     * entitled to; reading that would have reserved 600px of dead room on every route where no
+     * dock is open, which is most of them.
+     */
+    buildBand([0, 0]);
+    expect(syncStudyDockBandHeight()).toBe(0);
+    // Removed, not set to `0px`, so every consumer's `var(..., 0px)` fallback is the one
+    // definition of "no dock".
+    expect(readVar()).toBe('');
+  });
+
+  it('reserves nothing when the band is not mounted', () => {
+    document.body.innerHTML = '';
+    document.documentElement.style.setProperty(STUDY_DOCK_BAND_HEIGHT_VAR, '200px');
+    expect(syncStudyDockBandHeight()).toBe(0);
+    expect(readVar()).toBe('');
+  });
+
+  it('collapses when the band is hidden, as it is under the mobile keyboard', () => {
+    const layer = buildBand([120, 0]);
+    syncStudyDockBandHeight();
+    expect(readVar()).toBe('136px');
+    // `display: none` while the keyboard is up — every rect reports 0.
+    for (const slot of layer.children) mockRect(slot as HTMLElement, 0);
+    expect(syncStudyDockBandHeight()).toBe(0);
+    expect(readVar()).toBe('');
+  });
+});
+
+describe('observeStudyDockBandHeight', () => {
+  function stubResizeObserver() {
+    const instances: { observe: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> }[] = [];
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn();
+        disconnect = vi.fn();
+        constructor() {
+          instances.push(this as never);
+        }
+      },
+    );
+    vi.stubGlobal(
+      'MutationObserver',
+      class {
+        observe = vi.fn();
+        disconnect = vi.fn();
+      },
+    );
+    return instances;
+  }
+
+  it('measures once on bind, so the first paint is not a beat behind', () => {
+    stubResizeObserver();
+    const layer = buildBand([120, 0]);
+    const stop = observeStudyDockBandHeight(layer);
+    expect(readVar()).toBe('136px');
+    stop();
+  });
+
+  it('watches the slots as well as the layer', () => {
+    // A dock growing inside a slot does not change the layer's own box, so observing only the
+    // layer would miss every expand and collapse.
+    const instances = stubResizeObserver();
+    const layer = buildBand([120, 90]);
+    const stop = observeStudyDockBandHeight(layer);
+    expect(instances[0].observe).toHaveBeenCalledTimes(3);
+    stop();
+  });
+
+  it('stops watching and gives the room back on cleanup', () => {
+    const instances = stubResizeObserver();
+    const layer = buildBand([120, 0]);
+    observeStudyDockBandHeight(layer)();
+    expect(instances[0].disconnect).toHaveBeenCalled();
+    expect(readVar()).toBe('');
+  });
+
+  it('does nothing rather than throwing where there is no band or no observer', () => {
+    stubResizeObserver();
+    expect(() => observeStudyDockBandHeight(null)()).not.toThrow();
+    vi.stubGlobal('ResizeObserver', undefined);
+    const layer = buildBand([120, 0]);
+    expect(() => observeStudyDockBandHeight(layer)()).not.toThrow();
+  });
+});
+
+describe('the surfaces underneath reserve it', () => {
+  it('is read by every scroller and by the two chips outside the band', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { resolve } = await import('node:path');
+    const css = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+
+    const editor = css('spa/src/styles/prototype-editor.css');
+    const shell = css('spa/src/styles/prototype-shell.css');
+    const components = css('spa/src/styles/prototype-components.css');
+
+    // The note, the reader, Home and everything else, the study feed.
+    expect(editor).toContain('--proto-study-dock-band-height');
+    expect(shell).toContain('--proto-study-dock-band-height');
+    expect(components).toContain('--proto-study-dock-band-height');
+    // Both fixed-to-body chips, which the scrollers' reserve cannot move.
+    expect(components.match(/--proto-study-dock-band-height/g)?.length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/src/utils/study-dock-layout.ts
+++ b/src/utils/study-dock-layout.ts
@@ -221,6 +221,104 @@ export function syncFormatToolbarReservedHeight(): number {
   return height;
 }
 
+/**
+ * How much of the screen the dock band is covering, published for the page beneath it.
+ *
+ * The band is `position: absolute; bottom: 100%` inside a grid row that collapses to nothing,
+ * so it takes **zero layout height** and floats over the main cell. That is what lets one card
+ * span the sidebar and the main pane and follow the reader between routes, and it is also why
+ * the last part of every scrollable surface was unreachable while a dock was expanded: nothing
+ * under it knew it was there. The only height this module measured was
+ * `--proto-dock-expanded-max-height`, which is a *ceiling on the card* — the opposite quantity.
+ *
+ * So: measure the band, write it on the root, and let each scroller reserve it in its own
+ * padding. Returned as well as written, for the tests and for callers that want the number.
+ *
+ * Zero removes the property rather than writing `0px`, so every consumer's `var(..., 0px)`
+ * fallback is the single definition of "no dock". That matters on mobile, where the band is
+ * `display: none` while the keyboard is up: it reports 0, the reserve collapses, and the page
+ * is not left padding for a card nobody can see.
+ */
+export const STUDY_DOCK_BAND_HEIGHT_VAR = '--proto-study-dock-band-height';
+
+export function syncStudyDockBandHeight(): number {
+  if (typeof document === 'undefined') return 0;
+  const root = document.documentElement;
+  const layer = document.querySelector('.proto-shell__study-dock-layer');
+  if (!(layer instanceof HTMLElement)) {
+    root.style.removeProperty(STUDY_DOCK_BAND_HEIGHT_VAR);
+    return 0;
+  }
+
+  /*
+   * Summed from the slots rather than read off the layer.
+   *
+   * The layer is `justify-content: flex-end` over a fixed area and carries 16px of top padding
+   * for the card's shadow, so its own rect is the space it *may* use, not the space it is
+   * using. An empty band would have reserved that padding on every route.
+   */
+  let height = 0;
+  for (const slot of layer.children) {
+    if (!(slot instanceof HTMLElement)) continue;
+    const rect = slot.getBoundingClientRect();
+    if (rect.height > 0) height += rect.height;
+  }
+  if (height > 0) {
+    const gap = parseFloat(getComputedStyle(layer).rowGap) || 0;
+    const filled = [...layer.children].filter(
+      (slot) => slot instanceof HTMLElement && slot.getBoundingClientRect().height > 0,
+    ).length;
+    height += gap * Math.max(0, filled - 1);
+    height += parseFloat(getComputedStyle(layer).paddingTop) || 0;
+  }
+
+  const rounded = Math.round(height);
+  if (rounded <= 0) {
+    root.style.removeProperty(STUDY_DOCK_BAND_HEIGHT_VAR);
+    return 0;
+  }
+  // Written only on a change: this runs from a ResizeObserver, and setting a custom property
+  // on the root invalidates style for the whole document.
+  if (root.style.getPropertyValue(STUDY_DOCK_BAND_HEIGHT_VAR) !== `${rounded}px`) {
+    root.style.setProperty(STUDY_DOCK_BAND_HEIGHT_VAR, `${rounded}px`);
+  }
+  return rounded;
+}
+
+/**
+ * Keep {@link syncStudyDockBandHeight} current for as long as the band is mounted.
+ *
+ * Observes the layer and each slot, because a dock growing inside a slot does not change the
+ * layer's own box. Bound once in `PrototypeEditorChromeBar`, which is the single mount point on
+ * every route — the existing max-height effects live in `SimplifiedPrototypeLayout` behind an
+ * `isNoteRoute` check, which is exactly why the Bible reader never recomputed anything.
+ */
+export function observeStudyDockBandHeight(layer: HTMLElement | null): () => void {
+  if (!layer || typeof ResizeObserver === 'undefined') return () => {};
+  const observer = new ResizeObserver(() => syncStudyDockBandHeight());
+  observer.observe(layer);
+  for (const slot of layer.children) {
+    if (slot instanceof HTMLElement) observer.observe(slot);
+  }
+  /*
+   * Slots gain and lose their cards as docks open, and a card is a new element rather than a
+   * resize of an old one. Without this the observer would watch two empty slots forever.
+   */
+  const mutations = new MutationObserver(() => {
+    for (const slot of layer.children) {
+      if (slot instanceof HTMLElement) observer.observe(slot);
+    }
+    syncStudyDockBandHeight();
+  });
+  mutations.observe(layer, { childList: true, subtree: true });
+  syncStudyDockBandHeight();
+  return () => {
+    observer.disconnect();
+    mutations.disconnect();
+    document.documentElement.style.removeProperty(STUDY_DOCK_BAND_HEIGHT_VAR);
+  };
+}
+
 /** Recompute expanded study dock max-height and dock center offset (track required for offset). */
 export function updateStudyDockExpandedMaxHeight(track?: HTMLElement | null): void {
   if (typeof document === 'undefined') return;
@@ -229,6 +327,8 @@ export function updateStudyDockExpandedMaxHeight(track?: HTMLElement | null): vo
   }
   syncFormatToolbarPaperInset();
   syncFormatToolbarReservedHeight();
+  // The ceiling on the card and the room reserved beneath it are the same event.
+  syncStudyDockBandHeight();
   const chromeRow = document.querySelector('.proto-shell__editor-chrome-row');
   if (!chromeRow) return;
   const rect = chromeRow.getBoundingClientRect();


### PR DESCRIPTION
Second of four PRs from the Review exercise review. Fixes the dock covering the bottom of every scrollable surface — **not just Review's dock, and not just the reader**: the fix is in the band all study docks share.

## The problem

`.proto-shell__study-dock-layer` is `position: absolute; bottom: 100%` inside a grid row that collapses to nothing. It takes **zero layout height** and floats over `.proto-shell__main-cell`.

That is deliberate and worth keeping — it is what lets one card span sidebar + main and follow the reader across routes without remounting. But nothing underneath knew the band was there, so the end of every scroller sat behind an expanded card with no way to reach it except collapsing the dock.

The only height the layout module measured was `--proto-dock-expanded-max-height`, which is a *ceiling on the card* — the opposite quantity — and `updateStudyDockExpandedMaxHeight` only ran behind an `isNoteRoute` check in `SimplifiedPrototypeLayout`. On the Bible reader nothing recomputed anything at all.

## The fix

The band publishes its own height; each scroller reserves it.

- `syncStudyDockBandHeight()` writes `--proto-study-dock-band-height` on the root, **summing the slots rather than reading the layer**. The layer is `justify-content: flex-end` over a fixed area with 16px of shadow padding, so its rect is the space it *may* use — reading that would reserve a screenful of dead room on every route with no dock open.
- Zero **removes** the property rather than writing `0px`, so every consumer's `var(…, 0px)` fallback is the single definition of "no dock". This is also what makes the mobile-keyboard case fall out for free: the band is `display: none` there, every rect reports 0, the reserve collapses.
- `observeStudyDockBandHeight()` is bound once in `PrototypeEditorChromeBar` — the single mount point, live on every route. It observes the slots as well as the layer (a dock growing inside a slot does not change the layer's box) and re-observes on mutation (a card is a new element, not a resize).

Reserved in four scrollers plus the two `position: fixed` chips that live outside the band and would otherwise be covered (`.proto-sync-chip`, `.proto-update-toast`).

## Two cascade collisions, found by measuring rather than trusting the rule

Worth calling out, because both were silent and neither would have shown up in a unit test:

1. **`.pds-reader-stack`** lands on the same element as `.pds-reader__scroll` and set `padding-block`, so the stack's air replaced the reserve — and *only on chapters that happen to have a pile*. Now split into explicit top/bottom that composes.
2. **`.proto-feed-sheet__body`** already had a second `padding-bottom` later in its own rule, which simply overwrote the one I added. Merged into one `calc()`.

## Verification

Driven against a real chapter in the running app (and note: the first attempt measured the *wrong worktree* — port 4333 was already held by another dev server, which is worth knowing).

| Scroller | no dock | 200px band |
|---|---|---|
| `.pds-reader__scroll` | 20px | **220px** |
| `.proto-main-pane` | 0 | **200px** |
| `.proto-feed-sheet__body` | 20px | **220px** |
| `.proto-editor-scroll` | 0 (scroll-pad 24) | **200px** (scroll-pad 224, caret clearance kept) |

End to end with a live dock on John 5: band publishes 192px → reader pads 212px → the last verse clears the card by 322px and the "John 6" affordance is reachable. The observer recomputed 94px → 192px on its own when the viewport changed. Dismissing the dock removes the property and the reader returns to 20px — no dead space when nothing is open.

- `npx vitest run` — 575 files, 6152 tests, all passing
- `npm run build:spa && npm run perf:check` — passed, 1152.4 KB gzipped, no regressions
- New `study-dock-band-height.test.ts`: 10 cases covering the slot sum, the empty band, the hidden band, observer binding and cleanup

Also adds a `launch.json` entry for this worktree (SPA 4341 / API 3007), since every nearby port was taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
