### PR TITLE
Planner: a room plans a study, not a gathering

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -152,6 +152,16 @@
       ],
       "port": 4330,
       "autoPort": false
+    },
+    {
+      "name": "planner-study-worktree",
+      "runtimeExecutable": "sh",
+      "runtimeArgs": [
+        "-c",
+        "API_PORT=3006 DB_POOL_MAX=4 VITE_API_PROXY_TARGET=http://localhost:3006 npx concurrently --names api,spa -c green,yellow 'npm run dev:api' 'node scripts/wait-for-api.js && npm run dev:spa -- --port 4336 --strictPort'"
+      ],
+      "port": 4336,
+      "autoPort": false
     }
   ]
 }

--- a/docs/design-parity/HARVOUS_DESIGN_SYSTEM.md
+++ b/docs/design-parity/HARVOUS_DESIGN_SYSTEM.md
@@ -118,6 +118,17 @@ Harvous should feel **quiet, warm, and content-first** — a study desk, not a d
 - Menus use `role="menu"` / `menuitem*` (or native equivalents) with checked/expanded state.
 - Status banners and empty states expose `role="status"` or `role="alert"` as appropriate. Floating toasts do the same.
 - Focus rings use accent tokens; never remove focus outlines without a visible replacement.
+- **A field's focus ring is inset; a row's or card's is outward.** `outline` is painted outside
+  the border box, so any ancestor with `overflow: hidden` or `auto` crops whatever falls outside
+  its padding box. A field is the one focusable thing that is routinely `width: 100%` inside a
+  scrolling column — and the rails that hold them zero their side padding to buy width — so an
+  outward ring loses its left and right edges and reads as two stray brackets. Inputs, textareas
+  and selects therefore use a negative `outline-offset` (`calc(-1 * var(--focus-ring-width))`
+  globally, `-2px` in `prototype-components.css`); nav rows and cards keep the outward
+  `--focus-ring-offset`, because they sit in open space and want the halo. Watch for the trap
+  underneath it: setting `overflow-y: auto` forces `overflow-x` to compute to `auto` as well, so
+  a column that only meant to scroll down clips sideways too. The Inputs gallery scene
+  (`ds-11-inputs`) reproduces the condition rather than describing it.
 - Support `prefers-reduced-motion` and `prefers-reduced-transparency`.
 - Do not put `user-select: none` on editable note content or scripture pill text.
 

--- a/docs/future/CHURCH_SPACE_PLANS_AND_SERVICE_TIMES.md
+++ b/docs/future/CHURCH_SPACE_PLANS_AND_SERVICE_TIMES.md
@@ -1,5 +1,15 @@
 # Church space plans, service times, and the Home card stack
 
+> **Amended September 10, 2026 — the room lane's noun is now *study*.**
+> This doc's §1 doctrine is unchanged ("one next gathering per context you joined, never a
+> schedule of any context") and so is the plan/service-time split. What changed is the word and
+> the order in which the form asks for things: a room plans a **study**, and the date is a
+> collapsed section under the title and passage rather than the first field. **The church lane
+> keeps "sermon"** and keeps its date expanded, because there a sermon really is a slot on a
+> Sunday and the slot checkboxes live in that section. `ChurchServices.kind` still reads
+> `'gathering'`; it is a behavioural discriminator, not vocabulary. See
+> [SPACES_PLANNER_AND_GATHERINGS.md](./SPACES_PLANNER_AND_GATHERINGS.md).
+
 **Status:** P1, **P2 and P5 built**, plus **series-as-a-row (§9)** and **aggregate
 engagement (§10)** (Aug 2026); P3–P4 design only. Decided August 2026. Companion to
 [CHURCH_STUDY_MATERIAL_LINKING.md](./CHURCH_STUDY_MATERIAL_LINKING.md),

--- a/docs/future/SHARED_SPACE_STUDY_TOOLS.md
+++ b/docs/future/SHARED_SPACE_STUDY_TOOLS.md
@@ -59,7 +59,7 @@ launch audience, "small co-study groups."
 | Start / rename / pin a Thread | ● | ● | ○ | `canManageSpaceStructure`; the create sheet is stricter still — `if (!isOwner) return null` |
 | Read the room's plan | ● | ● | ○ | `resolveSpacePlanAccess` — `canManageSpaceStructure`, **narrowed Sep 2026** (gap 2) |
 | Change the plan | ● | ● | ○ | same, `spaceLaneWrite` |
-| "Coming up": the gathering, a note, **and the passage** | ● | ● | ● | `GET /api/church/spaces/:id/coming-up`, gated on membership alone |
+| "Coming up": the study, a note, **and the passage** | ● | ● | ● | `GET /api/church/spaces/:id/coming-up`, gated on membership alone |
 | Space Library shelf | curate | curate | read | `assertCanManageSpaceLibrary` — the server's verdict, shipped as `canManage` on the payload |
 | Space scripture index, scoped search, space-scoped study feed | ● | ● | ● | `StudyFeedScope.kind === 'space'` |
 | Pin a note | ● | ○ | ○ | `canPinSharedSpaceItem` — *"pinning is moderation"* |
@@ -72,8 +72,9 @@ launch audience, "small co-study groups."
 | Rest the room's passage card | ● | ● | ● | `RecallEvents.spaceId` + the space-keyed cooldown store; suppression never crosses rooms |
 
 The **Tools** popover in the room's header (`proto-tools-registry.tsx`) is where a room's
-tools are reached. It holds two rows today — Library and Planner — against the church hub's
-six. Both appear for a member once there is something to see, and for whoever curates them
+tools are reached. It builds up to four rows — Library, Planner, Note templates and What's
+next — each appearing on its own condition, against the church hub's six. (This doc said "two
+rows" until Sept 2026; templates and What's next had shipped since.) Both appear for a member once there is something to see, and for whoever curates them
 while still empty, *"otherwise the one person who could plan the first gathering is the one
 person who cannot find where."*
 
@@ -173,7 +174,15 @@ Restated because every one of these has been re-proposed at least once:
 
 - **No reminders, notifications, recurrence engine, room booking, or attendance.**
   `meetingDay` / `meetingTime` / `publishCadence` are display and defaults; whoever runs the
-  room still enters every gathering by hand.
+  room still enters every study by hand. `rhythmDates` offers the next few dates and a new
+  study can declare its own run length, which removes the retyping without introducing
+  recurrence, exceptions, cancellations or anything that fires on a clock.
+- **A room plans a study; only the church preaches a sermon.** Since Sept 2026 the room lane's
+  noun is *study* in every user-facing string, and the form asks what it is before when it
+  meets. `ChurchServices.kind` keeps the word `'gathering'` because it discriminates behaviour
+  (one row per date) rather than vocabulary.
+- **A one-off time is the church plan's field alone.** Every space lane writes
+  `serviceTime: null`; a room's hour lives on its meeting rhythm.
 - **One next gathering per context you joined, never a schedule of any context.**
 - **Review is never shared.** `Notes.startedFromServiceId` has a grep-enforced reader
   allowlist. A member seeing their *own* progress is not an exception to this — the rule

--- a/docs/future/SPACES_PLANNER_AND_GATHERINGS.md
+++ b/docs/future/SPACES_PLANNER_AND_GATHERINGS.md
@@ -1,5 +1,20 @@
 # Shared Spaces, the Planner, and Where a Gathering Shows Up
 
+> **Superseding change, September 10, 2026 — a room plans a *study*, not a gathering.**
+> The word "gathering" is gone from every user-facing string on a room's plan; `itemNoun` is
+> `'study'` and the primary action reads `New study`. The planner's form was reordered to match:
+> title and passage first, the series next, then a collapsed **When** section holding the date,
+> the room's rhythm, the calendar and the church's slots. A new study can declare its run length
+> on create ("Just this week" / "4 weeks" / …), which chains the existing repeat route. In the
+> room itself, the Current Thread block now outranks the Coming up card, and that card's eyebrow
+> names the series rather than the day. **This doc's title is therefore stale** — kept so the
+> file's history and inbound links survive, since renaming it would strand both. Everything
+> below about *placement* still holds; the decision log's last row records the change.
+>
+> `ChurchServices.kind` still reads `'gathering' | 'content'`. It is server-derived and baked
+> into `ChurchServices_space_date_unique`, and it discriminates behaviour (one row per date for a
+> room, many for a publishing queue) rather than vocabulary.
+
 **Status:** **Decided** (August 21, 2026) — Option B, with placement and bounds settled; see
 [Option B in detail](#option-b-in-detail). Most of what this item originally asked for was already
 built, **including the placement itself**: Home already draws a row per context, on the four-day
@@ -45,7 +60,7 @@ several of that assessment's findings have since been closed.
 
 | The premise | What is actually true |
 |---|---|
-| "Add a gathering" is a feature to design | It is one of **three labels for one create action**. `planVocabulary()` (`spa/src/lib/church-services.ts:509`) returns "Add a sermon" (church plan), "Add a study" (channel), or "Add a gathering" (a room that meets). `planKind` is server-derived from the space, never chosen by the client. |
+| "Add a gathering" is a feature to design | It is one of **three scopes on one create action**, and as of Sept 10, 2026 they use **two words**: `planVocabulary()` returns `New sermon` (church plan) or `New study` (a channel *and* a room that meets). A room and a channel share the label and differ in `addOpens` — a channel opens the series sheet, a room the one-row editor. `planKind` is server-derived from the space, never chosen by the client. |
 | Rooms retype the date of every gathering | `rhythmDates()` (`church-services.ts:383`) offers the next six dates from the room's declared rhythm, wired into the entry editor (`PrototypeSermonEditorFields.tsx:181`). It offers dates; it does not schedule or recur, and its own comment says so. |
 | Only church rooms can plan | A churchless shared space can hold a plan, and the Planner row appears in its own view for whoever can manage it — with the reasoning recorded inline: "otherwise the one person who could plan the first gathering is the one person who cannot find where" (`PrototypeSpaceHub.tsx:425-440`). |
 | Only staff can see the plan | The read is membership-gated. Members of the room see what it is on, and get the same one tap into notes that the church card gives (`PrototypeSpaceComingUp.tsx`). |
@@ -217,4 +232,5 @@ page, and the rows follow from it.
 | 2026-08-21 | **Bounded by the four-day wall, no cap.** | `SERVICE_GRACE_DAYS = 4` already governs the church card and is tied to the engagement research behind harvous.com/about. A cap would silently hide a gathering someone agreed to attend; the wall means a busy Tuesday is Tuesday's problem and not every day's. |
 | 2026-08-21 | **One "Coming up" group, soonest first** — church service and room gatherings interleaved by date, not separated by kind. | One idea rather than two lists for the same kind of thing. Means "This Sunday" stops being its own furniture and becomes the church's row in a shared group. |
 | 2026-08-21 | **Corrected: the placement is already built; the remaining work is server-side.** No decision above changes. | Checked against `main` before building rather than after. `selectHomeCards` already emits a context row per space on the four-day wall, soonest-first — the recommendation had been implemented for church-org spaces. The gap is a church-scoped data source in three places, one of which (`listViewerPlanSources`) decides which spaces' plans a viewer may read. That the existing rows already behave the way this doc argued for is the best evidence the calls were right. |
+| 2026-09-10 | **A room plans a study, not a gathering** — the noun, the form's field order, run-length on create, and the room's own section order all follow from it. | Derek's call: the planner's primary use is the content, and the times to meet are secondary. The form stated the opposite, opening with five time controls above the title, and the room did too, with the meeting card above the study. Two bugs fell out of the same region: the one-off time input was offered on space plans whose routes discard `serviceTime`, and the note banner called a churchless room's entry "the next sermon". |
 | 2026-08-21 | **One card for everyone; no leader variant.** | A leader reaches the Planner from the room itself. A role-conditional card state is a class of bug this codebase has hit before. The "you lead this and next week is empty" cue is a good idea, deferred rather than rejected — it can be added later without disturbing anything above. |

--- a/docs/future/STUDY_PLANS.md
+++ b/docs/future/STUDY_PLANS.md
@@ -9,6 +9,15 @@ A **study plan** is a sequence of steps a room walks together: week one, week tw
 three. It is the thing a church hands its congregation when a series is more than one
 sermon.
 
+**Not the same object as a room's plan, and the words now nearly collide.** Since Sept 2026 a
+room's planner calls each of its entries a *study* (see
+[SPACES_PLANNER_AND_GATHERINGS.md](./SPACES_PLANNER_AND_GATHERINGS.md)), and a new one can
+declare a run length on create. That produces `ChurchServices` rows — the plan of what the room
+will study, week by week. A **study plan** in this document is the `Threads` row with
+`mode='sequence'` that a *series* is published into, which is what members actually walk. The
+bridge between them is unchanged: group a run of plan rows under a `ChurchSeries`, then publish
+the series.
+
 ---
 
 ## What it is made of

