### PR TITLE
Review: a first attempt you can answer, and one that gets harder as it becomes yours

### DIFF
--- a/server/routes/__tests__/review-routes.test.ts
+++ b/server/routes/__tests__/review-routes.test.ts
@@ -377,11 +377,47 @@ describe('the ladder wrap and the truth restore', () => {
   });
 
   it('erodes the cloze by the pass, never by how many times it was answered', () => {
-    // `reviewCount` rises on every answer, so ten near misses would hand someone a
-    // mostly-blank verse they have never once recalled.
+    /*
+     * `reviewCount` rises on every answer, so ten near misses would hand someone a mostly-blank
+     * verse they have never once recalled. The spec is read from the rung's own pass — and from
+     * the item's recall state, which is the scheduler's verdict rather than a tally of attempts.
+     */
     const text = service();
-    expect(text).toContain('verseClozeRatio(rung.pass)');
-    expect(text).not.toContain('verseClozeRatio(item.reviewCount');
+    expect(text).toMatch(/verseClozeSpec\(rung\.pass/);
+    expect(text).not.toMatch(/verseClozeSpec\(item\.reviewCount/);
+    expect(text).not.toMatch(/verseClozeRatio\(item\.reviewCount/);
+  });
+
+  it('asks every staged rung at the tier the pass says, never at a tier the page claims', () => {
+    /*
+     * The tier decides which shape is graded, so reading it from the submission instead would
+     * let a page pick its own marking — send free text on a tier-0 initials item and the
+     * all-or-nothing subsequence match runs against a verse that was mostly on screen.
+     */
+    const text = service();
+    for (const call of [
+      /verseInitialsShare\(rung\.pass/,
+      /verseKeywordsCount\(rung\.pass/,
+      /verseRecallMode\(rung\.pass/,
+    ]) {
+      expect(text).toMatch(call);
+    }
+    const grader = text.slice(text.indexOf('async function gradeVerseAnswer'));
+    const initials = grader.slice(grader.indexOf("rung.key === 'verse.initials'"));
+    expect(initials.slice(0, 1200)).toMatch(/exercise\.tier < 2/);
+    expect(initials.slice(0, 1200)).toMatch(/exercise\.tier === 2/);
+  });
+
+  it('only offers a hint while there is a go left', () => {
+    /*
+     * The finalized response carries the answer itself, so a hint beside it would be a worse
+     * version of what the reader is about to be shown. One branch, and only one.
+     */
+    const text = review();
+    const nonFinal = text.slice(text.indexOf('attemptNumber < maxAttempts'));
+    const upToFinal = nonFinal.slice(0, nonFinal.indexOf('const verdict'));
+    expect(upToFinal).toContain('graded.hint');
+    expect(text.slice(text.indexOf('const verdict'))).not.toContain('graded.hint');
   });
 
   it('hands back the verse a rung withheld, once it has been answered', () => {
@@ -501,7 +537,7 @@ describe('the cloze payload', () => {
     const branch = reveal.slice(reveal.indexOf("rung.key === 'verse.rebuild'"));
     const block = branch.slice(0, branch.indexOf("rung.key === 'verse.sequence'"));
     // Segments and gap widths — the pieces either side of each blank, never the tokens.
-    expect(block).toContain('clozeSegments(cloze)');
+    expect(block).toMatch(/clozeSegments\(cloze/);
     expect(block).not.toMatch(/payload\.cloze = buildVerseCloze/);
 
     // And the payload type says so, so a later edit cannot widen it by accident.
@@ -625,13 +661,35 @@ describe('the text-keyed rungs withhold the verse', () => {
 
   it('sends first letters and a count, never the words', () => {
     const block = revealBlock('verse.initials', "rung.key === 'verse.keywords'");
-    expect(block).toContain('buildVerseInitials(text)');
+    expect(block).toMatch(/buildVerseInitials\(/);
     expect(block).toContain('payload.verseText = null');
+    /*
+     * `reduced` is the answer key — which words were taken out, and what they were. The staged
+     * tiers build it so they can grade, and the payload is assembled field by field precisely so
+     * a later edit cannot ship it by spreading the exercise.
+     */
+    expect(block).not.toContain('reduced');
+    expect(block).not.toMatch(/\.\.\.exercise/);
+    for (const field of ['initials:', 'wordCount:', 'tier:', 'segments:']) {
+      expect(block).toContain(field);
+    }
   });
 
   it('sends only how many words to name', () => {
     const block = revealBlock('verse.keywords', "rung.key === 'verse.before'");
-    expect(block).toContain('buildVerseKeywords(text)');
+    expect(block).toMatch(/buildVerseKeywords\(/);
+    expect(block).toContain('payload.verseText = null');
+  });
+
+  it('gives the recall rung a way in without giving it the answer', () => {
+    const reveal = service().slice(service().indexOf('export async function buildReviewReveal'));
+    const block = reveal.slice(
+      reveal.indexOf('FREE_RECALL_KEYS.has(rung.key)'),
+      reveal.indexOf("rung.key === 'verse.initials'"),
+    );
+    // What is shown, and nothing about what is not: `hiddenText` is the thing being asked for.
+    expect(block).toContain('shown: built.shown');
+    expect(block).not.toContain('hiddenText');
     expect(block).toContain('payload.verseText = null');
   });
 

--- a/server/routes/review.ts
+++ b/server/routes/review.ts
@@ -459,6 +459,18 @@ route.post('/api/review/items/:id/outcome', requireAuth, rateLimit('write'), req
         // reader's own submission; nothing here names anything they did not write.
         ...(graded.parts ? { parts: graded.parts } : {}),
         ...(graded.reached ? { reached: graded.reached } : {}),
+        /*
+         * And one thing to go on, **only while there is a go left**.
+         *
+         * A retry that repeats the identical question with no new information is a second chance
+         * to make the same mistake. This is the only branch a hint may appear in: the finalized
+         * response below carries the answer itself, so a hint there would be a worse version of
+         * something the reader is about to be shown anyway.
+         *
+         * It cannot buy the long interval — every second-or-later attempt already maps to
+         * `almost` a few lines down, so the most a hinted answer earns is a few days.
+         */
+        ...(graded.hint ? { hint: graded.hint } : {}),
       });
     }
 

--- a/server/utils/review-service.ts
+++ b/server/utils/review-service.ts
@@ -111,6 +111,9 @@ import {
   buildVerseBook,
   buildVerseInitials,
   buildVerseKeywords,
+  buildVerseRecall,
+  markVerseInitials,
+  markVerseInitialsParts,
   buildVerseLocate,
   buildVerseMarked,
   buildVerseNext,
@@ -148,6 +151,12 @@ import {
   verseClozeRatio,
   verseCue,
 } from '@/utils/verse-cloze';
+import {
+  verseClozeSpec,
+  verseInitialsShare,
+  verseKeywordsCount,
+  verseRecallMode,
+} from '@/utils/review-difficulty';
 import { stripServerAutoUntitledNoteTitleForDisplay } from '@/utils/server-auto-untitled-note-display';
 import { stripHtmlForListPreview } from '@/utils/html-stripper';
 import { collectStudyThreadGraph } from './study-thread-graph';
@@ -1034,6 +1043,19 @@ export async function buildReviewItemViews(
      * Dropped the way a note with nothing to ask about is dropped.
      */
     if (kind === 'chapter' && options.dropUnaskable && !chapterMaterial?.verses.length) continue;
+    /*
+     * Which tier this rung is asking at, resolved *before* the prompt so the instruction can
+     * describe the exercise the reveal is about to build. "Write it from memory" printed above
+     * two thirds of the verse is the app misdescribing its own question, and the staged rungs
+     * made that reachable — so the prompt takes the same `pass` the builder will.
+     *
+     * Resolved through `verseRungFor` here and again inside `reviewPromptFor`, which is free
+     * (both are pure over the same inputs) and is the only way to keep one resolver.
+     */
+    const promptSeed = reviewSeed(row);
+    const promptPass =
+      kind === 'verse' ? verseRungFor(row.ladderStep, promptSeed, verseMaterial).pass : 0;
+    const promptRecallState = row.recallState as RecallState;
     const { key, prompt } = reviewPromptFor(
       {
         kind,
@@ -1049,6 +1071,10 @@ export async function buildReviewItemViews(
         secondaryNoteTitle,
         threadTitle,
         cue,
+        recallMode: kind === 'verse' ? verseRecallMode(promptPass, promptRecallState) : null,
+        keywordCount: kind === 'verse' ? verseKeywordsCount(promptPass, promptRecallState) : null,
+        initialsTier:
+          kind === 'verse' ? (verseInitialsShare(promptPass, promptRecallState) >= 1 ? 2 : 0) : null,
       },
     );
 
@@ -1083,10 +1109,10 @@ export async function buildReviewItemViews(
     }
     const framingNodeKey = nodeKeyFor(row);
     const node = framingNodeKey ? nodeByKey.get(framingNodeKey) : undefined;
-    const seed = reviewSeed(row);
+    const seed = promptSeed;
     const pass =
       kind === 'verse'
-        ? verseRungFor(row.ladderStep, seed, verseMaterial).pass
+        ? promptPass
         : kind === 'chapter'
           ? chapterRungFor(row.ladderStep, seed, chapterMaterial).pass
           : 0;
@@ -1939,7 +1965,18 @@ export interface ReviewRevealPayload {
    */
   choice?: { options: string[]; opening: boolean } | null;
   /** First letters of every word, and how many words. The verse itself is never sent. */
-  initials?: { initials: string; wordCount: number } | null;
+  /**
+   * The line with some words on their first letter, and — below the top tier — the pieces either
+   * side of each reduced word so they can be typed in place. Never `reduced`: that is the key.
+   */
+  initials?: {
+    initials: string;
+    wordCount: number;
+    tier: number;
+    segments?: { segments: string[]; blankLengths: number[]; letters: string[] } | null;
+  } | null;
+  /** How much of the verse is given before the reader writes the rest. `null` shown = nothing. */
+  recall?: { shown: string | null; mode: string } | null;
   /** How many words to name. Nothing about which. */
   keywords?: { count: number } | null;
   /** Two openings from the same chapter; which comes first stays here. */
@@ -2874,12 +2911,19 @@ async function buildChapterVerseFor(
   return buildChapterVerse({ verses: material.verses, distractorTexts: own, fallbackTexts: fallback, seed });
 }
 
-function buildChapterFinishFor(material: ChapterKnowledgeMaterial, seed: string, pass: number): ChapterFinishExercise | null {
+function buildChapterFinishFor(
+  material: ChapterKnowledgeMaterial,
+  seed: string,
+  pass: number,
+  recallState?: RecallState | null,
+): ChapterFinishExercise | null {
+  const spec = verseClozeSpec(pass, recallState);
   return buildChapterFinish({
     verses: material.verses,
     highlightedNumbers: material.highlightedNumbers,
     seed,
-    ratio: verseClozeRatio(pass),
+    ratio: spec.ratio,
+    maxBlanks: spec.maxBlanks,
   });
 }
 
@@ -3076,15 +3120,63 @@ export async function gradeVerseAnswer(
     };
   }
   if (FREE_RECALL_KEYS.has(rung.key) && typeof answer.text === 'string') {
-    const marked = markVerseRecall(material.text, answer.text, RECALL_MIN_SHARE);
-    return { correct: marked.correct, correctAnswer: null, parts: marked.parts, reached: marked.reached };
+    /*
+     * Graded against what was *asked for*, not against the whole verse.
+     *
+     * At the lower tiers most of the verse is on screen and the reader writes the rest; marking
+     * the coverage share against the full text would score a perfect finish at two thirds.
+     */
+    const built = buildVerseRecall(material.text, verseRecallMode(rung.pass, item.recallState as RecallState));
+    const marked = markVerseRecall(built.hiddenText, answer.text, RECALL_MIN_SHARE);
+    return {
+      correct: marked.correct,
+      correctAnswer: null,
+      parts: marked.parts,
+      reached: marked.reached,
+      hint: marked.correct ? undefined : recallHint(built.hiddenText, answer.text),
+    };
   }
-  if (rung.key === 'verse.initials' && typeof answer.text === 'string') {
-    return { correct: gradeVerseInitials(material.text, answer.text), correctAnswer: null };
+  if (rung.key === 'verse.initials') {
+    /*
+     * Which shape is graded is decided by the **tier**, never by which field the client sent.
+     *
+     * Reading the field instead would let a page choose its own marking: send `text` on a
+     * tier-0 item and the all-or-nothing subsequence match runs against a verse that was mostly
+     * on screen. The tier is derived from stored state the client cannot set.
+     */
+    const share = verseInitialsShare(rung.pass, item.recallState as RecallState);
+    const exercise = buildVerseInitials(material.text, seedForRung, share);
+    if (!exercise) return null;
+    if (exercise.tier < 2 && Array.isArray(answer.words)) {
+      const marked = markVerseInitialsParts(exercise, answer.words);
+      return {
+        correct: marked.correct,
+        correctAnswer: null,
+        parts: marked.parts,
+        hint: marked.correct ? undefined : blankHint(exercise.reduced, answer.words, marked.parts),
+      };
+    }
+    if (exercise.tier === 2 && typeof answer.text === 'string') {
+      const marked = markVerseInitials(material.text, answer.text);
+      return {
+        correct: marked.correct,
+        correctAnswer: null,
+        parts: marked.parts,
+        reached: marked.reached,
+        hint: marked.correct ? undefined : wordHint(material.text, answer.text),
+      };
+    }
+    return null;
   }
   if (rung.key === 'verse.keywords' && Array.isArray(answer.words)) {
-    const marked = markVerseKeywords(material.text, answer.words);
-    return { correct: marked.correct, correctAnswer: null, parts: marked.parts };
+    const count = verseKeywordsCount(rung.pass, item.recallState as RecallState);
+    const marked = markVerseKeywords(material.text, answer.words, count);
+    return {
+      correct: marked.correct,
+      correctAnswer: null,
+      parts: marked.parts,
+      hint: marked.correct ? undefined : keywordHint(material.text, answer.words, seedForRung),
+    };
   }
   if (rung.key === 'verse.before' && typeof answer.option === 'string') {
     const exercise = await buildVerseBeforeFor(item, material.text, seedForRung);
@@ -3125,13 +3217,17 @@ export async function gradeVerseAnswer(
   if (isRebuild) {
     const html = await fetchVerseText(item.scriptureReference, item.translation ?? 'NET');
     if (!html) return null;
-    const cloze = buildVerseCloze(
-      stripHtml(html),
-      reviewSeed(item),
-      verseClozeRatio(rung.pass),
-    );
+    const spec = verseClozeSpec(rung.pass, item.recallState as RecallState);
+    const cloze = buildVerseCloze(stripHtml(html), reviewSeed(item), spec.ratio, {
+      maxBlanks: spec.maxBlanks,
+    });
     const marked = markVerseRebuild(cloze, answer.words!);
-    return { correct: marked.correct, correctAnswer: null, parts: marked.parts };
+    return {
+      correct: marked.correct,
+      correctAnswer: null,
+      parts: marked.parts,
+      hint: marked.correct ? undefined : blankHint(cloze.blanks, answer.words!, marked.parts),
+    };
   }
 
   if (isAltered) {
@@ -3579,6 +3675,94 @@ export interface GradedAnswer {
   parts?: boolean[];
   /** How much of the verse a written answer reached. Names nothing; it is a count. */
   reached?: { matched: number; total: number };
+  /**
+   * One thing to go on for the next try. Only ever computed for a wrong answer, and the route
+   * only ever sends it while there is a go left — see `ReviewHint`.
+   */
+  hint?: ReviewHint;
+}
+
+/**
+ * What the reader is given after a miss, when the question is still in front of them.
+ *
+ * A retry that repeats the identical question with no new information is a second chance to make
+ * the same mistake; a retry that hands over one piece is the repetition this feature is for.
+ *
+ * **Computed, never stored.** The grader rebuilds the exercise from the same seed and tier it was
+ * asked at, looks at what missed, and names one thing. A second identical attempt yields the same
+ * hint, which is correct — nothing about the reader's progress has changed.
+ *
+ * A hinted answer can never earn the long interval: the outcome route already maps every
+ * second-or-later attempt to `almost`, so the most a hint can buy is a few days rather than a
+ * fortnight. That is the price, and it is the right one — help is not the same as recall.
+ */
+export type ReviewHint =
+  /** A gap, filled. The reader sees the word appear in place and locked. */
+  | { kind: 'blank'; index: number; word: string }
+  /** The next few words of what they were asked to produce, from where they got to. */
+  | { kind: 'lead'; text: string }
+  /** One word they have not reached yet, named. */
+  | { kind: 'word'; word: string }
+  /** The first letter of a word that would have counted. */
+  | { kind: 'letter'; letter: string };
+
+/** How many words a `lead` hint hands over. Enough to restart a sentence, not to finish it. */
+const HINT_LEAD_WORDS = 3;
+
+/**
+ * The first gap that is wrong or empty, filled in.
+ *
+ * Deterministic and dull on purpose: the first one they have not got. Walking to a *random*
+ * missing gap would mean a second identical attempt hinting at a different word, which reads as
+ * the exercise changing under them.
+ */
+function blankHint(
+  blanks: readonly { word: string }[],
+  answers: readonly string[],
+  parts: readonly boolean[],
+): ReviewHint | undefined {
+  for (let i = 0; i < blanks.length; i++) {
+    if (parts[i] === true) continue;
+    if (!blanks[i]?.word) continue;
+    return { kind: 'blank', index: i, word: blanks[i].word };
+  }
+  return undefined;
+}
+
+/** Where the reader got to in what they were asked to produce, plus the next few words. */
+function recallHint(hiddenText: string, attempt: string): ReviewHint | undefined {
+  const wanted = hiddenText.replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
+  if (!wanted.length) return undefined;
+  const marked = markVerseRecall(hiddenText, attempt, RECALL_MIN_SHARE);
+  /*
+   * `reached.matched` counts content words; the lead has to start at a *token*. Walking forward
+   * to the token after the last content word they landed gives a hint that continues their
+   * sentence rather than one that restates it.
+   */
+  const from = Math.min(wanted.length - 1, Math.max(0, marked.reached.matched));
+  const text = wanted.slice(from, from + HINT_LEAD_WORDS).join(' ');
+  return text ? { kind: 'lead', text } : undefined;
+}
+
+/** The first content word of the verse the reader has not reached. */
+function wordHint(text: string, attempt: string): ReviewHint | undefined {
+  const marked = markVerseInitials(text, attempt);
+  const words = contentWords(text);
+  const next = words[Math.min(words.length - 1, Math.max(0, marked.reached.matched))];
+  return next ? { kind: 'word', word: next } : undefined;
+}
+
+/** A letter that would have counted, for the rung where any of several words is right. */
+function keywordHint(
+  text: string,
+  words: readonly string[],
+  seed: string,
+): ReviewHint | undefined {
+  const used = new Set(words.map((word) => word.trim().toLowerCase()).filter(Boolean));
+  const options = contentWords(text).filter((word) => !used.has(word.toLowerCase()));
+  if (!options.length) return undefined;
+  const letter = options[hashSeed(`${seed}:hint`) % options.length].charAt(0);
+  return letter ? { kind: 'letter', letter } : undefined;
 }
 
 export async function gradeNoteAnswer(
@@ -3688,17 +3872,38 @@ export async function buildReviewReveal(
           payload.verseText = null;
         }
         if (FREE_RECALL_KEYS.has(rung.key)) {
-          // Nothing to build: the prompt is the whole question. The verse comes back as truth
-          // once the answer is in, which is why it cannot be sent with the question.
+          /*
+           * At the top tier the prompt is the whole question and nothing is built. Below it the
+           * reader is given a way in — most of the verse to finish, or its opening few words —
+           * and `shown` is that much and no more. The rest is still withheld and still comes
+           * back as truth once the answer is in.
+           */
+          const built = buildVerseRecall(text, verseRecallMode(rung.pass, item.recallState as RecallState));
+          payload.recall = { shown: built.shown, mode: built.mode };
           payload.verseText = null;
         }
         if (rung.key === 'verse.initials') {
-          payload.initials = buildVerseInitials(text);
-          // The letters are the question; the verse would be the answer.
+          const exercise = buildVerseInitials(
+            text,
+            seed,
+            verseInitialsShare(rung.pass, item.recallState as RecallState),
+          );
+          // `reduced` is the answer key and never leaves the server; the letters are the question.
+          payload.initials = exercise
+            ? {
+                initials: exercise.initials,
+                wordCount: exercise.wordCount,
+                tier: exercise.tier,
+                segments: exercise.segments ?? null,
+              }
+            : null;
           if (payload.initials) payload.verseText = null;
         }
         if (rung.key === 'verse.keywords') {
-          payload.keywords = buildVerseKeywords(text);
+          payload.keywords = buildVerseKeywords(
+            text,
+            verseKeywordsCount(rung.pass, item.recallState as RecallState),
+          );
           if (payload.keywords) payload.verseText = null;
         }
         if (rung.key === 'verse.before') {
@@ -3725,10 +3930,15 @@ export async function buildReviewReveal(
         }
         if (rung.key === 'verse.rebuild') {
           // A later pass hides more, and the seed carries the step, so it hides a different set.
-          const cloze = buildVerseCloze(text, seed, verseClozeRatio(rung.pass));
+          const spec = verseClozeSpec(rung.pass, item.recallState as RecallState);
+          const cloze = buildVerseCloze(text, seed, spec.ratio, { maxBlanks: spec.maxBlanks });
           // The pieces either side of each gap, so the page can put an input where the gap is
           // rather than a picture of one. `display` is never sent: it is unfillable.
-          payload.cloze = cloze.blanks.length > 0 ? clozeSegments(cloze) : null;
+          // `uniformWidths` withdraws the letter-count hint at the top tier.
+          payload.cloze =
+            cloze.blanks.length > 0
+              ? clozeSegments(cloze, { uniformWidths: spec.uniformWidths })
+              : null;
           /*
            * The gaps, not the verse. This rung shipped both and rendered neither: it was not
            * graded, so the reveal was only fetched after "Check the verse", and the dock had no

--- a/spa/src/hooks/mutations/useReviewMutations.ts
+++ b/spa/src/hooks/mutations/useReviewMutations.ts
@@ -74,6 +74,15 @@ export interface ReviewOutcomeResponse {
   correctAnswer?: string;
   parts?: boolean[];
   reached?: { matched: number; total: number };
+  /**
+   * One thing to go on for the next try, sent only while there is a go left. Never on a
+   * finalized answer, which carries the answer itself.
+   */
+  hint?:
+    | { kind: 'blank'; index: number; word: string }
+    | { kind: 'lead'; text: string }
+    | { kind: 'word'; word: string }
+    | { kind: 'letter'; letter: string };
   leech?: boolean;
   /** The item has never once been recalled; the offer is worded for that. */
   stalled?: boolean;

--- a/spa/src/hooks/queries/useReview.ts
+++ b/spa/src/hooks/queries/useReview.ts
@@ -87,7 +87,15 @@ export interface ReviewRevealResponse {
   next?: { options: string[] } | null;
   altered?: { tokens: string[] } | null;
   choice?: { options: string[]; opening: boolean } | null;
-  initials?: { initials: string; wordCount: number } | null;
+  initials?: {
+    initials: string;
+    wordCount: number;
+    /** 0 and 1 reduce a share of the words and carry `segments`; 2 is the whole-verse skeleton. */
+    tier: number;
+    segments?: { segments: string[]; blankLengths: number[]; letters: string[] } | null;
+  } | null;
+  /** How much of the verse the recall rung gives away before the reader writes the rest. */
+  recall?: { shown: string | null; mode: string } | null;
   keywords?: { count: number } | null;
   before?: { options: string[] } | null;
   thread?: { title: string | null; members: { id: string; title: string | null }[] } | null;

--- a/spa/src/pages/prototype/PrototypeReviewDock.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewDock.tsx
@@ -69,6 +69,7 @@ import {
   useReviewOutcome,
   useSetReviewStatus,
   useStepBackReview,
+  type ReviewOutcomeResponse,
 } from '../../hooks/mutations/useReviewMutations';
 import { useLibraryPanelNav } from './library-panel/use-library-panel-nav';
 import { buildReviewCardStackOrigin } from './paper-stack-origins';
@@ -115,6 +116,9 @@ import {
   REVIEW_ANSWER_LABEL,
   REVIEW_INDEX_ANSWER_LABEL,
   REVIEW_INITIALS_PLACEHOLDER,
+  reviewHintLeadCopy,
+  reviewHintLetterCopy,
+  reviewHintWordCopy,
 } from './proto-review-copy';
 
 /** Kinds whose answer is another surface: the note itself, or the Thread beside you. */
@@ -279,6 +283,73 @@ function ReviewChoiceChips({
   );
 }
 
+/**
+ * A verse with gaps in it, where the gaps are inputs.
+ *
+ * Two rungs render this: the cloze, where a gap is empty, and the lower tiers of the initials
+ * rung, where each gap keeps its word's first letter beside it as the hint the rung is named
+ * for. One component because they are the same act — put the missing words back where they
+ * belong — and because the second one arrived by staging the first.
+ *
+ * A gap the server has given away after a miss is filled and locked: it is no longer a question,
+ * and leaving it editable invites the reader to retype what they were just handed.
+ */
+function GapLine({
+  segments,
+  blankLengths,
+  letters,
+  values,
+  given,
+  partState,
+  disabled,
+  onChange,
+}: {
+  segments: string[];
+  blankLengths: number[];
+  letters?: string[];
+  values: string[];
+  given: Map<number, string>;
+  partState: (index: number) => 'right' | 'wrong' | undefined;
+  disabled: boolean;
+  onChange: (index: number, value: string) => void;
+}) {
+  return (
+    <p className="proto-challenge__cloze">
+      {segments.map((segment, index) => (
+        <Fragment key={index}>
+          {segment}
+          {index < blankLengths.length ? (
+            <span className="proto-review-dock__gap">
+              {letters?.[index] ? (
+                // The letter is the hint, not part of what gets typed — so it sits beside the
+                // input rather than inside it, where it would have to be typed around.
+                <span className="proto-review-dock__gap-letter" aria-hidden>
+                  {letters[index]}
+                </span>
+              ) : null}
+              <input
+                type="text"
+                className="proto-review-dock__blank"
+                data-answer={given.has(index) ? 'given' : partState(index)}
+                style={{ width: `${Math.max(4, blankLengths[index]) + 1}ch` }}
+                value={values[index] ?? ''}
+                onChange={(event) => onChange(index, event.target.value)}
+                aria-label={
+                  letters?.[index] ? `Word ${index + 1}, starts with ${letters[index]}` : `Blank ${index + 1}`
+                }
+                autoComplete="off"
+                spellCheck={false}
+                readOnly={given.has(index)}
+                disabled={disabled}
+              />
+            </span>
+          ) : null}
+        </Fragment>
+      ))}
+    </p>
+  );
+}
+
 export default function PrototypeReviewDock() {
   const {
     reviewDock,
@@ -402,6 +473,23 @@ export default function PrototypeReviewDock() {
   const [attemptsTotal, setAttemptsTotal] = useState<number | null>(null);
   /** Words already tried and wrong on the altered rung, by index. Spent, like a spent chip. */
   const [spentWords, setSpentWords] = useState<number[]>([]);
+  /*
+   * What the server has handed over after a miss, in the order it handed it over.
+   *
+   * A retry that repeats the identical question with no new information is a second chance to
+   * make the same mistake. One piece per go, and only while a go remains — the finalized answer
+   * carries the real answer, so a hint beside it would be a worse version of what is already
+   * there. Keyed to the item like every other attempt state, so a new question starts clean.
+   */
+  const [hints, setHints] = useState<NonNullable<ReviewOutcomeResponse['hint']>[]>([]);
+  /** Gaps the server filled in. Locked, because they are no longer being asked. */
+  const givenBlanks = useMemo(() => {
+    const out = new Map<number, string>();
+    for (const hint of hints) if (hint.kind === 'blank') out.set(hint.index, hint.word);
+    return out;
+  }, [hints]);
+  /** The most recent hint that is a line to read rather than a gap to fill. */
+  const spokenHint = [...hints].reverse().find((hint) => hint.kind !== 'blank') ?? null;
   const [verdict, setVerdict] = useState<{
     state: 'right' | 'wrong';
     option: string | null;
@@ -431,6 +519,23 @@ export default function PrototypeReviewDock() {
           : REVIEW_TRY_AGAIN_COPY}
       </p>
     ) : null;
+
+  /**
+   * The one thing handed over after a miss, where it is a line rather than a filled gap.
+   *
+   * Sits above the retry line, so the order reads as "here is something" then "have another go".
+   * A `blank` hint never reaches here — it goes into the gap it names, which is the point of the
+   * gaps being inputs.
+   */
+  const hintLine = spokenHint ? (
+    <p className="proto-caption proto-review-dock__hint">
+      {spokenHint.kind === 'lead'
+        ? reviewHintLeadCopy(spokenHint.text)
+        : spokenHint.kind === 'word'
+          ? reviewHintWordCopy(spokenHint.word)
+          : reviewHintLetterCopy(spokenHint.letter)}
+    </p>
+  ) : null;
 
   /** What this rung allows: the server's answer once it has spoken, else the rung's own rule. */
   const goesTotal = attemptsTotal ?? (item ? maxAttemptsFor(item.promptKey) : 0);
@@ -512,6 +617,7 @@ export default function PrototypeReviewDock() {
     setSpentWords([]);
     setVerdict(null);
     setAttemptsTotal(null);
+    setHints([]);
   }, [item?.id]);
 
   /*
@@ -635,6 +741,22 @@ export default function PrototypeReviewDock() {
               setHeldItem(item);
               if (data.attempts) setAttemptsTotal(data.attempts.total);
               setVerdict({ state: 'wrong', option: picked, parts: data.parts, reached: data.reached });
+              /*
+               * One thing to go on. A `blank` hint is applied to the gap it names rather than
+               * printed as a line — the reader watches the word appear where it belongs, which
+               * is the whole point of the gaps being inputs.
+               */
+              if (data.hint) {
+                const hint = data.hint;
+                setHints((current) => [...current, hint]);
+                if (hint.kind === 'blank') {
+                  setBlanks((current) => {
+                    const next = [...current];
+                    next[hint.index] = hint.word;
+                    return next;
+                  });
+                }
+              }
               if (graded?.option) setMissed((m) => [...m, graded.option!]);
               // The altered rung answers with an index, not an option, so it never entered
               // `missed` — a word tapped wrongly stayed live and unmarked on the second go.
@@ -780,6 +902,7 @@ export default function PrototypeReviewDock() {
   const alteredExercise = reveal.data?.altered ?? null;
   const contextChoice = reveal.data?.choice ?? null;
   const initialsExercise = reveal.data?.initials ?? null;
+  const recallExercise = reveal.data?.recall ?? null;
   const keywordsExercise = reveal.data?.keywords ?? null;
   const beforeExercise = reveal.data?.before ?? null;
   const clozeExercise = reveal.data?.cloze ?? null;
@@ -1194,35 +1317,26 @@ export default function PrototypeReviewDock() {
            * into a box underneath in an order the reader has to keep track of.
            *
            * Each input is sized by the word it stands for, which is the same hint the underscore
-           * run always gave.
+           * run always gave — until the top tier, where that hint is withdrawn and every gap is
+           * the same width. See `review-difficulty.ts`.
            */
           <>
             <p className="proto-review-dock__prompt">{item.prompt}</p>
-            <p className="proto-challenge__cloze">
-              {clozeExercise.segments.map((segment, index) => (
-                <Fragment key={index}>
-                  {segment}
-                  {index < clozeExercise.blankLengths.length ? (
-                    <input
-                      type="text"
-                      className="proto-review-dock__blank"
-                      data-answer={partState(index)}
-                      style={{ width: `${Math.max(4, clozeExercise.blankLengths[index]) + 1}ch` }}
-                      value={blanks[index] ?? ''}
-                      onChange={(event) => {
-                        const next = [...blanks];
-                        next[index] = event.target.value;
-                        setBlanks(next);
-                      }}
-                      aria-label={`Blank ${index + 1}`}
-                      autoComplete="off"
-                      spellCheck={false}
-                      disabled={outcome.isPending}
-                    />
-                  ) : null}
-                </Fragment>
-              ))}
-            </p>
+            {subtitle ? <p className="proto-review-dock__subject">{subtitle}</p> : null}
+            <GapLine
+              segments={clozeExercise.segments}
+              blankLengths={clozeExercise.blankLengths}
+              values={blanks}
+              given={givenBlanks}
+              partState={partState}
+              disabled={outcome.isPending}
+              onChange={(index, value) => {
+                const next = [...blanks];
+                next[index] = value;
+                setBlanks(next);
+              }}
+            />
+            {hintLine}
             {retryLine}
             <div className="proto-review-dock__actions">
               <button
@@ -1346,14 +1460,63 @@ export default function PrototypeReviewDock() {
               </p>
             </div>
           </>
-        ) : initialsExercise ? (
+        ) : initialsExercise?.segments && initialsExercise.segments.blankLengths.length > 0 ? (
           /*
-           * The classic memory-verse aid: the first letter of every word, and the reader writes
-           * the verse back. Graded on the content words, in order — connectives and case are
-           * forgiven, because "the" for "a" is not forgetting.
+           * The staged form: a share of the words standing on their first letter, the rest of the
+           * verse shown, and each reduced word typed back in place.
+           *
+           * This rung is on step 1, which is an *opening* step — so before it was staged, roughly
+           * half of all new verses met "write the whole thing from its first letters" as the very
+           * first question Review ever asked them, graded on every content word with a single
+           * yes or no at the end. The top tier is still that exercise; this is the way up to it.
            */
           <>
             <p className="proto-review-dock__prompt">{item.prompt}</p>
+            {subtitle ? <p className="proto-review-dock__subject">{subtitle}</p> : null}
+            <GapLine
+              segments={initialsExercise.segments.segments}
+              blankLengths={initialsExercise.segments.blankLengths}
+              letters={initialsExercise.segments.letters}
+              values={blanks}
+              given={givenBlanks}
+              partState={partState}
+              disabled={outcome.isPending}
+              onChange={(index, value) => {
+                const next = [...blanks];
+                next[index] = value;
+                setBlanks(next);
+              }}
+            />
+            {hintLine}
+            {retryLine}
+            <div className="proto-review-dock__actions">
+              <button
+                type="button"
+                className="proto-settings-btn proto-settings-btn--secondary proto-settings-btn--compact"
+                disabled={
+                  outcome.isPending ||
+                  initialsExercise.segments.blankLengths.some((_, i) => !blanks[i]?.trim())
+                }
+                onClick={() =>
+                  answer('almost', {
+                    words: initialsExercise.segments!.blankLengths.map((_, i) => blanks[i] ?? ''),
+                    promptKey: item.promptKey,
+                  })
+                }
+              >
+                {REVIEW_CHECK_COPY}
+              </button>
+            </div>
+          </>
+        ) : initialsExercise ? (
+          /*
+           * The top tier, and what this rung has always been: the first letter of every word, and
+           * the reader writes the verse back. Graded on the content words, in order — connectives
+           * and case are forgiven, because "the" for "a" is not forgetting.
+           */
+          <>
+            <p className="proto-review-dock__prompt">{item.prompt}</p>
+            {subtitle ? <p className="proto-review-dock__subject">{subtitle}</p> : null}
             <p className="proto-challenge__cloze">{initialsExercise.initials}</p>
             <textarea
               className="proto-review-dock__attempt"
@@ -1362,6 +1525,7 @@ export default function PrototypeReviewDock() {
               onChange={(event) => setAttempt(event.target.value)}
               rows={3}
             />
+            {hintLine}
             {retryLine}
             <div className="proto-review-dock__actions">
               <button
@@ -1507,6 +1671,16 @@ export default function PrototypeReviewDock() {
            */
           <>
             <p className="proto-review-dock__prompt">{item.prompt}</p>
+            {subtitle ? <p className="proto-review-dock__subject">{subtitle}</p> : null}
+            {/*
+             * The way in, at the tiers that give one: most of the verse to finish, or its opening
+             * few words to carry on from. Nothing at the top tier, which is the bare reference
+             * this rung always was. The ellipsis is what makes it read as unfinished rather than
+             * as a verse that stops there.
+             */}
+            {recallExercise?.shown ? (
+              <p className="proto-challenge__cloze">{recallExercise.shown} …</p>
+            ) : null}
             <textarea
               className="proto-review-dock__attempt"
               data-answer={verdict?.state ?? undefined}
@@ -1516,6 +1690,7 @@ export default function PrototypeReviewDock() {
               rows={3}
               disabled={outcome.isPending}
             />
+            {hintLine}
             {retryLine}
             <div className="proto-review-dock__actions">
               <button

--- a/spa/src/pages/prototype/proto-review-copy.ts
+++ b/spa/src/pages/prototype/proto-review-copy.ts
@@ -86,6 +86,21 @@ export const REVIEW_REVEAL_FAILED_COPY = "This one didn't load.";
 export const REVIEW_REVEAL_RETRY_COPY = 'Try again';
 
 /**
+ * What the reader is given after a miss, while the question is still in front of them.
+ *
+ * Offered, not announced: "it goes on", not "the answer is". The rung is still theirs to finish,
+ * and the vocabulary rule at the top of this file applies here more than anywhere — a line that
+ * arrives after a wrong answer is the easiest place in the feature to sound disappointed.
+ *
+ * No counting either. "One of the words" rather than "1 of 3 left": a number about what remains
+ * is the thing this feature does not say.
+ */
+export const reviewHintLeadCopy = (text: string) => `It goes on: “${text}…”`;
+export const reviewHintWordCopy = (word: string) => `One of the words is “${word}”.`;
+export const reviewHintLetterCopy = (letter: string) =>
+  `One of the words starts with ${letter.toUpperCase()}.`;
+
+/**
  * The section heading on Activity.
  *
  * It was "Study Inbox" for its first week and the word was wrong twice over. An inbox is

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -23622,6 +23622,43 @@ button.proto-feed-sheet__stat:hover {
   background-size: 100% 1.5px;
 }
 
+/*
+ * A gap the app filled in after a miss.
+ *
+ * Deliberately neither of the two above: it is not the reader's answer, right or wrong, it is
+ * the one thing they were handed so the next go has somewhere to start. Muted and locked, so it
+ * reads as settled rather than as something still being asked.
+ */
+.proto-review-dock__blank[data-answer='given'] {
+  color: var(--pds-text-secondary);
+  background-image: none;
+  cursor: default;
+}
+
+/*
+ * The initials rung's letter, beside its gap rather than inside it.
+ *
+ * Inside, the reader would have to type around it — the letter is the hint, not part of what the
+ * answer is. `baseline` keeps it sitting on the same line as the words either side, which is what
+ * makes the whole thing still read as a verse.
+ */
+.proto-review-dock__gap {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 1px;
+}
+
+.proto-review-dock__gap-letter {
+  color: var(--pds-text-secondary);
+  font-variant-caps: normal;
+}
+
+/* The line offered after a miss. Sits above the retry line, quieter than it. */
+.proto-review-dock__hint {
+  color: var(--pds-text-secondary);
+  margin-top: 6px;
+}
+
 /* The word you tapped on the altered rung, once the server has marked the tap. */
 .proto-review-dock__altered-word[data-answer='wrong'] {
   background: var(--pds-destructive-bg-strong);

--- a/src/utils/__tests__/review-difficulty.test.ts
+++ b/src/utils/__tests__/review-difficulty.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RECALL_LEAD_IN_WORDS,
+  VERSE_KEYWORDS_MIN_COUNT,
+  reviewTierFor,
+  verseClozeSpec,
+  verseInitialsShare,
+  verseKeywordsCount,
+  verseRecallMode,
+} from '../review-difficulty';
+import { buildVerseCloze, clozeSegments, verseClozeRatio } from '../verse-cloze';
+import { buildVerseInitials, buildVerseRecall, contentWords } from '../verse-ladder-exercises';
+
+const JOHN = 'I am the vine; you are the branches. The one who remains in me — and I in him — bears much fruit, because apart from me you can accomplish nothing.';
+/** A long one, where the gap cap is the thing doing the work rather than the share. */
+const HEBREWS =
+  'Therefore, since we are surrounded by such a great cloud of witnesses, let us throw off everything that hinders and the sin that so easily entangles, and let us run with perseverance the race marked out before us, fixing our eyes upon Jesus, the pioneer and perfecter of faith.';
+
+describe('the tier a rung asks at', () => {
+  it('is the easiest one the first time a rung is met', () => {
+    // The rule the whole file is written around, and the one the owner asked for: whatever else
+    // is true of the verse, a first meeting is easy.
+    for (const state of ['new', 'fragile', 'forming', 'durable', 'slipping'] as const) {
+      expect(reviewTierFor(0, state)).toBe(0);
+    }
+  });
+
+  it('rises with the pass, and stops at the top', () => {
+    expect(reviewTierFor(1)).toBe(1);
+    expect(reviewTierFor(2)).toBe(2);
+    expect(reviewTierFor(9)).toBe(2);
+  });
+
+  it('reaches full strength sooner on a verse the reader demonstrably holds', () => {
+    /*
+     * Reaching tier 2 on pass alone takes a second full loop of the ladder — and intervals
+     * compound as a verse settles, so on the calendar that is a very long way out.
+     */
+    expect(reviewTierFor(1, 'durable')).toBe(2);
+    expect(reviewTierFor(1, 'forming')).toBe(1);
+  });
+
+  it('never drops someone down a tier for missing one', () => {
+    // The ladder already steps back on a genuine stall. Taking the rung away the moment someone
+    // slips would remove the work just as they started doing it.
+    expect(reviewTierFor(1, 'slipping')).toBe(1);
+    expect(reviewTierFor(2, 'slipping')).toBe(2);
+  });
+
+  it('treats nonsense as a first meeting rather than throwing', () => {
+    expect(reviewTierFor(Number.NaN)).toBe(0);
+    expect(reviewTierFor(-3)).toBe(0);
+  });
+});
+
+describe('every rung is gentle at tier 0 and hardest at tier 2', () => {
+  it('widens the cloze and caps its gaps', () => {
+    expect(verseClozeSpec(0).maxBlanks).toBe(2);
+    expect(verseClozeSpec(0).ratio).toBeLessThan(verseClozeSpec(1).ratio);
+    expect(verseClozeSpec(1).ratio).toBeLessThan(verseClozeSpec(2).ratio);
+    expect(verseClozeSpec(2).maxBlanks).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it('caps a long verse to two gaps on a first meeting, where a share alone would not', () => {
+    /*
+     * The cap is what makes tier 0 gentle; a share alone does not. Twenty per cent of a long
+     * verse's content words is still several gaps — a paragraph of typing on what is meant to be
+     * the easiest form of the rung.
+     */
+    const spec = verseClozeSpec(0);
+    const uncapped = buildVerseCloze(HEBREWS, 'seed', spec.ratio);
+    expect(uncapped.blanks.length).toBeGreaterThan(spec.maxBlanks);
+
+    const capped = buildVerseCloze(HEBREWS, 'seed', spec.ratio, { maxBlanks: spec.maxBlanks });
+    expect(capped.blanks.length).toBe(2);
+
+    // And the top tier is not capped at all — the share governs alone.
+    const top = verseClozeSpec(2);
+    const full = buildVerseCloze(HEBREWS, 'seed', top.ratio, { maxBlanks: top.maxBlanks });
+    expect(full.blanks.length).toBeGreaterThan(capped.blanks.length);
+
+    // A short verse needs no cap to be gentle: the share already lands at two.
+    expect(buildVerseCloze(JOHN, 'seed', spec.ratio).blanks.length).toBeLessThanOrEqual(
+      spec.maxBlanks,
+    );
+  });
+
+  it('withdraws the letter-count hint only at the top', () => {
+    const spec = verseClozeSpec(2);
+    const cloze = buildVerseCloze(HEBREWS, 'seed', spec.ratio, { maxBlanks: spec.maxBlanks });
+    const uniform = clozeSegments(cloze, { uniformWidths: true }).blankLengths;
+    expect(new Set(uniform).size).toBe(1);
+    // Below the top, each gap is still sized to the word it stands for.
+    const sized = clozeSegments(cloze).blankLengths;
+    expect(new Set(sized).size).toBeGreaterThan(1);
+    expect(verseClozeSpec(0).uniformWidths).toBe(false);
+    expect(verseClozeSpec(1).uniformWidths).toBe(false);
+  });
+
+  it('reduces a share of the initials before the whole verse', () => {
+    expect(verseInitialsShare(0)).toBeLessThan(verseInitialsShare(1));
+    expect(verseInitialsShare(2)).toBe(1);
+
+    const easy = buildVerseInitials(JOHN, 'seed', verseInitialsShare(0))!;
+    const hard = buildVerseInitials(JOHN, 'seed', verseInitialsShare(2))!;
+    expect(easy.tier).toBe(0);
+    expect(hard.tier).toBe(2);
+    // The easy form still reads as a sentence: most words are whole.
+    expect(easy.reduced.length).toBeLessThan(contentWords(JOHN).length);
+    expect(easy.initials).toContain('branches');
+    // The hard form is the skeleton, and has no gaps to type into.
+    expect(hard.segments).toBeUndefined();
+    expect(hard.initials).not.toContain('branches');
+  });
+
+  it('leaves the top tier byte-identical to the rung before it was staged', () => {
+    // A reader who has climbed to the top meets exactly the exercise they were meeting before.
+    const built = buildVerseInitials(JOHN, 'seed', 1)!;
+    expect(built.initials.split(' ').every((token) => token.replace(/[^\p{L}]/gu, '').length <= 1)).toBe(
+      true,
+    );
+  });
+
+  it('gives the recall rung a way in before taking it away', () => {
+    expect(verseRecallMode(0)).toBe('finish');
+    expect(verseRecallMode(1)).toBe('leadIn');
+    expect(verseRecallMode(2)).toBe('reference');
+
+    const finish = buildVerseRecall(JOHN, 'finish');
+    const lead = buildVerseRecall(JOHN, 'leadIn');
+    const bare = buildVerseRecall(JOHN, 'reference');
+
+    // Most of the verse, then a few words, then nothing.
+    expect(finish.shown!.length).toBeGreaterThan(lead.shown!.length);
+    expect(bare.shown).toBeNull();
+    expect(lead.shown!.split(' ')).toHaveLength(RECALL_LEAD_IN_WORDS);
+
+    // Shown and hidden are the whole verse between them, and never overlap.
+    for (const built of [finish, lead]) {
+      expect(`${built.shown} ${built.hiddenText}`.replace(/\s+/g, ' ').trim()).toBe(
+        JOHN.replace(/\s+/g, ' ').trim(),
+      );
+    }
+    expect(bare.hiddenText).toBe(JOHN.replace(/\s+/g, ' ').trim());
+  });
+
+  it('asks for fewer words before more', () => {
+    expect(verseKeywordsCount(0)).toBe(VERSE_KEYWORDS_MIN_COUNT);
+    expect(verseKeywordsCount(0)).toBeLessThan(verseKeywordsCount(1));
+    expect(verseKeywordsCount(1)).toBeLessThan(verseKeywordsCount(2));
+  });
+
+  it('keeps the old ratio helper honest about the new table', () => {
+    expect(verseClozeRatio(0)).toBe(verseClozeSpec(0).ratio);
+    expect(verseClozeRatio(2)).toBe(verseClozeSpec(2).ratio);
+  });
+});
+
+describe('a staged exercise is the same exercise every time it is asked', () => {
+  it('draws the same words for the same seed, and different ones for another', () => {
+    // The grader rebuilds from seed and tier to mark; a different draw would mark a question
+    // nobody was asked.
+    const a = buildVerseInitials(JOHN, 'item_1:2:0', 0.35)!;
+    const b = buildVerseInitials(JOHN, 'item_1:2:0', 0.35)!;
+    const c = buildVerseInitials(JOHN, 'item_2:2:0', 0.35)!;
+    expect(a.reduced).toEqual(b.reduced);
+    expect(a.reduced).not.toEqual(c.reduced);
+  });
+});

--- a/src/utils/__tests__/review-prompts.test.ts
+++ b/src/utils/__tests__/review-prompts.test.ts
@@ -268,10 +268,29 @@ describe('the ladder wraps rather than ending', () => {
     const first = VERSE_LADDER.length;
     const cycle = VERSE_MAINTENANCE.map((_, i) => verseRungFor(first + i).key);
     expect(cycle).toEqual([...VERSE_MAINTENANCE]);
-    // Learning rungs do not come back: "what does this verse say?" of something memorised
-    // months ago is a question with no work in it.
+    /*
+     * Recognising does not come back: picking a verse's opening out of four is how it is met,
+     * and it asks nothing of someone who has held it for months.
+     *
+     * Recall does, and used to not. The rung is staged now — at its lower tiers it finishes a
+     * verse that is mostly on screen — and without it the ladder never once asked a reader who
+     * had climbed the whole thing to produce the verse.
+     */
     expect(VERSE_MAINTENANCE).not.toContain('verse.recognize');
-    expect(VERSE_MAINTENANCE).not.toContain('verse.recall');
+    expect(VERSE_MAINTENANCE).toContain('verse.recall');
+  });
+
+  it('leaves every reader below step 14 exactly where they were', () => {
+    /*
+     * `ladderStep` is live data, so the maintenance list's order is its identity. Family 2 was
+     * appended rather than inserted: the first full loop is untouched, and only someone already
+     * past it shifts — once, by one family.
+     */
+    const first = VERSE_LADDER.length;
+    const beforeAppend = [1, 3, 4, 5, 6, 7];
+    for (let i = 0; i < beforeAppend.length; i++) {
+      expect(verseRungFor(first + i).family).toBe(beforeAppend[i]);
+    }
   });
 
   it('raises the pass each time round, and never before', () => {
@@ -378,12 +397,13 @@ describe('rung families', () => {
     }
   });
 
-  it('cycles families on maintenance, and never the two learning rungs', () => {
+  it('cycles families on maintenance, and never the rung a verse is met on', () => {
     const first = VERSE_FAMILIES.length;
     for (let i = 0; i < VERSE_MAINTENANCE_FAMILIES.length * 2; i++) {
       const rung = verseRungFor(first + i, `m:${first + i}`, rich);
       expect(rung.family).toBe(VERSE_MAINTENANCE_FAMILIES[i % VERSE_MAINTENANCE_FAMILIES.length]);
-      expect(['verse.recognize', 'verse.recall']).not.toContain(rung.key);
+      // Recall is back in the cycle; recognising is not, and never should be.
+      expect(rung.key).not.toBe('verse.recognize');
       expect(rung.pass).toBe(1 + Math.floor(i / VERSE_MAINTENANCE_FAMILIES.length));
     }
   });
@@ -518,8 +538,23 @@ describe('a family with two members draws both', () => {
   });
 
   it('alternates rebuild and initials across a verse\'s maintenance passes', () => {
-    // Family 1 comes round every six steps, so every recurrence has the same step parity.
-    const steps = [1, 8, 14, 20, 26, 32];
+    /*
+     * Family 1's recurrences, computed rather than written out: the cycle grew by one when
+     * recall rejoined it, and a hard-coded step list silently stopped describing family 1 at
+     * all — it drew six different rungs from five other families and still passed a `toEqual`
+     * on a set it happened to cover.
+     */
+    const first = VERSE_FAMILIES.length;
+    const family1At = VERSE_MAINTENANCE_FAMILIES.indexOf(1);
+    const steps = [1];
+    for (let loop = 0; loop < 5; loop++) {
+      steps.push(first + loop * VERSE_MAINTENANCE_FAMILIES.length + family1At);
+    }
+    for (const step of steps) {
+      expect(VERSE_FAMILIES[verseRungFor(step, `review_x:${step}`, verseMaterial).family]).toEqual(
+        VERSE_FAMILIES[1],
+      );
+    }
     const drawn = new Set(steps.map((s) => verseRungFor(s, `review_x:${s}`, verseMaterial).key));
     expect(drawn).toEqual(new Set(['verse.rebuild', 'verse.initials']));
   });

--- a/src/utils/chapter-ladder-exercises.ts
+++ b/src/utils/chapter-ladder-exercises.ts
@@ -285,13 +285,15 @@ export function buildChapterFinish(input: {
   verses: readonly ChapterVerse[];
   highlightedNumbers: readonly number[];
   seed: string;
-  /** Share of content words hidden — `verseClozeRatio(pass)`, so later passes hide more. */
+  /** Share of content words hidden — from the tier table, so later passes hide more. */
   ratio: number;
+  /** And at most this many gaps, which is what keeps a first meeting answerable. */
+  maxBlanks?: number;
 }): ChapterFinishExercise | null {
   const seed = `${input.seed}:finish`;
   const verse = pickSeeded(chapterFinishCandidates(input.verses, input.highlightedNumbers), seed);
   if (!verse) return null;
-  const cloze = buildVerseCloze(verse.text, seed, input.ratio);
+  const cloze = buildVerseCloze(verse.text, seed, input.ratio, { maxBlanks: input.maxBlanks });
   return cloze.blanks.length ? { verse, cloze } : null;
 }
 

--- a/src/utils/review-difficulty.ts
+++ b/src/utils/review-difficulty.ts
@@ -1,0 +1,135 @@
+/**
+ * How hard a rung asks, and when it gets harder.
+ *
+ * Review's exercises are for repetition, not for catching anyone out. The first time a reader
+ * meets a rung it should be easy enough to be worth doing; what makes it a memory aid rather
+ * than a quiz is that it tightens as the verse becomes theirs.
+ *
+ * Before this there was exactly one difficulty knob in the whole feature — `verseClozeRatio`,
+ * which widened the cloze — and three rungs ignored it entirely. `verse.initials` asked for the
+ * *whole verse* from its first letters, graded on every content word, all-or-nothing, and it is
+ * an opening rung: roughly half of all new verses met it as their first question. `verse.recall`
+ * handed over the reference and nothing else, on day one and on day four hundred alike. Those
+ * are the questions this file exists to stage.
+ *
+ * **One table, read by every surface.** The list resolves a rung to write the prompt, the reveal
+ * builds the exercise, the grader marks it and the truth restores the verse — and all four must
+ * agree about which tier they are in, or a reader is marked against a question they were not
+ * asked. Everything here is pure and derived, so there is nothing stored to migrate and nothing
+ * that can drift between client and server.
+ */
+
+import type { RecallState } from './review-item-kinds';
+
+/** Three steps. Naming them is what stops a bare 0/1/2 spreading through the builders. */
+export type ReviewTier = 0 | 1 | 2;
+
+/**
+ * Which tier a rung is asking at.
+ *
+ * `pass` is the driver and comes from `verseRungFor` / `chapterRungFor`: 0 for the whole climb,
+ * then 1, 2, 3… on each loop of the maintenance cycle. It is rung-scoped rather than
+ * item-scoped, which is exactly the property wanted here — meeting `verse.initials` for the
+ * first time is tier 0 even on a verse the reader has answered a dozen times on other rungs.
+ *
+ * **A first meeting is never accelerated.** `pass === 0` is tier 0 whatever else is true, and
+ * that is the rule the whole file is written around: the first attempt at any exercise is easy.
+ *
+ * `recallState` only shortens the gap between tier 1 and tier 2. Reaching tier 2 on pass alone
+ * takes a second full loop of the ladder — around fifteen clean recalls — and intervals compound
+ * as a verse settles, so on the calendar that is a very long way out. A verse the scheduler
+ * already calls `durable` is one the reader demonstrably holds; asking it at full strength is
+ * the point of having a full strength. `slipping` is deliberately *not* a demotion: dropping
+ * someone to an easier form the moment they miss would take away the rung they were working on
+ * just as they started working on it, and the ladder already steps back on a genuine stall.
+ *
+ * Read from the item as it was asked, never as it now is — the outcome route grades and restores
+ * the truth before the counters move, and this has to sit on the same side of that line.
+ */
+export function reviewTierFor(pass: number, recallState?: RecallState | null): ReviewTier {
+  const base = Math.max(0, Math.trunc(Number.isFinite(pass) ? pass : 0));
+  if (base <= 0) return 0;
+  const accelerated = recallState === 'durable' ? base + 1 : base;
+  return Math.min(2, accelerated) as ReviewTier;
+}
+
+/**
+ * The cloze, tier by tier: how much to hide, and at most how many gaps.
+ *
+ * The cap is what makes tier 0 a genuinely gentle question. A ratio alone does not: 20% of a
+ * long verse's content words is still six or seven gaps, which is a paragraph of typing before
+ * the reader has been given any reason to want to. Two gaps in a verse you have just marked is
+ * a question you can answer.
+ *
+ * `uniformWidths` withdraws the last hint rather than adding difficulty. Every input is sized to
+ * the character count of the word it stands for — "the same hint the underscore run always gave"
+ * — which is a real help early and a giveaway on a verse someone is meant to be producing from
+ * memory. It is the only helper in the feature that is taken away, and it is taken away last.
+ */
+export interface VerseClozeSpec {
+  ratio: number;
+  maxBlanks: number;
+  uniformWidths: boolean;
+}
+
+const CLOZE_TIERS: readonly VerseClozeSpec[] = [
+  { ratio: 0.2, maxBlanks: 2, uniformWidths: false },
+  { ratio: 0.4, maxBlanks: 4, uniformWidths: false },
+  { ratio: 0.6, maxBlanks: Number.POSITIVE_INFINITY, uniformWidths: true },
+];
+
+export function verseClozeSpec(pass: number, recallState?: RecallState | null): VerseClozeSpec {
+  return CLOZE_TIERS[reviewTierFor(pass, recallState)];
+}
+
+/**
+ * What share of a verse's content words are reduced to their first letter.
+ *
+ * At tier 0 and 1 the rest of the verse is shown in full, so the exercise reads as a sentence
+ * with a few words standing on their initials — recognisable, and answerable in place. Only at
+ * tier 2 is it the classic whole-verse skeleton, which is where this rung started and which it
+ * should never have been on a first asking.
+ */
+const INITIALS_TIERS: readonly number[] = [0.35, 0.65, 1];
+
+export function verseInitialsShare(pass: number, recallState?: RecallState | null): number {
+  return INITIALS_TIERS[reviewTierFor(pass, recallState)];
+}
+
+/**
+ * How much of the verse is given before the reader writes the rest.
+ *
+ * - `finish` — most of the verse, cut at a phrase boundary. "Finish it" is a question someone
+ *   can answer on a first meeting, and it is still retrieval.
+ * - `leadIn` — the opening few words only.
+ * - `reference` — nothing but the reference, which is what this rung always did.
+ */
+export type VerseRecallMode = 'finish' | 'leadIn' | 'reference';
+
+const RECALL_TIERS: readonly VerseRecallMode[] = ['finish', 'leadIn', 'reference'];
+
+export function verseRecallMode(pass: number, recallState?: RecallState | null): VerseRecallMode {
+  return RECALL_TIERS[reviewTierFor(pass, recallState)];
+}
+
+/** Where `leadIn` cuts. Enough to start the sentence, not enough to carry it. */
+export const RECALL_LEAD_IN_WORDS = 4;
+
+/** What share of the verse `finish` gives away, before rounding to a phrase boundary. */
+export const RECALL_SHOWN_SHARE = 2 / 3;
+
+/**
+ * How many words the keyword rung asks for.
+ *
+ * Two is a low bar on purpose — this is the lightest rung on the ladder and the one most likely
+ * to be someone's first contact with free recall. Four is as far as it goes: past that the rung
+ * stops being "name some of this verse" and becomes a worse version of `verse.recall`.
+ */
+const KEYWORDS_TIERS: readonly number[] = [2, 3, 4];
+
+export function verseKeywordsCount(pass: number, recallState?: RecallState | null): number {
+  return KEYWORDS_TIERS[reviewTierFor(pass, recallState)];
+}
+
+/** The smallest count any tier asks for, for the availability probe — see `verseFamilyMemberAvailable`. */
+export const VERSE_KEYWORDS_MIN_COUNT = KEYWORDS_TIERS[0];

--- a/src/utils/review-prompts.ts
+++ b/src/utils/review-prompts.ts
@@ -23,6 +23,7 @@
 
 import type { ReviewAskableKind, ReviewItemKind } from './review-item-kinds';
 import { seededIndex } from './verse-cloze';
+import { VERSE_KEYWORDS_MIN_COUNT } from './review-difficulty';
 
 export const REVIEW_PROMPT_KEYS = [
   'note.recognize',
@@ -65,6 +66,16 @@ export interface ReviewPromptContext {
   threadTitle?: string | null;
   /** A distinctive fragment of the verse, for the recognize rung. */
   cue?: string | null;
+  /**
+   * How much of the verse the recall rung is giving away, so the instruction can match the
+   * exercise. Absent on every caller that does not know — which then gets the bare form, the
+   * same one this rung always had.
+   */
+  recallMode?: 'finish' | 'leadIn' | 'reference' | null;
+  /** How many words the keyword rung is asking for, for the same reason. */
+  keywordCount?: number | null;
+  /** Which tier the initials rung is at: below the top it is gaps in place, not a blank page. */
+  initialsTier?: number | null;
 
 }
 
@@ -145,18 +156,42 @@ export const REVIEW_PROMPTS: Record<ReviewPromptKey, (ctx: ReviewPromptContext) 
    */
   'verse.rebuild': (ctx) =>
     named(ctx, (s) => `Fill in the blanks in ${s}.`, 'Fill in the blanks.'),
+  /*
+   * Three ways of asking, because the rung is staged — see `verseRecallMode`. The instruction has
+   * to match the exercise: "write it from memory" printed above two thirds of the verse is the
+   * app misdescribing its own question.
+   */
   'verse.recall': (ctx) =>
-    named(ctx, (s) => `Write ${s} from memory.`, 'Write this verse from memory.'),
+    ctx.recallMode === 'finish'
+      ? named(ctx, (s) => `Finish ${s}.`, 'Finish this verse.')
+      : ctx.recallMode === 'leadIn'
+        ? named(ctx, (s) => `Carry on from the opening of ${s}.`, 'Carry on from the opening.')
+        : named(ctx, (s) => `Write ${s} from memory.`, 'Write this verse from memory.'),
   // The classic memory-verse aid: the first letter of every word, and nothing else.
+  /*
+   * Two ways of asking, for the same reason recall has three: below the top tier only a few
+   * words stand on their initial and they are typed back in place, so "write it from its first
+   * letters" describes an exercise the reader is not being given.
+   */
   'verse.initials': (ctx) =>
-    named(
-      ctx,
-      (s) => `Write ${s} from its first letters.`,
-      'Write the verse from its first letters.',
-    ),
+    (ctx.initialsTier ?? 2) < 2
+      ? named(
+          ctx,
+          (s) => `Finish each word from its first letter in ${s}.`,
+          'Finish each word from its first letter.',
+        )
+      : named(
+          ctx,
+          (s) => `Write ${s} from its first letters.`,
+          'Write the verse from its first letters.',
+        ),
   // Free recall, the lightest rung: any three words that are actually in it.
-  'verse.keywords': (ctx) =>
-    named(ctx, (s) => `Name three words from ${s}.`, 'Name three words from this verse.'),
+  // The count is staged too, so the instruction cannot promise three and show two boxes.
+  'verse.keywords': (ctx) => {
+    const count = ctx.keywordCount ?? 3;
+    const word = count === 2 ? 'two' : count === 4 ? 'four' : 'three';
+    return named(ctx, (s) => `Name ${word} words from ${s}.`, `Name ${word} words from this verse.`);
+  },
   'verse.next': (ctx) =>
     named(ctx, (s) => `Pick the verse that follows ${s}.`, 'Pick the verse that follows.'),
   // Names the chapter, never the verse: "in John 15", because the verse number is the answer.
@@ -266,9 +301,9 @@ export const REVIEW_TASKS: Record<ReviewPromptKey, string> = {
   'note.annotation': 'Pick the passage you wrote this on',
   'verse.recognize': 'Pick how it begins',
   'verse.rebuild': 'Fill in the blanks',
-  'verse.initials': 'Write it from first letters',
-  'verse.recall': 'Write it from memory',
-  'verse.keywords': 'Name three of its words',
+  'verse.initials': 'Fill it in from first letters',
+  'verse.recall': 'Write it out',
+  'verse.keywords': 'Name some of its words',
   'verse.next': 'Pick what comes next',
   'verse.before': 'Pick which comes first',
   'verse.altered': 'Find the changed word',
@@ -456,10 +491,22 @@ export const VERSE_FAMILIES: readonly (readonly ReviewPromptKey[])[] = [
 /**
  * The families that come round again once the ladder is climbed.
  *
- * Recognising and recalling are how a verse is learned, not how it is kept, so families 0 and 2
- * do not repeat. Everything else gets harder each pass, and draws a fresh member each time.
+ * Recognising is how a verse is met, not how it is kept, so family 0 does not repeat.
+ *
+ * **Family 2 — recall and keywords — now does.** It was excluded on the same reasoning, and the
+ * reasoning was right about the *old* rung: a bare reference and a blank box is how a verse is
+ * learned, and asking that of something memorised months ago is a question with no work in it.
+ * But those rungs are staged now (`review-difficulty.ts`), and their lower tiers are not that
+ * question — "finish this verse" is a maintenance question in a way "write it from memory" never
+ * was. Without this the ladder had no rung that ever asks for the whole verse, so a reader who
+ * climbed the whole thing was never once asked to produce it.
+ *
+ * **Appended, never inserted.** `ladderStep` is live data and this list's order is its identity:
+ * offsets 0-5 — steps 8 to 13 — resolve to exactly the families they did before, and only a
+ * reader already past step 13 shifts, once, by one family. Inserting at position 1 would have
+ * moved everyone past step 9.
  */
-export const VERSE_MAINTENANCE_FAMILIES: readonly number[] = [1, 3, 4, 5, 6, 7];
+export const VERSE_MAINTENANCE_FAMILIES: readonly number[] = [1, 3, 4, 5, 6, 7, 2];
 
 /** The maintenance cycle by its default members — what a caller with no seed sees. */
 export const VERSE_MAINTENANCE: readonly ReviewPromptKey[] = VERSE_MAINTENANCE_FAMILIES.map(
@@ -488,7 +535,15 @@ export function verseFamilyMemberAvailable(
     case 'verse.book':
       return (material.locateRivals ?? LOCATE_MIN_RIVALS) < LOCATE_MIN_RIVALS;
     case 'verse.keywords':
-      return (material.contentWordCount ?? 3) >= 3;
+      /*
+       * Judged at the *easiest* tier's count, plus headroom — asking whether a verse can spare
+       * four content words would bar the rung from short verses it reads fine on at two.
+       *
+       * Strictly more than the count, because a verse with exactly as many content words as it
+       * is asked for is not this rung at all: naming all of them is `verse.recall` wearing three
+       * input boxes. The old literal 3 was this rule with the old count baked into it.
+       */
+      return (material.contentWordCount ?? 0) > VERSE_KEYWORDS_MIN_COUNT;
     case 'verse.initials':
       return (material.contentWordCount ?? 4) >= 4;
     case 'verse.marked':

--- a/src/utils/review-sample.ts
+++ b/src/utils/review-sample.ts
@@ -138,6 +138,13 @@ export function buildSampleExercise(
     return { kind, cloze: clozeSegments(cloze), blankCount: cloze.blanks.length };
   }
   if (kind === 'letters') {
+    /*
+     * The whole-verse form, deliberately, and the only place in the feature that still asks for
+     * it cold. The sample is a showcase a visitor picks from a menu of four, not a scheduled
+     * review of their own study — nobody is being asked to hold this verse next week — and it is
+     * already tuned by its own knobs rather than by the ladder's (`SAMPLE_CLOZE_RATIO`). Passing
+     * no share keeps it at tier 2, which is what it has always shown.
+     */
     const built = buildVerseInitials(text);
     return built ? { kind, initials: built.initials, wordCount: built.wordCount } : null;
   }

--- a/src/utils/verse-cloze.ts
+++ b/src/utils/verse-cloze.ts
@@ -17,6 +17,9 @@
  * "the" removed tests typing, not memory — and blanking them makes the verse unreadable as a
  * cue, which defeats the rung.
  */
+import type { RecallState } from './review-item-kinds';
+import { verseClozeSpec } from './review-difficulty';
+
 /** Words too common to be a fair thing to recall. Shared by every text-keyed rung. */
 export const STOPWORDS = new Set([
   'the', 'and', 'for', 'but', 'not', 'you', 'your', 'his', 'her', 'him', 'she', 'they',
@@ -101,20 +104,23 @@ export function bareWord(token: string): string {
 const MAX_BLANK_SHARE = 0.6;
 
 /**
- * How much of a verse to hide on a given maintenance pass.
+ * How much of a verse to hide at a given tier.
  *
  * A verse that has been round the ladder does not need the same gaps back; it needs bigger
  * ones. Three steps and then a ceiling, because `verse.recall` — write it from memory — is
  * already the 100% rung, and a cloze that hides more than three content words in five stops
  * being a prompt and becomes that rung with extra steps.
  *
+ * The steps themselves live in `review-difficulty.ts`, with every other rung's, so the tiers
+ * can be read side by side and a first meeting can be checked to be easy on all of them at
+ * once. The share opens at 0.2 rather than the 0.3 it used to, and is capped in count as well
+ * as in share — see `VerseClozeSpec`.
+ *
  * Driven by the pass, never by `reviewCount`: the count rises on every answer, so ten near
  * misses would hand someone a mostly-blank verse they have never once recalled.
  */
-export function verseClozeRatio(pass: number): number {
-  const steps = [0.3, 0.45, 0.6];
-  const index = Math.min(steps.length - 1, Math.max(0, Math.trunc(Number.isFinite(pass) ? pass : 0)));
-  return Math.min(MAX_BLANK_SHARE, steps[index]);
+export function verseClozeRatio(pass: number, recallState?: RecallState | null): number {
+  return Math.min(MAX_BLANK_SHARE, verseClozeSpec(pass, recallState).ratio);
 }
 
 /**
@@ -129,7 +135,12 @@ export function verseClozeRatio(pass: number): number {
  * At least one blank whenever anything is eligible, because a "rebuild" with nothing missing
  * is just the verse.
  */
-export function buildVerseCloze(text: string, seed: string, ratio = 0.3): VerseCloze {
+export function buildVerseCloze(
+  text: string,
+  seed: string,
+  ratio = 0.3,
+  options?: { maxBlanks?: number },
+): VerseCloze {
   const tokens = text.trim().split(/\s+/).filter(Boolean);
   if (tokens.length === 0) {
     return { tokens: [], blanks: [], display: '' };
@@ -157,7 +168,15 @@ export function buildVerseCloze(text: string, seed: string, ratio = 0.3): VerseC
   }
 
   const ceiling = Math.max(1, Math.floor(eligible.length * MAX_BLANK_SHARE));
-  const target = Math.max(1, Math.min(ceiling, Math.round(eligible.length * ratio)));
+  /*
+   * A count cap as well as a share, because a share alone does not make an easy question.
+   *
+   * Twenty per cent of a long verse's content words is still six or seven gaps — a paragraph of
+   * typing on what is meant to be the gentlest form of the rung. The cap is what makes a first
+   * meeting answerable; at the top tier it is infinite and the share governs alone.
+   */
+  const cap = Math.max(1, Math.trunc(options?.maxBlanks ?? Number.POSITIVE_INFINITY));
+  const target = Math.max(1, Math.min(ceiling, cap, Math.round(eligible.length * ratio)));
 
   // Fisher-Yates over the eligible indices with the seeded PRNG, then take the first `target`
   // and re-sort. Shuffling beats sampling-with-retries: no duplicate draws, no unbounded loop.
@@ -252,6 +271,9 @@ function normaliseWord(value: string): string {
   return value.toLowerCase().replace(/[^\p{L}\p{N}]/gu, '');
 }
 
+/** One width for every gap once the letter-count hint is withdrawn. Wide enough for most words. */
+const UNIFORM_BLANK_WIDTH = 8;
+
 /** The verse split at its gaps, so the gaps can be inputs rather than a picture of inputs. */
 export interface VerseClozeSegments {
   /** `blanks.length + 1` pieces of visible text; a piece may be empty at either end. */
@@ -271,7 +293,10 @@ export interface VerseClozeSegments {
  * Punctuation stays outside the gap, exactly as `display` puts it: a blank standing for
  * `branches` in `branches.` leaves the full stop at the head of the next segment.
  */
-export function clozeSegments(cloze: VerseCloze): VerseClozeSegments {
+export function clozeSegments(
+  cloze: VerseCloze,
+  options?: { uniformWidths?: boolean },
+): VerseClozeSegments {
   const blankAt = new Map(cloze.blanks.map((b) => [b.index, b.word]));
   const blankLengths: number[] = [];
 
@@ -289,7 +314,15 @@ export function clozeSegments(cloze: VerseCloze): VerseClozeSegments {
       const word = blankAt.get(index);
       if (word === undefined) return token;
       const at = token.indexOf(word);
-      blankLengths.push(Math.max(3, word.length));
+      /*
+       * The width of each gap is the last helper standing, and the top tier takes it away.
+       *
+       * Sizing an input to the character count of the word it stands for is a real help while a
+       * verse is being learned and a giveaway once it is meant to be produced from memory — a
+       * four-letter box after "I am the" narrows the field to almost nothing. Every other helper
+       * in the feature is added; this is the only one withdrawn, and it goes last.
+       */
+      blankLengths.push(options?.uniformWidths ? UNIFORM_BLANK_WIDTH : Math.max(3, word.length));
       if (at < 0) return MARK;
       return `${token.slice(0, at)}${MARK}${token.slice(at + word.length)}`;
     })

--- a/src/utils/verse-ladder-exercises.ts
+++ b/src/utils/verse-ladder-exercises.ts
@@ -13,7 +13,26 @@
  * Pure. `verse-cloze.ts` next door does the same job for the rebuild rung.
  */
 
-import { MIN_BLANK_LENGTH, STOPWORDS, bareWord, hashSeed, mulberry32, verseCue } from '@/utils/verse-cloze';
+import {
+  MIN_BLANK_LENGTH,
+  STOPWORDS,
+  bareWord,
+  clozeSegments,
+  hashSeed,
+  markVerseRebuild,
+  mulberry32,
+  verseCue,
+  type VerseClozeBlank,
+  type VerseClozeSegments,
+} from '@/utils/verse-cloze';
+import {
+  RECALL_LEAD_IN_WORDS,
+  RECALL_SHOWN_SHARE,
+  VERSE_KEYWORDS_MIN_COUNT,
+  type ReviewTier,
+  type VerseRecallMode,
+} from '@/utils/review-difficulty';
+import type { RecallState } from '@/utils/review-item-kinds';
 import { buildChoiceExercise, gradeChoiceExercise, type ChoiceExercise } from '@/utils/choice-exercise';
 
 // ─── Sequence: put the phrases back in order ─────────────────────────────────
@@ -419,47 +438,170 @@ export function contentWords(text: string): string[] {
 
 const normaliseWord = (value: string) => value.toLowerCase().replace(/[^\p{L}\p{N}]/gu, '');
 
-/** "I a t v; y a t b." — the classic memory-verse aid, punctuation kept where it was. */
+/**
+ * "I a t v; y a t b." — the classic memory-verse aid, punctuation kept where it was.
+ *
+ * Staged, because the full skeleton is a hard question and this is an *opening* rung: step 1 of
+ * the verse ladder draws between this and the cloze, so roughly half of all new verses met
+ * "write the whole thing from its first letters" as the very first thing Review ever asked
+ * them. Graded on every content word, all-or-nothing, with no per-part feedback — a reader who
+ * missed one word of eighteen saw a bare "not this one" three times running.
+ *
+ * At tier 0 and 1 a *share* of the content words is reduced and the rest of the verse is shown
+ * in full, so the line still reads as a sentence and the reduced words can be typed in place.
+ * Only tier 2 is the whole-verse skeleton this rung started as.
+ */
 export interface VerseInitialsExercise {
+  /** The line as displayed, with the chosen words standing on their first letter. */
   initials: string;
   wordCount: number;
+  tier: ReviewTier;
+  /**
+   * Which words were reduced, in order. **Server-only** — this is the answer key, and it never
+   * goes in a payload. The client gets `segments` and the letters, which is the question.
+   */
+  reduced: VerseClozeBlank[];
+  /**
+   * Tier 0 and 1: the line split at each reduced word, so they are inputs in place rather than
+   * a whole verse retyped into a box. Absent at tier 2, where the exercise is the free-text
+   * skeleton and there is nothing to split.
+   */
+  segments?: VerseClozeSegments & { letters: string[] };
 }
 
-export function buildVerseInitials(text: string): VerseInitialsExercise | null {
+/** Below this there is not enough verse for the rung to be worth asking. */
+const INITIALS_MIN_WORDS = 4;
+
+export function buildVerseInitials(
+  text: string,
+  seed = '',
+  share = 1,
+  recallState?: RecallState | null,
+): VerseInitialsExercise | null {
   const tokens = text.trim().split(/\s+/).filter(Boolean);
-  if (tokens.length < 4) return null;
-  let wordCount = 0;
+  if (tokens.length < INITIALS_MIN_WORDS) return null;
+
+  const wordCount = tokens.filter((token) => bareWord(token)).length;
+  if (wordCount < INITIALS_MIN_WORDS) return null;
+
+  const tier = share >= 1 ? 2 : share >= 0.5 ? 1 : 0;
+  void recallState;
+
+  /*
+   * Tier 2 is the original: every word on its initial, nothing to split, free text.
+   *
+   * Kept byte-identical to what this function used to return, so a reader who has climbed to
+   * the top of the rung meets exactly the exercise they were meeting before.
+   */
+  if (tier === 2) {
+    const initials = tokens
+      .map((token) => {
+        const word = bareWord(token);
+        if (!word) return token;
+        const at = token.indexOf(word);
+        return `${at > 0 ? token.slice(0, at) : ''}${word.charAt(0)}${token.slice(at + word.length)}`;
+      })
+      .join(' ');
+    return { initials, wordCount, tier, reduced: [] };
+  }
+
+  /*
+   * Below that, choose a share of the *content* words — the same eligibility the cloze uses, so
+   * "the" and "and" are never the thing being asked for — and leave every other word whole.
+   */
+  const eligible: number[] = [];
+  tokens.forEach((token, index) => {
+    const word = bareWord(token);
+    if (!word || word.length < MIN_BLANK_LENGTH) return;
+    if (STOPWORDS.has(word.toLowerCase())) return;
+    if (!token.includes(word)) return;
+    eligible.push(index);
+  });
+  if (!eligible.length) return null;
+
+  const target = Math.max(1, Math.min(eligible.length, Math.round(eligible.length * share)));
+  const random = mulberry32(hashSeed(`${seed}:initials`));
+  const pool = [...eligible];
+  for (let i = pool.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [pool[i], pool[j]] = [pool[j], pool[i]];
+  }
+  const chosen = pool.slice(0, target).sort((a, b) => a - b);
+  const reduced: VerseClozeBlank[] = chosen.map((index) => ({ index, word: bareWord(tokens[index]) }));
+
+  const chosenSet = new Set(chosen);
   const initials = tokens
-    .map((token) => {
+    .map((token, index) => {
+      if (!chosenSet.has(index)) return token;
       const word = bareWord(token);
-      if (!word) return token;
-      wordCount += 1;
       const at = token.indexOf(word);
-      const leading = at > 0 ? token.slice(0, at) : '';
-      const trailing = token.slice(at + word.length);
-      return `${leading}${word.charAt(0)}${trailing}`;
+      return `${token.slice(0, at)}${word.charAt(0)}${token.slice(at + word.length)}`;
     })
     .join(' ');
-  return wordCount >= 4 ? { initials, wordCount } : null;
+
+  /*
+   * The gaps, via the cloze splitter, so the spacing and the punctuation rules are the ones
+   * already proved rather than a second implementation of them. The first letter is handed over
+   * beside each gap instead of inside it — it is the hint, not part of the answer.
+   */
+  const base = clozeSegments({ tokens, blanks: reduced, display: '' });
+  const letters = reduced.map((blank) => blank.word.charAt(0));
+
+  return { initials, wordCount, tier, reduced, segments: { ...base, letters } };
 }
 
 /**
- * Did the reader write the verse back from its first letters?
+ * Tier 0 and 1: did each reduced word come back?
+ *
+ * The same per-slot marking the cloze uses, and for the same reason — the reader has been given
+ * the first letter and the word's place in the sentence, so the exact word is a fair ask, and
+ * telling them *which* one missed is what makes the retry worth having.
+ */
+export function markVerseInitialsParts(
+  exercise: VerseInitialsExercise,
+  answers: readonly string[],
+): { correct: boolean; parts: boolean[] } {
+  return markVerseRebuild({ tokens: [], blanks: exercise.reduced, display: '' }, answers);
+}
+
+/**
+ * Tier 2: did the reader write the verse back from its first letters?
  *
  * Every content word must appear, in order, in what they wrote — a subsequence match, so
  * "the/a/and" slips and a paraphrased connective are not marked as forgetting. Case and
  * punctuation are forgiven for the same reason the cloze forgives them.
+ *
+ * Now returns `parts` and `reached` like `markVerseRecall`, which it never did: this was the one
+ * produced rung in the feature that answered a miss with nothing but "no". `parts` indexes the
+ * reader's own words, so showing it back marks their sentence rather than handing over the
+ * verse's vocabulary.
  */
-export function gradeVerseInitials(text: string, attempt: string): boolean {
+export function markVerseInitials(
+  text: string,
+  attempt: string,
+): { correct: boolean; parts: boolean[]; reached: { matched: number; total: number } } {
   const wanted = contentWords(text).map(normaliseWord);
-  if (!wanted.length) return false;
-  const written = attempt.trim().split(/\s+/).map(normaliseWord).filter(Boolean);
+  const written = attempt.trim().split(/\s+/).filter(Boolean);
+  const parts: boolean[] = [];
+  let matched = 0;
   let i = 0;
   for (const word of written) {
-    if (word === wanted[i]) i += 1;
-    if (i === wanted.length) return true;
+    const normalised = normaliseWord(word);
+    if (i < wanted.length && normalised === wanted[i]) {
+      parts.push(true);
+      matched += 1;
+      i += 1;
+      continue;
+    }
+    parts.push(false);
   }
-  return false;
+  const total = wanted.length;
+  return { correct: total > 0 && matched === total, parts, reached: { matched, total } };
+}
+
+/** The whole-verse form, for callers with nothing but a verdict to give (the free sample). */
+export function gradeVerseInitials(text: string, attempt: string): boolean {
+  return markVerseInitials(text, attempt).correct;
 }
 
 /**
@@ -481,6 +623,60 @@ export function gradeVerseInitials(text: string, attempt: string): boolean {
  * now, which is what its name always meant.)
  */
 export const RECALL_MIN_SHARE = 0.45;
+
+/**
+ * How much of the verse is on screen before the reader writes the rest.
+ *
+ * This rung used to hand over the reference and nothing else, on a first meeting and on the
+ * twentieth alike — the single hardest question in the feature, asked at full strength from the
+ * first day. Staged now: finish the sentence, then carry on from its opening, then the bare
+ * reference it always was.
+ *
+ * `shown` is what the card prints above the box; `hiddenText` is the only thing graded. Marking
+ * against the whole verse while showing two thirds of it would mean a reader who finished it
+ * perfectly still scored two thirds — the coverage floor is a share of *what was asked for*.
+ */
+export interface VerseRecallExercise {
+  shown: string | null;
+  hiddenText: string;
+  mode: VerseRecallMode;
+}
+
+export function buildVerseRecall(text: string, mode: VerseRecallMode): VerseRecallExercise {
+  const clean = text.replace(/\s+/g, ' ').trim();
+  if (!clean || mode === 'reference') return { shown: null, hiddenText: clean, mode };
+
+  const tokens = clean.split(' ').filter(Boolean);
+
+  if (mode === 'leadIn') {
+    if (tokens.length <= RECALL_LEAD_IN_WORDS + 1) return { shown: null, hiddenText: clean, mode };
+    return {
+      shown: tokens.slice(0, RECALL_LEAD_IN_WORDS).join(' '),
+      hiddenText: tokens.slice(RECALL_LEAD_IN_WORDS).join(' '),
+      mode,
+    };
+  }
+
+  /*
+   * "Finish it" cuts at a clause boundary rather than at a word count, so the reader is picking
+   * up a sentence rather than resuming mid-phrase. The phrase splitter is the one the sequence
+   * rung already uses; a verse it cannot split falls back to the word count, which is worse and
+   * still answerable.
+   */
+  const phrases = splitVersePhrases(clean);
+  if (phrases.length >= 2) {
+    const target = Math.max(1, Math.round(phrases.length * RECALL_SHOWN_SHARE));
+    const keep = Math.min(phrases.length - 1, target);
+    return {
+      shown: phrases.slice(0, keep).join(' '),
+      hiddenText: phrases.slice(keep).join(' '),
+      mode,
+    };
+  }
+
+  const cut = Math.max(1, Math.min(tokens.length - 1, Math.round(tokens.length * RECALL_SHOWN_SHARE)));
+  return { shown: tokens.slice(0, cut).join(' '), hiddenText: tokens.slice(cut).join(' '), mode };
+}
 
 export function verseRecallCoverage(text: string, attempt: string): number {
   const wanted = contentWords(text).map(normaliseWord);
@@ -542,16 +738,34 @@ export interface VerseKeywordsExercise {
   count: number;
 }
 
+/** The middle tier's count, and the value every caller used before the rung was staged. */
 export const VERSE_KEYWORDS_COUNT = 3;
 
-export function buildVerseKeywords(text: string): VerseKeywordsExercise | null {
+/**
+ * `count` comes from the tier table. A verse without enough distinct content words to fill the
+ * asked-for count falls back to what it can manage rather than refusing the rung — being asked
+ * for two words of a short verse is a fine question, and the alternative is the step resolving
+ * to something else entirely on exactly the verses where this rung reads best.
+ */
+export function buildVerseKeywords(text: string, count = VERSE_KEYWORDS_COUNT): VerseKeywordsExercise | null {
   const distinct = new Set(contentWords(text).map(normaliseWord));
-  return distinct.size >= VERSE_KEYWORDS_COUNT ? { count: VERSE_KEYWORDS_COUNT } : null;
+  /*
+   * Strictly more words than the smallest count asked for — the same rule the availability
+   * probe applies, and it has to be the same or the step resolves to a rung the builder then
+   * refuses. A verse with exactly as many content words as it is asked for is `verse.recall`
+   * wearing input boxes.
+   */
+  if (distinct.size <= VERSE_KEYWORDS_MIN_COUNT) return null;
+  return { count: Math.max(VERSE_KEYWORDS_MIN_COUNT, Math.min(count, distinct.size)) };
 }
 
 /** Each typed word is a distinct content word of the verse, in any order. */
-export function gradeVerseKeywords(text: string, words: readonly string[]): boolean {
-  return markVerseKeywords(text, words).correct;
+export function gradeVerseKeywords(
+  text: string,
+  words: readonly string[],
+  count = VERSE_KEYWORDS_COUNT,
+): boolean {
+  return markVerseKeywords(text, words, count).correct;
 }
 
 /**
@@ -565,6 +779,7 @@ export function gradeVerseKeywords(text: string, words: readonly string[]): bool
 export function markVerseKeywords(
   text: string,
   words: readonly string[],
+  count = VERSE_KEYWORDS_COUNT,
 ): { correct: boolean; parts: boolean[] } {
   const wanted = new Set(contentWords(text).map(normaliseWord));
   const seen = new Set<string>();
@@ -574,7 +789,7 @@ export function markVerseKeywords(
     seen.add(normalised);
     return true;
   });
-  return { correct: parts.length >= VERSE_KEYWORDS_COUNT && parts.every(Boolean), parts };
+  return { correct: parts.length >= count && parts.every(Boolean), parts };
 }
 
 /**


### PR DESCRIPTION
Third of four PRs from the Review exercise review. This is the substantive one: **the first attempt at every exercise is now easy, and difficulty rises as a verse becomes the reader's.**

## The problem

`pass` was the only difficulty knob in the feature, and only one rung read it. `verse.initials`, `verse.recall` and `verse.keywords` were pass-blind — identical on the first asking and the fiftieth.

The sharpest case: **`verse.initials` is an opening rung.** Step 1 of the verse ladder draws between it and the cloze, so roughly half of all new verses met *"write the whole thing from its first letters"* as the very first question Review ever asked about them — graded on 100% of content words, all-or-nothing, and the one produced rung that returned no `parts`, so a reader who missed one word of eighteen saw a bare "not this one" three times running.

## The tier table

One module, `review-difficulty.ts`, that every surface reads — the list resolves a rung to write the prompt, the reveal builds the exercise, the grader marks it, the truth restores the verse, and all four must agree or someone is marked against a question they were not asked.

| Rung | Tier 0 — first meeting | Tier 1 | Tier 2 |
|---|---|---|---|
| `verse.rebuild` / `chapter.finish` | ratio 0.2, **max 2 gaps** | 0.4, max 4 | 0.6, **width hint withdrawn** |
| `verse.initials` | ~35% of words reduced, rest shown, typed in place | ~65% | whole-verse skeleton (today's form) |
| `verse.recall` | **finish it** — 2/3 shown, cut at a clause | 4-word lead-in | reference only (today's form) |
| `verse.keywords` | 2 words | 3 | 4 |

**A first meeting is never accelerated.** `pass === 0` is tier 0 whatever else is true — that is your rule #1 and the file is written around it. `recallState` only shortens the gap between tier 1 and 2, because reaching the top on pass alone takes a second full loop of the ladder and intervals compound as a verse settles, so on the calendar that was a very long way out. `slipping` is deliberately *not* a demotion: taking the rung away the moment someone misses removes the work just as they started doing it.

The gap **count** cap matters as much as the share — 20% of a long verse's content words is still six or seven gaps, a paragraph of typing on what is meant to be the gentlest form.

## Three consequences, not bolt-ons

- **The instruction must match the exercise.** "Write it from memory" printed above two thirds of the verse is the app misdescribing its own question. Recall and initials have per-tier prompts; the keyword count is in its own sentence. The rung is resolved *before* the prompt is filled so both see one pass. (I caught the initials prompt mismatch only by looking at the running app — it still read "Write John 15:5 from its first letters" above three gaps.)
- **`GapLine`** renders the cloze and the staged initials, because they are the same act. Initials keeps each word's first letter *beside* its input, not inside it, where it would have to be typed around.
- **Hints on retry**, stateless: the grader rebuilds from the same seed and tier, sees what missed, and hands over one thing — a gap filled and locked, the next few words, a word, a letter. Only while a go remains (the finalized response carries the answer itself). It cannot buy the long interval: every second-or-later attempt already maps to `almost`.

## Security-shaped detail

Which shape is graded is decided **by the tier, never by which field the client sent**. Reading the field would let a page choose its own marking — send free text on a tier-0 initials item and the all-or-nothing subsequence match runs against a verse that was mostly on screen. There's a contract test for it, and for `reduced` (the answer key) never entering a payload.

## Recall rejoins the maintenance cycle

`VERSE_MAINTENANCE_FAMILIES` gains family 2, **appended**: steps 8–13 resolve exactly as before, and only a reader already past step 13 shifts, once, by one family. Without it the ladder never once asked someone who had climbed the whole thing to actually produce the verse. The old exclusion was right about the old rung and wrong about a staged one.

## Two latent bugs found on the way

1. The keyword availability probe read `>= 3`, but the real rule is *strictly more content words than the count asked for* — a verse with exactly as many is `verse.recall` wearing input boxes. The probe and the builder also disagreed, so a step could resolve to a rung the builder then refused.
2. A test asserting family 1's maintenance draw used hardcoded steps assuming a six-family cycle. It drew from five *other* families and still passed, on a set it happened to cover. Now computed from the cycle.

## Verification

Driven against a real verse in the running app (John 15:5, my own account, borrowed and restored to its exact recorded state; the throwaway probe item was deleted):

- tier-0 **rebuild** renders **2 gaps** where it used to render 3
- tier-0 **initials** renders 3 gaps carrying `r`/`a`/`n` with the rest of the verse intact, and the payload withholds both `verseText` and `reduced`
- a wrong answer fills the first missed gap with **"remains"**, locked and muted, leaving the others live, under *"None of those yet. One more go."*

`npx vitest run` — 575 files, 6160 tests, all passing (14 new tier tests). `npm run build:spa && npm run perf:check` — 1152.5 KB gzipped, no regressions.

The free sample deliberately keeps the whole-verse form: it's a showcase picked from a menu of four, not a scheduled review of anyone's own study, and it's already tuned by its own knobs. Called out in a comment so it doesn't read as an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