--- a/server/routes/church-space-plan.ts
+++ b/server/routes/church-space-plan.ts
@@ -126,7 +126,7 @@ function planKindForSpace(space: { type: string | null; orgId: string | null }):
 
 /** "Gathering" is a lie for a channel; "entry" is honest for both. */
 function notFoundError(kind: PlanKind): string {
-  return kind === 'content' ? 'Entry not found' : 'Gathering not found';
+  return kind === 'content' ? 'Entry not found' : 'Study not found';
 }
 
 type SpaceSermonInput = {
@@ -385,10 +385,12 @@ app.post('/api/church/spaces/:spaceId/services/create', requireAuth, rateLimit('
       if (isUniqueViolation(error, 'ChurchServices_space_date_unique')) {
         return c.json(
           {
-            /* Only reachable for gatherings — the unique index no longer
-               covers content, because a channel publishing twice in a day is
-               ordinary rather than a mistake. */
-            error: 'This ministry already has a gathering planned that day.',
+            /* Only reachable for `kind='gathering'` — the unique index no
+               longer covers content, because a channel publishing twice in a
+               day is ordinary rather than a mistake. The column keeps that
+               word; the sentence does not, because a room plans a study and a
+               churchless one is not a ministry. */
+            error: 'This space already has a study planned that day.',
             code: 'SERVICE_DATE_TAKEN',
           },
           409,
@@ -496,10 +498,12 @@ app.post('/api/church/spaces/:spaceId/services/update', requireAuth, rateLimit('
       if (isUniqueViolation(error, 'ChurchServices_space_date_unique')) {
         return c.json(
           {
-            /* Only reachable for gatherings — the unique index no longer
-               covers content, because a channel publishing twice in a day is
-               ordinary rather than a mistake. */
-            error: 'This ministry already has a gathering planned that day.',
+            /* Only reachable for `kind='gathering'` — the unique index no
+               longer covers content, because a channel publishing twice in a
+               day is ordinary rather than a mistake. The column keeps that
+               word; the sentence does not, because a room plans a study and a
+               churchless one is not a ministry. */
+            error: 'This space already has a study planned that day.',
             code: 'SERVICE_DATE_TAKEN',
           },
           409,
@@ -609,7 +613,7 @@ app.post('/api/church/spaces/:spaceId/services/repeat', requireAuth, rateLimit('
           error:
             planKindForSpace(gate.space) === 'content'
               ? 'Give this a date first — repeat counts weeks from one.'
-              : 'Give this gathering a date first — repeat counts weeks from one.',
+              : 'Give this study a date first — repeat counts weeks from one.',
           code: 'BAD_REQUEST',
         },
         400,

--- a/spa/src/lib/__tests__/church-services.test.ts
+++ b/spa/src/lib/__tests__/church-services.test.ts
@@ -339,10 +339,30 @@ describe('planVocabulary', () => {
     expect(planVocabulary({ onSpacePlan: false }).addLabel).toBe('New sermon');
   });
 
-  it('calls a shared space a gathering', () => {
+  it('calls a shared space\u2019s entry a study', () => {
+    /*
+      The room used to say "gathering", which put the meeting ahead of the thing
+      being studied. What a room decides is what it will study; when it meets is
+      an attribute of that, and usually already declared as the room's rhythm.
+    */
     const v = planVocabulary({ onSpacePlan: true, planKind: 'gathering' });
-    expect(v.addLabel).toBe('New gathering');
-    expect(v.itemNoun).toBe('gathering');
+    expect(v.addLabel).toBe('New study');
+    expect(v.itemNoun).toBe('study');
+  });
+
+  it('keeps the room on the one-row editor, unlike a channel', () => {
+    /*
+      A room and a channel now share `addLabel` and differ in `addOpens` — which
+      is what that field exists to carry. A channel's unit of work is a run of
+      weeks, so it opens the series sheet; a room commits to one study and then
+      repeats it across the weeks it needs. If the two branches are ever
+      collapsed because their labels match, the channel loses the series sheet.
+    */
+    const room = planVocabulary({ onSpacePlan: true, planKind: 'gathering' });
+    const channel = planVocabulary({ onSpacePlan: true, planKind: 'content' });
+    expect(room.addLabel).toBe(channel.addLabel);
+    expect(room.addOpens).toBe('entry');
+    expect(channel.addOpens).toBe('series');
   });
 
   it('makes the study a channel’s primary action — it publishes, it does not meet', () => {
@@ -384,8 +404,16 @@ describe('planVocabulary', () => {
     );
   });
 
-  it('reads an absent kind as a gathering, for payloads cached before it shipped', () => {
-    expect(planVocabulary({ onSpacePlan: true }).addLabel).toBe('New gathering');
+  it('reads an absent kind as a room, for payloads cached before it shipped', () => {
+    /*
+      A payload cached before `planKind` shipped arrives without it, and must
+      read as a room rather than a channel — the labels match now, so
+      `addOpens` is what actually proves which branch answered.
+    */
+    const v = planVocabulary({ onSpacePlan: true });
+    expect(v.addLabel).toBe('New study');
+    expect(v.addOpens).toBe('entry');
+    expect(v.itemNoun).toBe('study');
   });
 
   it("never offers a channel the church's own wording", () => {
@@ -398,7 +426,7 @@ describe('planVocabulary', () => {
   it('does not call a churchless room a ministry', () => {
     // "Ministry" is a church's word for a room. A Tuesday book club is not one.
     const v = planVocabulary({ onSpacePlan: true, planKind: 'gathering', hasChurch: false });
-    expect(v.addLabel).toBe('New gathering');
+    expect(v.addLabel).toBe('New study');
     expect(v.emptyWritable).not.toContain('ministry');
     expect(v.emptyWritable).not.toContain('church');
   });

--- a/spa/src/lib/__tests__/compose-purpose.test.ts
+++ b/spa/src/lib/__tests__/compose-purpose.test.ts
@@ -31,14 +31,36 @@ describe('notePurposeModel', () => {
   });
 
   it('does not claim "this week" for a note started in a room', () => {
-    // "Coming up" is the room's *next* sermon, which can be weeks out — the one place
+    // "Coming up" is the room's *next* entry, which can be weeks out — the one place
     // the Home wording would have been a small lie.
     const purpose = notePurposeModel({
       composePurpose: null,
       startedFromServiceTitle: 'The Weight of Grace',
       startedInChurchSpace: true,
     });
-    expect(purpose?.label).toBe('The next sermon');
+    expect(purpose?.label).toBe('The next study');
+  });
+
+  it('never calls a room\u2019s entry a sermon — only the church preaches one', () => {
+    /*
+      `startedInChurchSpace` is true for any space that is not My Home, so this
+      label reaches a churchless book club too. A room plans a study; the word
+      "sermon" belongs to the church-wide plan and to Home's "This Sunday".
+    */
+    const room = notePurposeModel({
+      composePurpose: null,
+      startedFromServiceTitle: 'The Weight of Grace',
+      startedInChurchSpace: true,
+    });
+    expect(room?.label).not.toContain('sermon');
+
+    // And the Home surface keeps it, because there it is true.
+    const home = notePurposeModel({
+      composePurpose: null,
+      startedFromServiceTitle: 'The Weight of Grace',
+      startedInChurchSpace: false,
+    });
+    expect(home?.label).toBe("This week's sermon");
   });
 
   it('still says nothing when there was no service to start from', () => {

--- a/spa/src/lib/church-services.ts
+++ b/spa/src/lib/church-services.ts
@@ -475,10 +475,22 @@ export function sermonTimeLabel(
 /**
  * What a plan calls the things in it.
  *
- * Three answers, not two: the church preaches sermons, a Shared Space gathers,
- * and a ministry channel publishes. A channel was being asked to "Add a
- * gathering" for something nobody attends — the word promised a room and a
- * time that a published study does not have.
+ * Three scopes, two words. The church preaches **sermons**; a room that meets
+ * and a channel that publishes both plan a **study**.
+ *
+ * The room used to say "gathering", and the word put the meeting ahead of the
+ * thing being studied — which is backwards. What a room decides is what it is
+ * going to study; when it meets is an attribute of that, and one the room has
+ * usually already declared as its rhythm. A study can run one week or eight,
+ * and calling it a gathering made an eight-week run sound like eight unrelated
+ * evenings.
+ *
+ * **A room and a channel share `addLabel` and differ in `addOpens`**, which is
+ * exactly the distinction that field exists to carry: a channel's usual unit of
+ * work is a run of weeks, so its primary opens the series sheet, while a room
+ * makes one study that may then repeat. Sharing the label is deliberate; if the
+ * two branches are ever collapsed because their labels match, the channel loses
+ * the series sheet. A test asserts the pair.
  */
 export type PlanVocabulary = {
   /**
@@ -491,6 +503,9 @@ export type PlanVocabulary = {
    * so it says New — and the Planner header stopped using both verbs at once
    * for the same kind of act, which is what it did while this read
    * "Add a gathering" beside "New series".
+   *
+   * Not unique across scopes: a room and a channel both read "New study". See
+   * the type docblock for why, and `addOpens` for what still separates them.
    */
   addLabel: string;
   /**
@@ -570,15 +585,22 @@ export function planVocabulary(
       readOnlyRole: 'A pastor or admin changes what this channel publishes.',
     };
   }
+  /*
+    A room that meets. The study is the object here for the same reason it is on
+    a channel — it is what the room decided — but the primary opens the one-row
+    editor rather than the series sheet: a room commits to a study and then
+    repeats it across the weeks it needs, which is the shape "how many weeks" on
+    the create form produces.
+  */
   return {
-    addLabel: 'New gathering',
+    addLabel: 'New study',
     addOpens: 'entry',
     secondaryAddLabel: null,
     emptyWritable:
       scope.hasChurch === false
         ? 'Plan what this group studies. Everyone in the space sees what is coming up.'
         : 'Plan what this ministry studies. Its members see it inside the space.',
-    itemNoun: 'gathering',
+    itemNoun: 'study',
     readOnlyRole: 'Whoever leads this space arranges its plan.',
   };
 }

--- a/spa/src/lib/compose-purpose.ts
+++ b/spa/src/lib/compose-purpose.ts
@@ -113,15 +113,24 @@ export function notePurposeModel(input: {
     the same words. And "Writing notes for", because writing notes is what this whole
     surface is; a register above the paper does not need to announce it.
 
-    "Sermon" is the product's own word for both of these — `sermonEyebrow`,
-    `ChurchSermon`, `starterFolderForSermon`. "Gathering" only ever appeared in a code
-    docblock.
+    **The two surfaces name two different things, and only one is a sermon.**
+    "This Sunday" on Home names the *church's* sermon, and says so. "Coming up"
+    names a room's own plan entry — and a room plans a **study**, which is the
+    word its planner uses and the only one true of a churchless room. A Tuesday
+    book club reading Habakkuk was being handed a banner reading "The next
+    sermon"; `startedInChurchSpace` is true for any space that is not My Home,
+    church or not, so that was every room.
+
+    An earlier note here claimed "Sermon" was the product's word for both of
+    these and that "Gathering" only ever appeared in a code docblock. Both halves
+    were wrong: the room's noun was user-facing in the planner header, the title
+    placeholder, the date-picker label and a 409 message, and it is now "study".
   */
   const service = input.startedFromServiceTitle?.trim();
   if (service && input.readingInStartedContext !== false) {
     return {
       kind: 'service',
-      label: input.startedInChurchSpace ? 'The next sermon' : "This week's sermon",
+      label: input.startedInChurchSpace ? 'The next study' : "This week's sermon",
       actionLabel: null,
     };
   }

--- a/spa/src/pages/dev/design-system/DesignSystemScenePreview.tsx
+++ b/spa/src/pages/dev/design-system/DesignSystemScenePreview.tsx
@@ -450,6 +450,7 @@ function InputsScene() {
   const [search, setSearch] = useState('James');
   const [name, setName] = useState('Small group');
   const [inspectorTitle, setInspectorTitle] = useState('Romans overview');
+  const [scrolled, setScrolled] = useState('Search the library');
 
   return (
     <div className="pds-gallery-stack pds-gallery-stack--narrow">
@@ -486,6 +487,40 @@ function InputsScene() {
           placeholder="Title"
         />
       </label>
+
+      {/*
+        The case the fields above cannot show: one inside a scroller.
+
+        A field is the one focusable thing that is routinely `width: 100%`
+        inside a column that scrolls, and the rails that hold them — the
+        planner editor, the inspector, the review dock — zero their side
+        padding to buy width on a narrow panel. An outward ring is painted
+        outside the border box, so the scroller crops its left and right edges
+        and it reads as two stray brackets. Focus this one: the ring stays
+        whole because the field's ring is inset.
+
+        Deliberately reproduced rather than described, because every field
+        above sits in open space where the bug cannot appear — which is why it
+        reached three surfaces before anyone caught it.
+      */}
+      <PrototypeSectionHeader>Field inside a scroller</PrototypeSectionHeader>
+      <p className="pds-caption">
+        Focus rings on fields are <strong>inset</strong>, so a scrolling ancestor cannot crop
+        them. Note <code>overflow-y: auto</code> also makes <code>overflow-x</code> compute to{' '}
+        <code>auto</code>, so a column that only meant to scroll down clips sideways too.
+      </p>
+      <div className="pds-gallery-scroller">
+        <label className="proto-settings-field">
+          <span className="proto-settings-field__label">Full-width, zero side padding</span>
+          <input
+            type="text"
+            className="proto-settings-field__input proto-create-folder-sheet__name-input"
+            value={scrolled}
+            onChange={(e) => setScrolled(e.target.value)}
+            placeholder="Focus me"
+          />
+        </label>
+      </div>
     </div>
   );
 }

--- a/spa/src/pages/prototype/PrototypeSermonEditorFields.tsx
+++ b/spa/src/pages/prototype/PrototypeSermonEditorFields.tsx
@@ -111,7 +111,20 @@ export interface PrototypeSermonEditorFieldsProps {
    * every entry deliberately. Absent, or with a null interval, the field behaves
    * exactly as it did before: one seeded default and a picker.
    */
-  rhythm?: { meetingDay: number | null; intervalDays: number | null };
+  rhythm?: {
+    meetingDay: number | null;
+    intervalDays: number | null;
+    /**
+     * The room's own hour, for the collapsed **When** summary only.
+     *
+     * Never written to the row: every space lane stores `serviceTime: null`,
+     * because the hour belongs to the room's rhythm rather than to one study.
+     * It is here so the summary can answer "when" completely while closed —
+     * the room's card already says "This Tuesday · 7:00 PM", and a chip that
+     * dropped the hour made the two surfaces disagree.
+     */
+    meetingTime?: string | null;
+  };
   /**
    * Extra fields rendered at the end of the scrolling region, above the footer.
    * The compact sheet puts the resources picker here; the docked pane scrolls
@@ -228,10 +241,35 @@ export default function PrototypeSermonEditorFields({
   const [seriesId, setSeriesId] = useState<string | null>(null);
   const [reference, setReference] = useState('');
   const [starterTemplateId, setStarterTemplateId] = useState('');
-  const [datePickerOpen, setDatePickerOpen] = useState(false);
+  /*
+    Whether the When section is expanded.
+
+    **Open on the church's plan, closed on a room's.** On the church's own plan
+    a sermon genuinely *is* a slot on a Sunday, and the slots to tick live in
+    this section — collapsing it would hide the control that decides which of
+    two Sunday services hears the sermon. A room's date is already implied by
+    its rhythm, so there the section opens only when asked.
+
+    An undated idea opens it regardless: giving the thing a date is the whole
+    reason to open an idea, and `createDefaultDate: null` is what the board's
+    Ideas column passes.
+  */
+  const [whenOpen, setWhenOpen] = useState(
+    () => planSpaceId == null || createDefaultDate === null,
+  );
   /** "Repeat weekly" is closed until asked for — most sermons are one week. */
   const [repeatOpen, setRepeatOpen] = useState(false);
   const [repeatWeeks, setRepeatWeeks] = useState(7);
+  /**
+   * How many weeks a *new* study runs, counted inclusively — 1 is a one-off.
+   *
+   * A study that runs eight weeks is one decision, and it was previously two
+   * sittings: create the first week, reopen it, then find "Repeat weekly". The
+   * run length is a property of the study, so it is asked while the study is
+   * being described. Defaults to 1 because most entries are one week and the
+   * common path must stay a single click.
+   */
+  const [createWeeks, setCreateWeeks] = useState(1);
   /** Not an error: the run may have been cut short and still be a success. */
   const [notice, setNotice] = useState<string | null>(null);
   const [seriesListOpen, setSeriesListOpen] = useState(false);
@@ -262,8 +300,14 @@ export default function PrototypeSermonEditorFields({
     const row = serviceRef.current;
     setError(null);
     setNotice(null);
-    setDatePickerOpen(false);
+    /*
+      Back to the lane's default rather than flatly closed. Retargeting the
+      docked pane at another row re-runs this, and forcing it shut would collapse
+      the church lane's slot pickers — the one section that lane needs open.
+    */
+    setWhenOpen(planSpaceId == null || (row ? !row.serviceDate : createDefaultDate === null));
     setRepeatOpen(false);
+    setCreateWeeks(1);
     setSeriesListOpen(false);
     setServiceDate(
       row
@@ -281,7 +325,7 @@ export default function PrototypeSermonEditorFields({
     setStarterTemplateId(row?.starterTemplateId ?? '');
     setPickedNoteId(row?.viewerDraftNoteId ?? null);
     setPickedNoteTitle(row?.viewerDraftNoteTitle ?? null);
-  }, [active, serviceKey, createDefaultDate]);
+  }, [active, serviceKey, createDefaultDate, planSpaceId]);
 
   /*
     Drop any service that no longer falls on the chosen day.
@@ -306,12 +350,12 @@ export default function PrototypeSermonEditorFields({
   // The calendar is taller than the body it opens into, so opening it would
   // otherwise leave most of it below the fold.
   useEffect(() => {
-    if (!datePickerOpen) return;
+    if (!whenOpen) return;
     const raf = requestAnimationFrame(() => {
       datePickerRef.current?.scrollIntoView({ block: 'nearest' });
     });
     return () => cancelAnimationFrame(raf);
-  }, [datePickerOpen]);
+  }, [whenOpen]);
 
   /*
     Passage history is prep, never a gate on saving. Debounced so a half-typed
@@ -364,7 +408,7 @@ export default function PrototypeSermonEditorFields({
   */
   useEffect(() => {
     onLayoutChange?.();
-  }, [onLayoutChange, serviceDate, title, datePickerOpen, showSeriesList, historyNotes.length]);
+  }, [onLayoutChange, serviceDate, title, whenOpen, showSeriesList, historyNotes.length]);
 
   /*
     The church's templates belong to a plan the church is behind — its own, or a
@@ -437,6 +481,53 @@ export default function PrototypeSermonEditorFields({
   const sameDaySlots = serviceDate ? serviceTimes.filter((slot) => slot.dayOfWeek === chosenDay) : [];
   const isEditing = Boolean(service);
   const isUnscheduled = !serviceDate;
+  /**
+   * The church's own plan, as opposed to any room's.
+   *
+   * `planKind` separates a channel from a room; this separates both from the
+   * church. Only `spaceId IS NULL` rows can carry a `serviceTime` or claim a
+   * recurring slot — every space lane writes `serviceTime: null` server-side.
+   */
+  const isChurchLane = planSpaceId == null;
+
+  /*
+    What the collapsed When section says.
+
+    Reuses the same two formatters the card and the list already render dates
+    and times with, so the summary cannot drift from what the plan shows
+    elsewhere. The slot labels win over a one-off time for the same reason the
+    card prefers them: a sermon at the usual 10:45 is at the usual service, and
+    the one-off column only speaks when no usual service applies.
+  */
+  const whenSummary = useMemo(() => {
+    if (isUnscheduled) return 'No date yet';
+    const day = formatServiceDate(serviceDate);
+    const claimed = serviceTimes.filter((slot) => serviceTimeIds.includes(slot.id));
+    if (claimed.length > 0) {
+      return `${day} · ${claimed.map((slot) => formatServiceTime(slot.startTime)).join(', ')}`;
+    }
+    if (serviceTime) return `${day} · ${formatServiceTime(serviceTime)}`;
+    /* A room's standing hour. Display only — see `rhythm.meetingTime`. */
+    if (rhythm?.meetingTime) return `${day} · ${formatServiceTime(rhythm.meetingTime)}`;
+    return day;
+  }, [isUnscheduled, serviceDate, serviceTimes, serviceTimeIds, serviceTime, rhythm?.meetingTime]);
+
+  /*
+    Fold the section back up once the date is settled — but only when the date
+    is all it holds.
+
+    On a room's plan it is: there are no slots and no one-off time, so picking a
+    date has answered the whole question. On the church's plan the slots sit
+    underneath and are the next thing to tick, so collapsing there would hide
+    the control the pastor came for. `chosenDay` cannot be reused here because
+    it is derived from the *current* `serviceDate`, and this runs while that
+    state update is still pending.
+  */
+  const collapseWhenSettled = (iso: string) => {
+    const day = parseLocalDateInput(iso)?.getDay() ?? null;
+    const slotsForDay = serviceTimes.filter((slot) => slot.dayOfWeek === day);
+    if (slotsForDay.length === 0 && !isChurchLane) setWhenOpen(false);
+  };
   const canSubmit =
     title.trim().length > 0 && (Boolean(serviceDate) || allowNullDate) && !actions.isPending;
 
@@ -518,6 +609,47 @@ export default function PrototypeSermonEditorFields({
         );
         return;
       }
+
+      /*
+        The rest of the run, through the same route "Repeat weekly" uses.
+
+        **Deliberately a second write rather than a `weeks` field on create.**
+        The repeat route already owns the weekly arithmetic, the 12-week cap,
+        and the rule that it stops at the first date already spoken for — and
+        that route is contract-tested. A `weeks` parameter on create would
+        restate all of it and force a fresh decision about whether a mid-run
+        collision should abort a study whose first week is perfectly good.
+
+        The cost is that this is **not atomic**, and the handling below is the
+        whole point: a four-week study whose third week is taken leaves three
+        real rows, which is a short plan rather than a failed one. It reports
+        what it managed and leaves the editor open so the gap is visible. Only
+        a run that completed closes the editor.
+      */
+      if (!isEditing && serviceId && createWeeks > 1) {
+        try {
+          const res = await actions.mutateAsync({
+            kind: 'repeat',
+            serviceId,
+            weeks: createWeeks - 1,
+          });
+          const result = res as { services?: unknown[]; stoppedAt?: string | null };
+          if (result?.stoppedAt) {
+            const added = (result?.services?.length ?? 0) + 1;
+            setNotice(
+              `Planned ${added} of ${createWeeks} weeks. Stopped at ${formatServiceDate(result.stoppedAt)} — something is already planned then.`,
+            );
+            return;
+          }
+        } catch {
+          /* The study itself saved; only the run fell short. Naming the first
+             week keeps this a partial success rather than an error. */
+          setNotice(
+            `Saved the first week, but the rest of the run didn't plan. Open it again to repeat.`,
+          );
+          return;
+        }
+      }
       onDone();
     })();
   };
@@ -572,167 +704,6 @@ export default function PrototypeSermonEditorFields({
   return (
     <>
       <div className="proto-service-editor">
-        {/*
-          The calendar used to be open permanently: 394px of a 520px modal for
-          the one field that already has a sensible default (the coming Sunday),
-          which pushed the title, the passage and the save button off screen. It
-          opens on demand now, and closes as soon as a date is chosen.
-        */}
-        <label className="proto-inspector-section-title proto-create-folder-sheet__field-label">
-          Date
-        </label>
-        <div className="proto-service-editor__date-row">
-          <button
-            type="button"
-            className="proto-service-editor__date-chip"
-            aria-expanded={datePickerOpen}
-            onClick={() => setDatePickerOpen((open) => !open)}
-          >
-            <Icon name="calendar" size={12} aria-hidden />
-            <span className="proto-service-editor__date-value">{formatServiceDate(serviceDate)}</span>
-            <Icon name={datePickerOpen ? 'caret-up' : 'caret-down'} size={10} aria-hidden />
-          </button>
-          {/*
-            Unscheduling from inside the form, for the keyboard path the board's
-            drag covers with a mouse. Hidden when there is no date to clear.
-          */}
-          {allowNullDate && !isUnscheduled ? (
-            <button
-              type="button"
-              className="proto-sheet-quiet-action"
-              onClick={() => {
-                setServiceDate('');
-                setDatePickerOpen(false);
-              }}
-            >
-              Move to ideas
-            </button>
-          ) : null}
-        </div>
-        {/*
-          The room's own rhythm, offered as dates.
-
-          `schema.ts` says of `meetingDay`/`publishCadence`: "Nothing here
-          schedules, reminds, or recurs; whoever runs the room still enters every
-          gathering by hand." That stays true — this only stops them retyping a
-          date the room already declares. Nothing recurs and nothing fires.
-
-          Only while creating: an existing entry has a date, and offering to move
-          it onto the rhythm is a different question nobody asked.
-        */}
-        {!service && rhythmSuggestions.length > 0 ? (
-          <div className="proto-rhythm-dates">
-            {rhythmSuggestions.map((iso) => (
-              <button
-                key={iso}
-                type="button"
-                className={`proto-chip${iso === serviceDate ? ' proto-chip--selected' : ''}`}
-                aria-pressed={iso === serviceDate}
-                onClick={() => {
-                  setServiceDate(iso);
-                  setDatePickerOpen(false);
-                }}
-              >
-                {formatServiceDate(iso)}
-              </button>
-            ))}
-          </div>
-        ) : null}
-
-        {datePickerOpen ? (
-          <div ref={datePickerRef}>
-            <ProtoDatePicker
-              value={serviceDate}
-              min={earliestSelectableDate()}
-              onChange={(iso) => {
-                setServiceDate(iso);
-                // Picking a date is the whole reason it was open.
-                setDatePickerOpen(false);
-              }}
-              aria-label={`${noun.charAt(0).toUpperCase()}${noun.slice(1)} date`}
-            />
-          </div>
-        ) : null}
-
-        {/*
-          Checkboxes, not a single select: one sermon is preached at both Sunday
-          morning services, while the evening service hears a different one.
-          Only the chosen day's services are offered — a Sunday sermon has no
-          business claiming the Wednesday slot, and an undated idea has no day
-          to claim one on at all.
-        */}
-        {sameDaySlots.length > 0 ? (
-          <>
-            <label className="proto-inspector-section-title proto-create-folder-sheet__field-label">
-              <span>Preached at</span>
-              <span className="proto-service-editor__optional">optional</span>
-            </label>
-            <div className="proto-service-editor__slots" role="group" aria-label="Services">
-              {sameDaySlots.map((slot) => {
-                const checked = serviceTimeIds.includes(slot.id);
-                return (
-                  <label key={slot.id} className="proto-service-editor__slot">
-                    {/*
-                      The input stays and stays real — it carries the checked
-                      state, the keyboard, and the label association. It is
-                      visually replaced, not removed, so the orb the rest of
-                      the app selects with is what you see here too.
-                    */}
-                    <input
-                      type="checkbox"
-                      className="proto-service-editor__slot-input"
-                      checked={checked}
-                      onChange={() =>
-                        setServiceTimeIds((ids) =>
-                          checked ? ids.filter((id) => id !== slot.id) : [...ids, slot.id],
-                        )
-                      }
-                    />
-                    <span className="proto-service-editor__slot-orb" aria-hidden>
-                      {checked ? (
-                        <span className="proto-accent-check-orb proto-accent-check-orb--selected">
-                          <Icon name="check" size={9} />
-                        </span>
-                      ) : (
-                        <span className="proto-select-orb-idle" />
-                      )}
-                    </span>
-                    <span>
-                      {formatServiceTime(slot.startTime)}
-                      {slot.label ? ` · ${slot.label}` : ''}
-                    </span>
-                  </label>
-                );
-              })}
-            </div>
-          </>
-        ) : null}
-
-        {/*
-          The escape hatch, shown only when no usual service applies: a
-          Christmas Eve at 17:00 should not become a permanent Thursday slot on
-          the church's week. `<input type="time">` ignores placeholder, so the
-          hint has to be a sibling caption.
-        */}
-        {!isUnscheduled && planKind !== 'content' && serviceTimeIds.length === 0 ? (
-          <>
-            <label
-              className="proto-inspector-section-title proto-create-folder-sheet__field-label"
-              htmlFor="proto-service-time"
-            >
-              <span>{sameDaySlots.length > 0 ? 'Or a one-off time' : 'Time'}</span>
-              <span className="proto-service-editor__optional">optional</span>
-            </label>
-            <input
-              id="proto-service-time"
-              type="time"
-              className="proto-create-folder-sheet__name-input"
-              value={serviceTime}
-              onChange={(e) => setServiceTime(e.target.value)}
-            />
-          </>
-        ) : null}
-
         <label
           className="proto-inspector-section-title proto-create-folder-sheet__field-label"
           htmlFor="proto-service-title"
@@ -889,6 +860,236 @@ export default function PrototypeSermonEditorFields({
             </p>
           ) : null}
         </div>
+
+        {/*
+          How long this study runs, asked while the study is being described.
+
+          A run is a property of the study rather than of a date: "we're doing
+          eight weeks in Romans" is one decision, and it used to take two
+          sittings — save week one, reopen it, find "Repeat weekly" under the
+          footer. That control stays for a run decided later, which is a real
+          case; this one is for a run decided up front.
+
+          Only on create, and only with a date to count from. An undated idea
+          has no first week, and the repeat route refuses one outright ("Give
+          this study a date first"), so offering the choice there would promise
+          something the server declines.
+        */}
+        {!isEditing && !isUnscheduled ? (
+          <>
+            <label className="proto-inspector-section-title proto-create-folder-sheet__field-label">
+              <span>How long</span>
+              <span className="proto-service-editor__optional">optional</span>
+            </label>
+            <ProtoSelectMenu
+              label="How long this study runs"
+              className="proto-service-editor__weeks-select"
+              value={createWeeks}
+              disabled={actions.isPending}
+              onChange={setCreateWeeks}
+              /* Totals, not "more weeks" — on create the first week does not
+                 exist yet, so "4 weeks" is the whole study rather than five.
+                 The edit-side control counts the other way for the same reason,
+                 and each says which in its own label. */
+              options={[1, 4, 6, 8, 12].map((weeks) => ({
+                value: weeks,
+                label: weeks === 1 ? 'Just this week' : `${weeks} weeks`,
+              }))}
+            />
+            {createWeeks > 1 ? (
+              <p className="proto-caption proto-service-editor__series-hint">
+                {`Plans ${createWeeks} weekly entries from ${formatServiceDate(serviceDate)}.`}
+              </p>
+            ) : null}
+          </>
+        ) : null}
+
+        {/*
+          When, and everything that sets it — the date, the room's rhythm, the
+          calendar, the church's service slots, a one-off time.
+
+          **Last, and collapsed on a room's plan.** What a room decides is what
+          it is going to *study*; when it meets is an attribute of that, and one
+          the room has usually already declared as its rhythm — so the date
+          arrives correct and the section only has to say so. It led the form
+          for one historical reason: on the church's plan a sermon really is a
+          slot on a Sunday, and that lane still opens expanded (see `whenOpen`).
+
+          The calendar itself stays on demand for the reason it always was:
+          394px of a 520px modal for a field that already has a sensible
+          default pushed the title, the passage and the save button off screen.
+        */}
+        <label className="proto-inspector-section-title proto-create-folder-sheet__field-label">
+          When
+        </label>
+        <div className="proto-service-editor__date-row">
+          {/*
+            The chip is the whole section's control, not just the calendar's.
+            It already read as "the current selection first, a control second",
+            which is exactly what a collapsed When needs to be — so there is no
+            second disclosure header above it duplicating the value it shows.
+          */}
+          <button
+            type="button"
+            className="proto-service-editor__date-chip"
+            aria-expanded={whenOpen}
+            onClick={() => setWhenOpen((open) => !open)}
+          >
+            <Icon name="calendar" size={12} aria-hidden />
+            <span className="proto-service-editor__date-value">{whenSummary}</span>
+            <Icon name={whenOpen ? 'caret-up' : 'caret-down'} size={10} aria-hidden />
+          </button>
+          {/*
+            Unscheduling from inside the form, for the keyboard path the board's
+            drag covers with a mouse. Hidden when there is no date to clear.
+          */}
+          {allowNullDate && !isUnscheduled ? (
+            <button
+              type="button"
+              className="proto-sheet-quiet-action"
+              onClick={() => {
+                setServiceDate('');
+                setWhenOpen(true);
+              }}
+            >
+              Move to ideas
+            </button>
+          ) : null}
+        </div>
+        {/*
+          The room's own rhythm, offered as dates.
+
+          `schema.ts` says of `meetingDay`/`publishCadence`: "Nothing here
+          schedules, reminds, or recurs; whoever runs the room still enters every
+          gathering by hand." That stays true — this only stops them retyping a
+          date the room already declares. Nothing recurs and nothing fires.
+
+          Only while creating: an existing entry has a date, and offering to move
+          it onto the rhythm is a different question nobody asked.
+        */}
+        {whenOpen && !service && rhythmSuggestions.length > 0 ? (
+          <div className="proto-rhythm-dates">
+            {rhythmSuggestions.map((iso) => (
+              <button
+                key={iso}
+                type="button"
+                className={`proto-chip${iso === serviceDate ? ' proto-chip--selected' : ''}`}
+                aria-pressed={iso === serviceDate}
+                onClick={() => {
+                  setServiceDate(iso);
+                  collapseWhenSettled(iso);
+                }}
+              >
+                {formatServiceDate(iso)}
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        {whenOpen ? (
+          <div ref={datePickerRef}>
+            <ProtoDatePicker
+              value={serviceDate}
+              min={earliestSelectableDate()}
+              onChange={(iso) => {
+                setServiceDate(iso);
+                /* Picking a date is the whole reason it was open — but only on
+                   a plan where the date is all this section holds. The church's
+                   lane still has slots to tick underneath. */
+                collapseWhenSettled(iso);
+              }}
+              aria-label={`${noun.charAt(0).toUpperCase()}${noun.slice(1)} date`}
+            />
+          </div>
+        ) : null}
+
+        {/*
+          Checkboxes, not a single select: one sermon is preached at both Sunday
+          morning services, while the evening service hears a different one.
+          Only the chosen day's services are offered — a Sunday sermon has no
+          business claiming the Wednesday slot, and an undated idea has no day
+          to claim one on at all.
+        */}
+        {whenOpen && sameDaySlots.length > 0 ? (
+          <>
+            <label className="proto-inspector-section-title proto-create-folder-sheet__field-label">
+              <span>Preached at</span>
+              <span className="proto-service-editor__optional">optional</span>
+            </label>
+            <div className="proto-service-editor__slots" role="group" aria-label="Services">
+              {sameDaySlots.map((slot) => {
+                const checked = serviceTimeIds.includes(slot.id);
+                return (
+                  <label key={slot.id} className="proto-service-editor__slot">
+                    {/*
+                      The input stays and stays real — it carries the checked
+                      state, the keyboard, and the label association. It is
+                      visually replaced, not removed, so the orb the rest of
+                      the app selects with is what you see here too.
+                    */}
+                    <input
+                      type="checkbox"
+                      className="proto-service-editor__slot-input"
+                      checked={checked}
+                      onChange={() =>
+                        setServiceTimeIds((ids) =>
+                          checked ? ids.filter((id) => id !== slot.id) : [...ids, slot.id],
+                        )
+                      }
+                    />
+                    <span className="proto-service-editor__slot-orb" aria-hidden>
+                      {checked ? (
+                        <span className="proto-accent-check-orb proto-accent-check-orb--selected">
+                          <Icon name="check" size={9} />
+                        </span>
+                      ) : (
+                        <span className="proto-select-orb-idle" />
+                      )}
+                    </span>
+                    <span>
+                      {formatServiceTime(slot.startTime)}
+                      {slot.label ? ` · ${slot.label}` : ''}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          </>
+        ) : null}
+
+        {/*
+          The escape hatch, shown only when no usual service applies: a
+          Christmas Eve at 17:00 should not become a permanent Thursday slot on
+          the church's week. `<input type="time">` ignores placeholder, so the
+          hint has to be a sibling caption.
+
+          **The church's own plan only.** Every space lane — a room that gathers
+          as much as a channel that publishes — writes `serviceTime: null` in
+          the route (`church-space-plan.ts` create, repeat and series all
+          hardcode it), so on a room this input accepted a time and the server
+          discarded it silently. The condition used to be `planKind !==
+          'content'`, which caught the channel and missed the room. A room's
+          hour belongs to its meeting rhythm, which is a fact about the room
+          rather than a field on one study.
+        */}
+        {whenOpen && !isUnscheduled && isChurchLane && serviceTimeIds.length === 0 ? (
+          <>
+            <label
+              className="proto-inspector-section-title proto-create-folder-sheet__field-label"
+              htmlFor="proto-service-time"
+            >
+              <span>{sameDaySlots.length > 0 ? 'Or a one-off time' : 'Time'}</span>
+              <span className="proto-service-editor__optional">optional</span>
+            </label>
+            <input
+              id="proto-service-time"
+              type="time"
+              className="proto-create-folder-sheet__name-input"
+              value={serviceTime}
+              onChange={(e) => setServiceTime(e.target.value)}
+            />
+          </>
+        ) : null}
 
         {/*
           Which of my notes this sermon is.

--- a/spa/src/pages/prototype/PrototypeSpaceComingUp.tsx
+++ b/spa/src/pages/prototype/PrototypeSpaceComingUp.tsx
@@ -34,7 +34,6 @@ import {
   sermonEyebrow,
   starterFolderForSermon,
   starterNoteTitle,
-  weekdayLabel,
   type ChurchSermon,
 } from '../../lib/church-services';
 import { useProtoShell } from '../../layouts/proto-shell-context';
@@ -155,13 +154,16 @@ export default function PrototypeSpaceComingUp({ spaceId, enabled }: PrototypeSp
   if (!gathering) return null;
 
   /*
-    The space's own rhythm, not the church's clock list: a space gathers once,
-    so its `meetingTime` labels every row rather than each row carrying a time.
+    When it meets, as one subordinate phrase.
+
+    `sermonEyebrow` already names the day in the reader's own terms ("This
+    Tuesday", "Today", "Last Wednesday"), so the room's declared weekday would
+    only repeat it — "This Tuesday · Tuesdays · 7:00pm" says Tuesday twice. The
+    hour is the part the day cannot carry, so that is the part that joins it.
   */
-  const rhythm =
-    data?.space?.meetingTime && data.space.meetingDay !== null
-      ? `${weekdayLabel(data.space.meetingDay)}s · ${formatServiceTime(data.space.meetingTime)}`
-      : null;
+  const whenLabel = data?.space?.meetingTime
+    ? `${sermonEyebrow(gathering)} · ${formatServiceTime(data.space.meetingTime)}`
+    : sermonEyebrow(gathering);
   const hasNote = Boolean(gathering.viewerNoteId);
   /*
     Only when the reference actually resolves to a chapter. A gathering can be
@@ -177,16 +179,25 @@ export default function PrototypeSpaceComingUp({ spaceId, enabled }: PrototypeSp
 
   return (
     <div className="proto-home-section">
+      {/*
+        The run, not the date.
+
+        This eyebrow used to be "This Tuesday · Tuesdays · 7:00pm" — the room's
+        appointment, with what it was studying underneath. A room's subject is
+        what it is studying; when it meets is an attribute of that, so the study
+        leads and the day follows it into the row's own meta line. The series is
+        the truest name for the run when there is one; without one there is
+        nothing to name but the section.
+      */}
       <p className="proto-caption proto-home-section__eyebrow">
-        {sermonEyebrow(gathering)}
-        {rhythm ? ` · ${rhythm}` : ''}
+        {gathering.seriesTitle || 'Coming up'}
       </p>
       <div className="proto-glass-surface proto-glass-surface--panel proto-church-tools proto-home-cascade">
         <button
           type="button"
           className="proto-church-tools__row"
           aria-label={
-            hasNote ? 'Open my note on this gathering' : 'New note on this gathering'
+            hasNote ? 'Open my note on this study' : 'New note on this study'
           }
           onClick={() => takeNotes(gathering)}
         >
@@ -200,9 +211,11 @@ export default function PrototypeSpaceComingUp({ spaceId, enabled }: PrototypeSp
             >
               <span>{gathering.title}</span>
             </span>
+            {/* Passage, then day. The series has moved up to the eyebrow, so
+                repeating it here would say the same thing twice in one card. */}
             <span className="proto-caption proto-church-tools__row-meta proto-marquee-self">
               {gathering.reference || 'No passage yet'}
-              {gathering.seriesTitle ? ` · ${gathering.seriesTitle}` : ''}
+              {` · ${whenLabel}`}
             </span>
           </span>
           <span className="proto-church-tools__row-chevron" aria-hidden>

--- a/spa/src/pages/prototype/PrototypeSpaceHub.tsx
+++ b/spa/src/pages/prototype/PrototypeSpaceHub.tsx
@@ -1166,22 +1166,6 @@ function PrototypeSpaceHubLive() {
           {/* Fading out over the dashboard arriving underneath, so the two states overlap
               rather than swapping between frames. Out of flow; costs the layout nothing. */}
           {showLoader ? <ProtoSpaceLoading label="Loading space" leaving={loaderLeaving} /> : null}
-          {/*
-            What this room is studying next. Staff-gated server-side, so it is
-            only requested for someone who can already see the church's plans;
-            everyone else, and every space without a plan, renders nothing.
-          */}
-          {/* Members, not just staff: the read is membership-gated now, so the
-              people who actually gather here see what the room is on. Still
-              only asked of a church room — a personal Shared Space has no
-              plan to answer with. */}
-          {/* Any room that can hold a plan can say what is coming up. The org
-              condition predated churchless plans; the endpoint behind it was
-              only ever gated on membership. */}
-          <PrototypeSpaceComingUp
-            spaceId={activeSpaceId ?? null}
-            enabled={ministryMeta.type !== 'personal'}
-          />
           {bannerNewCount > 0 ? (
             <div className="proto-home-section">
               <p className="proto-home-greeting">
@@ -1317,6 +1301,26 @@ function PrototypeSpaceHubLive() {
               )}
             </div>
           ) : null}
+
+          {/*
+            When it next meets — **after** what it is studying, not before.
+
+            This card used to sit above the Current Thread block, so a member
+            opening their room was told the day before the subject. A room's
+            subject is the study; the meeting is the appointment for it. The
+            welcome-back layer above (the catch-up line and the greeting) stays
+            first because it answers "what happened while I was away", which is
+            neither.
+
+            Members, not just staff: the read is membership-gated, so the people
+            who actually gather here see what the room is on. Any room that can
+            hold a plan can answer; a personal space has no plan, and every room
+            without one renders nothing at all.
+          */}
+          <PrototypeSpaceComingUp
+            spaceId={activeSpaceId ?? null}
+            enabled={ministryMeta.type !== 'personal'}
+          />
 
           {totalNoteCount === 0 ? (
             <div className="proto-home-section">

--- a/spa/src/pages/prototype/__tests__/sermon-editor-field-order.test.tsx
+++ b/spa/src/pages/prototype/__tests__/sermon-editor-field-order.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * The planner form's field order, asserted against the rendered DOM.
+ *
+ * A source contract (`planner/__tests__/planner-study-first-contract.test.ts`)
+ * holds the same line, and the two catch different things: that one survives a
+ * refactor that moves the JSX, this one catches a conditional that renders the
+ * right fields in the wrong place — or not at all. Order is invisible to types
+ * and to any query that finds a field by its label.
+ *
+ * A room decides what it is going to *study*; when it meets is an attribute of
+ * that. The form used to open with five time controls above the title.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('@clerk/clerk-react', () => ({
+  useAuth: () => ({ isLoaded: true, isSignedIn: true, userId: 'user_1', getToken: async () => 't' }),
+}));
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => () => {} }));
+
+const noopActions = { mutate: () => {}, mutateAsync: async () => ({}), isPending: false };
+vi.mock('../../../hooks/queries/useChurchTeachingPlan', () => ({
+  useChurchSermonActions: () => noopActions,
+}));
+vi.mock('../../../hooks/queries/useChurchSpacePlan', () => ({
+  useChurchSpaceSermonActions: () => noopActions,
+}));
+vi.mock('../../../hooks/queries/useNoteTemplates', () => ({ useNoteTemplates: () => ({ data: [] }) }));
+vi.mock('../../../hooks/queries/useNotesByReference', () => ({
+  useNotesByReference: () => ({ data: null }),
+}));
+vi.mock('../../../hooks/usePrototypeHomeSpaceId', () => ({
+  usePrototypeHomeSpaceId: () => 'space_home',
+}));
+
+const PrototypeSermonEditorFields = (await import('../PrototypeSermonEditorFields')).default;
+
+/** Document order of the first element matching each selector. */
+function orderOf(container: HTMLElement, selectors: string[]): number[] {
+  const all = [...container.querySelectorAll<HTMLElement>('*')];
+  return selectors.map((sel) => all.findIndex((el) => el.matches(sel)));
+}
+
+const base = {
+  orgId: 'org_1',
+  service: null,
+  series: [],
+  active: true,
+  onDone: () => {},
+  canWrite: true,
+};
+
+describe('a room’s plan asks what before when', () => {
+  it('renders title, passage and series above the When control', () => {
+    const { container } = render(
+      <PrototypeSermonEditorFields
+        {...base}
+        planSpaceId="space_room"
+        planKind="gathering"
+        createDefaultDate="2026-09-15"
+      />,
+    );
+    const [title, reference, series, when] = orderOf(container, [
+      '#proto-service-title',
+      '#proto-service-reference',
+      '#proto-service-series',
+      '.proto-service-editor__date-chip',
+    ]);
+    for (const i of [title, reference, series, when]) expect(i).toBeGreaterThan(-1);
+    expect(title).toBeLessThan(reference);
+    expect(reference).toBeLessThan(series);
+    expect(series).toBeLessThan(when);
+  });
+
+  it('names the entry a study, never a gathering', () => {
+    const { container } = render(
+      <PrototypeSermonEditorFields
+        {...base}
+        planSpaceId="space_room"
+        planKind="gathering"
+        createDefaultDate="2026-09-15"
+      />,
+    );
+    expect(container.textContent).not.toMatch(/gathering/i);
+    expect(screen.getByPlaceholderText('Study title')).toBeTruthy();
+  });
+
+  it('summarises the room’s hour too, so the closed chip answers “when”', () => {
+    /*
+      The hour is never written to the row — every space lane stores
+      `serviceTime: null` — but the room's card says "This Tuesday · 7:00 PM",
+      and a chip that dropped it made the two surfaces disagree.
+    */
+    const { container } = render(
+      <PrototypeSermonEditorFields
+        {...base}
+        planSpaceId="space_room"
+        planKind="gathering"
+        createDefaultDate="2026-09-15"
+        rhythm={{ meetingDay: 2, intervalDays: 7, meetingTime: '19:00' }}
+      />,
+    );
+    const chip = container.querySelector('.proto-service-editor__date-chip');
+    expect(chip?.textContent).toContain('Sep');
+    expect(chip?.textContent).toMatch(/7:00/);
+    // Still not offered as an editable field, because the server discards it.
+    expect(container.querySelector('#proto-service-time')).toBeNull();
+  });
+
+  it('keeps When collapsed, summarising the date it already has', () => {
+    const { container } = render(
+      <PrototypeSermonEditorFields
+        {...base}
+        planSpaceId="space_room"
+        planKind="gathering"
+        createDefaultDate="2026-09-15"
+      />,
+    );
+    const chip = container.querySelector('.proto-service-editor__date-chip');
+    expect(chip?.getAttribute('aria-expanded')).toBe('false');
+    // The summary is the value, so the collapsed state still answers "when".
+    expect(chip?.textContent).toContain('Sep');
+    // And the calendar is not occupying the form while collapsed.
+    expect(container.querySelector('.proto-date-picker')).toBeNull();
+  });
+
+  it('never offers a one-off time, which the space routes discard', () => {
+    const { container } = render(
+      <PrototypeSermonEditorFields
+        {...base}
+        planSpaceId="space_room"
+        planKind="gathering"
+        createDefaultDate="2026-09-15"
+      />,
+    );
+    expect(container.querySelector('#proto-service-time')).toBeNull();
+  });
+
+  it('offers a run length on create, defaulting to a single week', () => {
+    render(
+      <PrototypeSermonEditorFields
+        {...base}
+        planSpaceId="space_room"
+        planKind="gathering"
+        createDefaultDate="2026-09-15"
+      />,
+    );
+    expect(screen.getByText('Just this week')).toBeTruthy();
+  });
+
+  it('offers no run length for an undated idea', () => {
+    render(
+      <PrototypeSermonEditorFields
+        {...base}
+        planSpaceId="space_room"
+        planKind="gathering"
+        createDefaultDate={null}
+        allowNullDate
+      />,
+    );
+    expect(screen.queryByText('Just this week')).toBeNull();
+  });
+});
+
+describe('the church’s own plan keeps its date in front of it', () => {
+  it('opens the When section, because the slots to tick live inside it', () => {
+    const { container } = render(
+      <PrototypeSermonEditorFields
+        {...base}
+        planSpaceId={null}
+        serviceTimes={[
+          { id: 'st_1', dayOfWeek: 2, startTime: '10:45', label: 'Morning' },
+        ]}
+        createDefaultDate="2026-09-15"
+      />,
+    );
+    const chip = container.querySelector('.proto-service-editor__date-chip');
+    expect(chip?.getAttribute('aria-expanded')).toBe('true');
+    // 2026-09-15 is a Tuesday, so the Tuesday slot is offered.
+    expect(screen.getByText(/Morning/)).toBeTruthy();
+  });
+
+  it('still calls the entry a sermon', () => {
+    render(
+      <PrototypeSermonEditorFields {...base} planSpaceId={null} createDefaultDate="2026-09-15" />,
+    );
+    expect(screen.getByPlaceholderText('Sermon title')).toBeTruthy();
+  });
+});

--- a/spa/src/pages/prototype/__tests__/space-coming-up-study-first.test.tsx
+++ b/spa/src/pages/prototype/__tests__/space-coming-up-study-first.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * The room's "Coming up" card leads with the study, not the day.
+ *
+ * It used to head the card "This Tuesday · Tuesdays · 7:00pm" with the subject
+ * underneath. A room's subject is what it is studying; when it meets is an
+ * attribute of that. Rendered rather than source-read because what matters is
+ * which text lands in the eyebrow and which in the row, and that is a fact
+ * about the DOM.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+vi.mock('@clerk/clerk-react', () => ({
+  useAuth: () => ({ isLoaded: true, isSignedIn: true, userId: 'user_1', getToken: async () => 't' }),
+}));
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => () => {} }));
+vi.mock('../../../layouts/proto-shell-context', () => ({
+  useProtoShell: () => ({
+    isMobileSidebar: false,
+    closeDrawer: () => {},
+    beginPrototypeComposeSession: () => {},
+  }),
+}));
+
+/** A Tuesday, far enough out that the eyebrow reads as a weekday rather than "Today". */
+const SERVICE_DATE = '2099-09-15';
+const comingUp = vi.fn();
+vi.mock('../../../hooks/queries/useSpaceComingUp', () => ({
+  useSpaceComingUp: () => comingUp(),
+}));
+
+const PrototypeSpaceComingUp = (await import('../PrototypeSpaceComingUp')).default;
+
+function withPlan(overrides: Record<string, unknown> = {}) {
+  comingUp.mockReturnValue({
+    data: {
+      space: { id: 'sp_1', title: 'Romans Study Group', meetingDay: 2, meetingTime: '19:00' },
+      services: [
+        {
+          id: 'svc_1',
+          serviceDate: SERVICE_DATE,
+          serviceTime: null,
+          times: [],
+          title: 'The Spirit of adoption',
+          reference: 'Romans 8:14-16',
+          seriesTitle: 'Life in the Spirit',
+          viewerNoteId: null,
+          starter: null,
+          ...overrides,
+        },
+      ],
+    },
+  });
+  return render(<PrototypeSpaceComingUp spaceId="sp_1" />);
+}
+
+describe('the study is the subject', () => {
+  it('puts the run in the eyebrow and the day in the row', () => {
+    const { container } = withPlan();
+    const eyebrow = container.querySelector('.proto-home-section__eyebrow');
+    const meta = container.querySelector('.proto-church-tools__row-meta');
+
+    expect(eyebrow?.textContent).toBe('Life in the Spirit');
+    // The day moved down here, beside the passage, with the hour attached.
+    expect(meta?.textContent).toContain('Romans 8:14-16');
+    expect(meta?.textContent).toContain('Tuesday');
+    expect(meta?.textContent).toContain('7:00');
+  });
+
+  it('never says the weekday twice', () => {
+    /*
+      The old line was "This Tuesday · Tuesdays · 7:00pm" — `sermonEyebrow`
+      already names the day, so the room's declared weekday only repeated it.
+    */
+    const { container } = withPlan();
+    const text = container.textContent ?? '';
+    expect(text.match(/Tuesday/g) ?? []).toHaveLength(1);
+  });
+
+  it('falls back to naming the section when the study has no run', () => {
+    const { container } = withPlan({ seriesTitle: null });
+    expect(container.querySelector('.proto-home-section__eyebrow')?.textContent).toBe('Coming up');
+  });
+
+  it('does not call the entry a gathering', () => {
+    const { container } = withPlan();
+    expect(container.innerHTML).not.toMatch(/gathering/i);
+  });
+
+  it('keeps the study title as the row it opens', () => {
+    const { container } = withPlan();
+    expect(container.querySelector('.proto-church-tools__row-title')?.textContent).toBe(
+      'The Spirit of adoption',
+    );
+  });
+
+  it('still renders nothing at all when the room has no plan', () => {
+    comingUp.mockReturnValue({ data: { space: undefined, services: [] } });
+    const { container } = render(<PrototypeSpaceComingUp spaceId="sp_1" />);
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/spa/src/pages/prototype/planner/PrototypeExpandedPlanner.tsx
+++ b/spa/src/pages/prototype/planner/PrototypeExpandedPlanner.tsx
@@ -290,8 +290,15 @@ export default function PrototypeExpandedPlanner({ exiting, origin, onClose }: E
               parsePublishCadence(spacePlan.data?.space.publishCadence),
             ),
           }
-        : { meetingDay: defaultDay, intervalDays: 7 },
-    [planKind, defaultDay, spacePlan.data?.space.publishCadence],
+        : {
+            meetingDay: defaultDay,
+            intervalDays: 7,
+            /* Display only, for the collapsed When summary — never written to
+               a row. A channel has no hour, which is why this sits on the
+               gathering arm alone. */
+            meetingTime: spacePlan.data?.space.meetingTime ?? null,
+          },
+    [planKind, defaultDay, spacePlan.data?.space.publishCadence, spacePlan.data?.space.meetingTime],
   );
 
   /*

--- a/spa/src/pages/prototype/planner/__tests__/planner-study-first-contract.test.ts
+++ b/spa/src/pages/prototype/planner/__tests__/planner-study-first-contract.test.ts
@@ -1,0 +1,111 @@
+/**
+ * The planner's form asks what the study is before it asks when it meets.
+ *
+ * Asserted against the source, in the style of `planner-add-contract`, because
+ * both things guarded here fail *silently*. A field order is invisible to types
+ * and to every rendering test that queries by label rather than by position,
+ * and the one-off time field was accepted by a form and discarded by a route
+ * for weeks without anything failing.
+ *
+ * The ordering is not cosmetic. A room decides what it is going to study; when
+ * it meets is an attribute of that, and usually already declared as the room's
+ * rhythm. The form used to open with five time controls above the title.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const withoutComments = (text: string) =>
+  text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+const fields = () =>
+  withoutComments(source('spa/src/pages/prototype/PrototypeSermonEditorFields.tsx'));
+
+describe('the study comes before the date', () => {
+  it('puts the title and the passage above the When section', () => {
+    const text = fields();
+    const title = text.indexOf('htmlFor="proto-service-title"');
+    const reference = text.indexOf('htmlFor="proto-service-reference"');
+    const when = text.indexOf('>\n          When\n        </label>');
+
+    expect(title).toBeGreaterThan(-1);
+    expect(reference).toBeGreaterThan(-1);
+    expect(when).toBeGreaterThan(-1);
+    expect(title).toBeLessThan(when);
+    expect(reference).toBeLessThan(when);
+  });
+
+  it('keeps the series with the study rather than with the date', () => {
+    // A run is what the study *is*, not when it happens.
+    const text = fields();
+    expect(text.indexOf('htmlFor="proto-service-series"')).toBeLessThan(
+      text.indexOf('>\n          When\n        </label>'),
+    );
+  });
+
+  it('opens When on the church plan and leaves it closed on a room', () => {
+    /*
+      On the church's plan a sermon really is a slot on a Sunday, and the slot
+      checkboxes live inside this section — collapsing it there would hide the
+      control that decides which of two Sunday services hears the sermon.
+    */
+    expect(fields()).toContain('planSpaceId == null || createDefaultDate === null');
+  });
+});
+
+describe('the one-off time belongs to the church alone', () => {
+  it('never offers it on a space plan', () => {
+    /*
+      Every space lane writes `serviceTime: null` server-side — a room that
+      gathers as much as a channel that publishes. The condition used to be
+      `planKind !== 'content'`, which caught the channel and missed the room, so
+      a room's plan accepted a time and the server dropped it in silence.
+    */
+    const text = fields();
+    expect(text).toContain('whenOpen && !isUnscheduled && isChurchLane && serviceTimeIds.length === 0');
+    expect(text).toContain('const isChurchLane = planSpaceId == null');
+  });
+
+  it('the space routes really do refuse it, which is why the field is gated', () => {
+    // If this ever stops being true the gate above is the thing to revisit.
+    const route = withoutComments(source('server/routes/church-space-plan.ts'));
+    expect(route).not.toMatch(/normalizeServiceTime\s*\(\s*body\.serviceTime/);
+    expect(route).toContain('serviceTime: null');
+  });
+});
+
+describe('a run can be planned as it is created', () => {
+  it('counts weeks inclusively and chains the existing repeat route', () => {
+    /*
+      Create-then-repeat, deliberately: the repeat route already owns the weekly
+      arithmetic, the 12-week cap and the stop-at-first-collision rule. A
+      `weeks` field on create would restate all three.
+    */
+    const text = fields();
+    expect(text).toContain("kind: 'repeat',");
+    expect(text).toContain('weeks: createWeeks - 1,');
+  });
+
+  it('reports a run that stopped short as a partial success, not an error', () => {
+    /*
+      A four-week study whose third week is taken leaves three real rows. That
+      is a short plan, not a failed save, and it must not reach `setError`.
+    */
+    const text = fields();
+    const start = text.indexOf('if (!isEditing && serviceId && createWeeks > 1)');
+    expect(start).toBeGreaterThan(-1);
+    // Bounded to the block itself — `repeat()` below it reports its own failures
+    // through setError, and that is correct there.
+    const end = text.indexOf('onDone();', start);
+    expect(end).toBeGreaterThan(start);
+    const block = text.slice(start, end);
+    expect(block).toContain('setNotice(');
+    expect(block).not.toContain('setError(');
+  });
+
+  it('does not offer a run for an undated idea', () => {
+    // The repeat route refuses one outright — there is no first week to count from.
+    expect(fields()).toContain('{!isEditing && !isUnscheduled ? (');
+  });
+});

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -4328,7 +4328,9 @@ html.harvous-prototype-route button[class*='proto-'].proto-resource-add__open sp
   border-color: var(--pds-accent-focus-border);
   background: var(--pds-bg-page);
   outline: 2px solid var(--pds-accent-focus-ring);
-  outline-offset: 0;
+  /* Inset for the same reason as the canonical field above: the inspector is a
+     scrolling column, and an outward ring loses its sides in one. */
+  outline-offset: -2px;
 }
 
 /* ─── Folder + tag editor ────────────────────────────────────────────────── */
@@ -5129,7 +5131,11 @@ html.harvous-proto-wallpaper-color .proto-fte-field:focus-within {
 .proto-settings-field__input:focus {
   border-color: var(--pds-accent-focus-border);
   outline: 2px solid var(--pds-accent-focus-ring);
-  outline-offset: 0;
+  /* Inset, matching the global field ring — see the note there. At `0` the ring
+     sat wholly outside the border box, so any scrolling ancestor cropped its
+     left and right edges; this field is `width: 100%` and the planner rail
+     zeroes its side padding, which left it nothing to bleed into. */
+  outline-offset: -2px;
 }
 
 .proto-create-folder-sheet__notes-label {
@@ -13092,6 +13098,32 @@ p.proto-teaching-plan__divider {
 }
 
 /*
+  The row the chip and "Move to ideas" share.
+
+  Unstyled before this, which is why the two drifted apart visually: with no
+  `display: flex` here, `.proto-sheet-quiet-action`'s own `width: 100%` (built
+  for a sheet footer, stacked under a primary) had nothing to constrain it to
+  but the row's full width, so it dropped to its own line and centered its
+  text — an orphaned link under the chip rather than a second control beside
+  it. `flex-wrap` lets the pair wrap on a narrow rail instead of overflowing.
+*/
+.proto-service-editor__date-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* Same fix `.proto-suggest-mine .proto-sheet-quiet-action` already made for
+   the library queue's actions: `proto-sheet-quiet-action` carries `width:
+   100%` for its usual stacked-under-a-primary case, which here pushed this
+   button onto its own centered line instead of sitting beside the chip. */
+.proto-service-editor__date-row .proto-sheet-quiet-action {
+  width: auto;
+  flex-shrink: 0;
+}
+
+/*
   The shared field class adds its own `margin-top: 6px`, which lands on top of
   this column's 6px flex gap — so every input sat 12px under its label while the
   date chip (no such margin) sat at 6px. The gap is the one spacing authority
@@ -13204,6 +13236,22 @@ p.proto-teaching-plan__divider {
 .proto-service-editor__repeat-select {
   flex: 1;
   min-width: 0;
+}
+
+/*
+  "How long" on create — a plain field in the form's own column, not a row.
+
+  Deliberately its own class rather than reusing `__repeat-select` above: that
+  one carries `flex: 1` for sitting beside a button inside `.repeat`, a ROW
+  flex container. Here the trigger is a direct child of `.proto-service-editor`
+  itself, which is a COLUMN flex container — `flex: 1` there means "grow to
+  fill remaining height", not width, and the reused class stretched this
+  control to fill the whole scrolling form. `flex: 0 0 auto` says explicitly
+  what a bare rule left implicit: this control sizes to its own content, the
+  way `.proto-select-menu__trigger`'s own `width: 100%` already intends.
+*/
+.proto-service-editor__weeks-select {
+  flex: 0 0 auto;
 }
 
 /* Not an error and not a caption in the field flow: the result of an action
@@ -17139,6 +17187,18 @@ html.harvous-prototype-route
 
 .proto-planner-editor__body > .proto-add-notes-sheet__footer {
   flex: 0 0 auto;
+  /*
+    More air above Save than the 10px the wildcard `[class*='__footer']` rule
+    above gives every footer under this body. Deliberately for both docked
+    rails that share this wrapper — the study editor (a note-search result as
+    its last row) and the library item editor (a checkbox group as its last
+    row) — since both end a form in dense rows right up against the footer,
+    which read as crowding rather than a clear break before Save. Only the
+    top value: right/bottom/left stay the wildcard rule's, since this rule
+    comes later in the cascade at equal specificity and overrides just what
+    it sets.
+  */
+  padding-top: 16px;
 }
 
 /* ─── Select menu (the prototype's choice control) ────────────────────────── */

--- a/spa/src/styles/prototype-design-gallery.css
+++ b/spa/src/styles/prototype-design-gallery.css
@@ -215,6 +215,25 @@
   max-width: 360px;
 }
 
+/*
+  Reproduces the rail a field actually lives in: a scrolling column whose side
+  padding is zero, so a `width: 100%` field has nothing to bleed into. That is
+  the shape of the planner editor, the inspector and the review dock, and it is
+  the only condition under which a focus ring can be cropped — so the Inputs
+  scene demonstrates it rather than describing it.
+
+  `overflow-y: auto` is the whole point and is not a typo: it forces
+  `overflow-x` to compute to `auto` as well, which is what clips sideways.
+*/
+.pds-gallery-scroller {
+  max-height: 96px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: var(--pds-space-2) 0;
+  border: 0.5px dashed var(--pds-border-control);
+  border-radius: var(--pds-radius-row);
+}
+
 .pds-gallery-swatch-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -670,7 +670,25 @@ select:focus-visible {
   /* Prototype surfaces carry a theme-aware ring that flips in dark mode; the
      legacy token is the fallback for pages that don't load prototype-tokens.css. */
   outline: var(--focus-ring-width) solid var(--pds-accent-focus-ring, var(--focus-ring-color));
-  outline-offset: var(--focus-ring-offset);
+  /*
+    Inset, not the shared `--focus-ring-offset`, because a field is the one
+    focusable thing that is routinely full-width inside a scroller.
+
+    An outward ring is painted outside the border box, so an ancestor with
+    `overflow: hidden` or `auto` clips whatever falls outside its padding box —
+    and a `width: 100%` field has nothing to spare on the left and right. The
+    ring then lost both of its vertical edges and read as two stray brackets.
+    Setting `overflow-y: auto` forces `overflow-x` to compute to `auto` too, so
+    a column that only meant to scroll vertically clips horizontally as well;
+    that is why this showed up in the planner rail and the review dock, both of
+    which scroll a form.
+
+    `-1 * width` puts the ring just inside the edge instead, where nothing can
+    crop it and it still reads as one band against the field's own border. Same
+    construction as the OTP fields below. The shared token stays at `+2px` for
+    nav rows and cards, which sit in open space and want the halo.
+  */
+  outline-offset: calc(-1 * var(--focus-ring-width));
 }
 
 .color-selection button[style*="background-color"] {


### PR DESCRIPTION
## What

The planner's primary object on a room's plan is now the **study**, not the
gathering — the form leads with title and passage instead of date, a new study
can declare its run length on create, and the room hub leads with what it is
studying rather than when it next meets.

## Why

> "The planner's primary use should be less about the actual gathering... but
> more about the content, and then secondary are the times to meet, which I
> never liked calling 'gathering'."

There is no `Gathering` entity — one row type wearing one of three words
depending on scope. The room's word was "gathering," and both the word and the
form's field order put the meeting ahead of the thing being studied.

## What changed

- **Vocabulary**: room's plan says `New study` / `itemNoun: 'study'`, sharing
  a label with a channel's primary action, differing in `addOpens`. Church
  plan keeps `sermon`. `ChurchServices.kind` is unchanged (`'gathering' |
  'content'`) — it's server-derived and behavioral, not vocabulary.
- **Editor reorder**: title → passage → series → how long → a collapsed
  **When** section (date, rhythm, calendar, church slots). Collapsed by
  default on a room's plan, expanded on the church's (its slot checkboxes
  live there).
- **Multi-week create**: a run-length control (1/4/6/8/12 weeks) chains the
  existing repeat route rather than a new server contract. A collision
  mid-run reports what it planned ("Planned 1 of 4 weeks...") instead of
  erroring.
- **Room hub reorder**: Current Thread now outranks Coming up. That card's
  eyebrow names the series rather than the day, with meeting time folded into
  the row's meta line.
- **Two layout bugs**, found verifying the reorder live: a reused CSS class
  carrying `flex: 1` into the wrong flex-axis context (stretched a select
  trigger to 125px), and a full-width sheet-footer button class dropping
  "Move to ideas" onto its own centered line instead of sitting beside the
  date chip. Both scoped to their own rules now, plus more breathing room
  above the docked editor's footer.
- **Focus-ring fix** (found on the same rail, turned out global): field focus
  rings were drawn outward and clipped by any scrolling ancestor — reproduced
  exactly on a 319px field inside a 319px zero-padding scroller. Traced to the
  global `input/textarea/select:focus-visible` rule, which is why it also hit
  the review dock's textarea. Fields now draw inset; `--focus-ring-offset`
  stays outward for nav rows/cards. Documented in the design system doc, and
  `ds-11-inputs` now reproduces the clipping condition rather than describing
  it.
- **Docs corrected**: `SPACES_PLANNER_AND_GATHERINGS.md` (canonical doc,
  title left stale on purpose), `SHARED_SPACE_STUDY_TOOLS.md`,
  `STUDY_PLANS.md`, `CHURCH_SPACE_PLANS_AND_SERVICE_TIMES.md`.

## Verification

- Full suite: 6167 tests passing
- `typecheck:ratchet`, `design:check`, `check:color-tokens`, `perf:check`: all
  pass, no regressions
- Walked live against a real dev database: create → multi-week → mid-run
  collision → room hub, including the church lane's read-only plan and its
  own "sermon" wording
- Focus ring verified on a real click, in the planner rail and the gallery
  scroller, light and dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)
