### PR TITLE
fix: stop a stale bundle crashing Home, and tell our errors from extensions

### DIFF
--- a/Changelog/3.9.11.md
+++ b/Changelog/3.9.11.md
@@ -1,0 +1,8 @@
+# Version 3.9.11
+
+**Release Date**: September 11, 2026
+
+## Fixes
+
+- Stop a stale bundle crashing Home, and tell our errors from extensions
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.9.10
+**Version:** 3.9.11
 **Status:** Official 1.0 Released January 8, 2026

--- a/cloudflare/worker.ts
+++ b/cloudflare/worker.ts
@@ -137,6 +137,10 @@ function legacyRedirect(url: URL): Response | null {
   return null;
 }
 
+/** How long the Worker waits on Fly before answering for it. See the /api/* branch below. */
+const API_UPSTREAM_TIMEOUT_MS = 20_000;
+const OG_UPSTREAM_TIMEOUT_MS = 45_000;
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
@@ -148,7 +152,37 @@ export default {
     // (/api/og/image/* and /api/*) pointed at the same origin, so one branch covers them.
     if (url.pathname.startsWith('/api/')) {
       const upstream = new URL(url.pathname + url.search, env.API_ORIGIN);
-      return fetch(new Request(upstream.toString(), request));
+      /*
+       * Bounded, and the failure is spelled out.
+       *
+       * Unbounded, whatever Fly does is what the browser sees — and when the single machine
+       * drops a connection mid-request the browser sees Cloudflare's bare 520, which carries
+       * no path, no status and no body for the client to report. A 504 with a JSON body is
+       * something `api.ts` can parse and `reportApiDiagnostic` can file with its apiPath
+       * attached, which is the difference between a diagnosable incident and one open issue
+       * reading "HTTP 520".
+       *
+       * OG image generation gets its own ceiling: it drives Chromium in the API process
+       * (server/fly.ts) and is served to crawlers, which wait more patiently than Home does.
+       */
+      const timeoutMs = url.pathname.startsWith('/api/og/') ? OG_UPSTREAM_TIMEOUT_MS : API_UPSTREAM_TIMEOUT_MS;
+      try {
+        return await fetch(new Request(upstream.toString(), request), {
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+      } catch (error) {
+        const timedOut = error instanceof Error && error.name === 'TimeoutError';
+        return new Response(
+          JSON.stringify({
+            error: timedOut ? 'Upstream timed out' : 'Upstream unavailable',
+            code: timedOut ? 'upstream_timeout' : 'upstream_unavailable',
+          }),
+          {
+            status: timedOut ? 504 : 502,
+            headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+          },
+        );
+      }
     }
 
     // ── Crawlers on share URLs get server-rendered OG meta HTML from Fly so unfurls

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.9.10",
+  "version": "3.9.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-9-10';
+const CACHE_NAME = 'harvous-cache-v3-9-11';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**
@@ -235,6 +235,15 @@ self.addEventListener('fetch', (event) => {
         })
       )
     );
+    return;
+  }
+
+  // The build-id probe (src/utils/build-freshness.ts). Network-only, and deliberately above
+  // every caching branch below: a cached copy would compare a stale build against its own
+  // stale id, always agree, and the check would silently never fire again. No offline
+  // fallback either — an unanswered probe reads as "cannot tell", which is the safe answer.
+  if (url.pathname === '/build-id.json') {
+    event.respondWith(fetch(event.request, { cache: 'no-store' }));
     return;
   }
 

--- a/release-notes/2026-09-11.md
+++ b/release-notes/2026-09-11.md
@@ -1,0 +1,40 @@
+# What's New in Harvous — September 11, 2026
+
+**Release Date:** September 2026
+**Version:** v3.9.11
+
+A fix for a blank Home screen some people hit after an update, and a better answer when the app
+you have open is no longer the newest one.
+
+---
+
+## Updates in This Release
+
+### Home no longer breaks after an update
+
+**What changed:**
+- The question offered to accounts without Review could fail to load and take the whole Home screen down with it
+- It happened only after a release, and only until the app updated itself
+
+**How it helps you:**
+- Home opens, whether or not that question is ready
+- If one part of Home cannot load, the rest of the page still does
+
+### A clearer way back when the app has moved on
+
+**What changed:**
+- A tab left open across a release now recognises that it is behind
+- Where it used to show an error and offer "Try again", it now says Harvous was updated and offers a reload
+
+**How it helps you:**
+- One button that actually fixes it, instead of a retry that fails the same way
+- Less chance of being stuck on a screen that will not recover on its own
+
+### Fixes
+
+**What changed:**
+- "From your church" now gives up in good time when the server is not answering, rather than holding on
+- The same feed loads a little faster
+
+**How it helps you:**
+- Home settles sooner on a bad connection instead of waiting on one slow section

--- a/scripts/build-id.js
+++ b/scripts/build-id.js
@@ -1,0 +1,20 @@
+/**
+ * The one build identifier this deploy is known by.
+ *
+ * Two things need to agree on it: the service worker's CACHE_NAME
+ * (scripts/inject-sw-cache-version.js) and the `build-id.json` the running client compares
+ * itself against (vite.config.ts). If they were derived separately they could disagree, and a
+ * client would either nag for an update it already has or miss one it needs.
+ *
+ * Netlify sets COMMIT_REF (and DEPLOY_ID) on every build, including redeploys of the same
+ * commit. GitHub Actions sets GITHUB_SHA instead and sets neither of the others — so the
+ * Cloudflare deploy workflow would otherwise fall through to an empty id. Keep all three.
+ *
+ * Empty locally, on purpose: local builds stay deterministic and don't churn tracked files.
+ * `isBuildIdStale` treats an empty id as "cannot tell", never as stale.
+ */
+export function resolveBuildId() {
+  return (process.env.COMMIT_REF || process.env.DEPLOY_ID || process.env.GITHUB_SHA || '')
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .slice(0, 8);
+}

--- a/scripts/inject-sw-cache-version.js
+++ b/scripts/inject-sw-cache-version.js
@@ -18,6 +18,7 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { resolveBuildId } from './build-id.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
@@ -28,14 +29,9 @@ const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
 const version = pkg.version || '0.0.0';
 // e.g. "1.132.0" -> "v1-132-0"
 const cacheVersion = 'v' + version.replace(/\./g, '-');
-// Netlify sets COMMIT_REF (and DEPLOY_ID) on every build, including redeploys of the same
-// commit. GitHub Actions sets GITHUB_SHA instead, and sets neither of the others — so the
-// Cloudflare deploy workflow would otherwise fall through to an empty build id here and ship
-// a byte-identical sw.js for every deploy between two version bumps, which is exactly the
-// failure the paragraph above describes. Keep all three.
-const buildId = (process.env.COMMIT_REF || process.env.DEPLOY_ID || process.env.GITHUB_SHA || '')
-  .replace(/[^a-zA-Z0-9]/g, '')
-  .slice(0, 8);
+// Shared with the client's own freshness check — see scripts/build-id.js for why all three
+// env vars matter, and why this is empty locally.
+const buildId = resolveBuildId();
 const cacheName = buildId
   ? `harvous-cache-${cacheVersion}-${buildId}`
   : `harvous-cache-${cacheVersion}`;

--- a/server/routes/church.ts
+++ b/server/routes/church.ts
@@ -50,6 +50,7 @@ import {
   desc,
   inArray,
   isNull,
+  sql,
 } from '../db';
 import { getAuthenticatedAuth, requireAuth } from '../middleware/auth';
 import { rateLimit } from '@/utils/rate-limit';
@@ -344,7 +345,7 @@ app.post('/api/church/channels/:spaceId/unfollow', requireAuth, rateLimit('write
  * Encrypted notes are excluded at the query level, matching how every other
  * shared surface treats them.
  */
-app.get('/api/church/feed', requireAuth, async (c) => {
+app.get('/api/church/feed', requireAuth, rateLimit('read'), async (c) => {
   try {
     const auth = getAuthenticatedAuth(c);
     const limitRaw = Number(c.req.query('limit') ?? FEED_LIMIT_DEFAULT);
@@ -385,7 +386,14 @@ app.get('/api/church/feed', requireAuth, async (c) => {
       .select({
         noteId: Notes.id,
         title: Notes.title,
-        content: Notes.content,
+        /*
+         * A prefix, not the note. Every row here is reduced to a 180-character excerpt
+         * (FEED_EXCERPT_LENGTH) a few lines below, so selecting whole note bodies for up to
+         * 50 rows was this route's largest payload and its largest CPU cost — stripHtmlForCard
+         * regexes each one on a shared vCPU. 4000 chars leaves ample room for HTML tags to
+         * inflate the prefix and still yield 180 visible characters.
+         */
+        content: sql<string | null>`left(${Notes.content}, 4000)`,
         noteType: Notes.noteType,
         authorUserId: Notes.userId,
         createdAt: Notes.createdAt,

--- a/server/utils/__tests__/diagnostics-sanitize.test.ts
+++ b/server/utils/__tests__/diagnostics-sanitize.test.ts
@@ -109,6 +109,72 @@ describe('topStackFrame', () => {
 });
 
 describe('sanitizeDiagnosticPayload', () => {
+  /*
+   * The client has always sent these three; the metadata allowlist dropped them, which is why
+   * an extension's crash and ours looked identical in the admin list. Keeping them is what
+   * makes the panel's script-origin line possible.
+   */
+  it('keeps the script origin of a client error', () => {
+    const result = sanitizeDiagnosticPayload({
+      source: 'client_js',
+      message: 'Something broke',
+      anonymousSessionId: 'sess-123',
+      platform: 'web',
+      metadata: {
+        scriptFilename: 'https://app.harvous.com/assets/index-1uUOH_2w.js',
+        scriptLineno: 49,
+        scriptColno: 118,
+      },
+    });
+    expect(result?.metadata?.scriptFilename).toBe('https://app.harvous.com/assets/index-1uUOH_2w.js');
+    expect(result?.metadata?.scriptLineno).toBe(49);
+    expect(result?.metadata?.scriptColno).toBe(118);
+  });
+
+  it('strips a query string off the script filename', () => {
+    const result = sanitizeDiagnosticPayload({
+      source: 'client_js',
+      message: 'Something broke',
+      anonymousSessionId: 'sess-123',
+      platform: 'web',
+      metadata: { scriptFilename: 'https://app.harvous.com/assets/index.js?token=abc' },
+    });
+    expect(result?.metadata?.scriptFilename).toBe('https://app.harvous.com/assets/index.js');
+  });
+
+  /* Rejected at ingest too, so a build predating the client-side filter can't keep filing these. */
+  it('rejects an error thrown by a browser extension', () => {
+    const byFilename = sanitizeDiagnosticPayload({
+      source: 'client_js',
+      message: 'window.ethereum.emit is not a function',
+      anonymousSessionId: 'sess-123',
+      platform: 'web',
+      metadata: { scriptFilename: 'chrome-extension://abcdefgh/inject.js' },
+    });
+    expect(byFilename).toBeNull();
+
+    const byStack = sanitizeDiagnosticPayload({
+      source: 'client_js',
+      message: "null is not an object (evaluating 'document.querySelector(...).content')",
+      anonymousSessionId: 'sess-123',
+      platform: 'web',
+      stack: 'TypeError\n    at chrome-extension://abcdefgh/share.js:12:9',
+    });
+    expect(byStack).toBeNull();
+  });
+
+  it('still accepts our own crash with an extension somewhere in the stack', () => {
+    const result = sanitizeDiagnosticPayload({
+      source: 'client_js',
+      message: "Cannot read properties of undefined (reading 'blankLengths')",
+      anonymousSessionId: 'sess-123',
+      platform: 'web',
+      stack:
+        'TypeError\n    at chrome-extension://abcdefgh/hook.js:3:1\n    at https://app.harvous.com/assets/index.js:20:7',
+    });
+    expect(result).not.toBeNull();
+  });
+
   it('accepts valid client payload', () => {
     const result = sanitizeDiagnosticPayload({
       source: 'client_js',

--- a/server/utils/diagnostics-sanitize.ts
+++ b/server/utils/diagnostics-sanitize.ts
@@ -13,6 +13,7 @@ import {
   normalizeDiagnosticMessageForSignature,
   redactDiagnosticRoute,
   scrubDiagnosticText,
+  isExtensionOriginated,
   isNoiseDiagnosticMessage,
 } from '@/utils/diagnostics-route';
 
@@ -23,6 +24,7 @@ const MAX_ROUTE = 300;
 const MAX_SESSION_ID = 64;
 const MAX_APP_VERSION = 40;
 const MAX_METADATA_JSON = 2000;
+const MAX_SCRIPT_FILENAME = 200;
 
 export type SanitizedDiagnosticInput = {
   source: DiagnosticSource;
@@ -80,6 +82,27 @@ function sanitizeMetadata(value: unknown): Record<string, unknown> | null {
   if (typeof raw.userAgentFamily === 'string' && raw.userAgentFamily.trim()) {
     out.userAgentFamily = truncate(scrubDiagnosticText(raw.userAgentFamily.trim()), 80);
   }
+  /*
+   * Where the throwing script was served from, plus its position. The client has always sent
+   * these (see the `error` listener in diagnostics-client.ts); the allowlist dropped them, which
+   * is why extension errors and our own were indistinguishable in the admin list. Query string
+   * stripped — a script URL's params are the one place a token could ride along.
+   */
+  if (typeof raw.scriptFilename === 'string' && raw.scriptFilename.trim()) {
+    const withoutQuery = raw.scriptFilename.trim().split('?')[0] ?? '';
+    if (withoutQuery) {
+      out.scriptFilename = truncate(scrubDiagnosticText(withoutQuery), MAX_SCRIPT_FILENAME);
+    }
+  }
+  if (typeof raw.scriptLineno === 'number' && Number.isFinite(raw.scriptLineno)) {
+    out.scriptLineno = Math.round(raw.scriptLineno);
+  }
+  if (typeof raw.scriptColno === 'number' && Number.isFinite(raw.scriptColno)) {
+    out.scriptColno = Math.round(raw.scriptColno);
+  }
+  if (typeof raw.staleBuild === 'boolean') {
+    out.staleBuild = raw.staleBuild;
+  }
   if (Object.keys(out).length === 0) return null;
   const json = JSON.stringify(out);
   if (json.length > MAX_METADATA_JSON) return null;
@@ -107,6 +130,14 @@ export function sanitizeDiagnosticPayload(body: unknown): SanitizedDiagnosticInp
   if (!isDiagnosticPlatform(platform)) return null;
 
   const stackRaw = typeof raw.stack === 'string' ? raw.stack : null;
+  /*
+   * Rejected here as well as at capture, so a build that predates the client-side filter
+   * cannot keep filling the admin list -- the same reasoning as isNoiseDiagnosticMessage above.
+   */
+  const metaRaw = (raw.metadata ?? null) as Record<string, unknown> | null;
+  const scriptFilenameRaw =
+    metaRaw && typeof metaRaw.scriptFilename === 'string' ? metaRaw.scriptFilename : null;
+  if (isExtensionOriginated(scriptFilenameRaw, stackRaw)) return null;
   const routeRaw = typeof raw.route === 'string' ? raw.route : null;
   const appVersionRaw = typeof raw.appVersion === 'string' ? raw.appVersion.trim() : null;
   const manualNoteRaw = typeof raw.manualNote === 'string' ? raw.manualNote.trim() : null;

--- a/spa/src/pages/prototype/PrototypeReviewSample.tsx
+++ b/spa/src/pages/prototype/PrototypeReviewSample.tsx
@@ -79,12 +79,28 @@ export default function PrototypeReviewSample({
   const translation = sample.translation?.trim() || 'NET';
   const translationLabel = TRANSLATIONS[translation]?.abbreviation ?? translation;
   const exercise = sample.exercise;
+
+  /*
+   * Narrowed on the data, not only on the `kind` discriminant.
+   *
+   * The type says a 'blanks' exercise always carries a cloze, and the builder upholds that
+   * (buildSampleExercise returns null rather than a blanks exercise with no blanks). But the
+   * type only describes *this* build's contract, and the card is served to whatever bundle the
+   * reader is running: when the sample payload was re-nested from `sample.cloze` to
+   * `sample.exercise.cloze`, every still-cached bundle read `undefined.blankLengths` and took
+   * the whole Home route down with it. Rendering nothing is the right failure here -- the
+   * section below is an offer, not something the reader asked for.
+   */
+  const cloze = exercise && exercise.kind === 'blanks' ? (exercise.cloze ?? null) : null;
+  const blankLengths = cloze?.blankLengths ?? null;
+  if (!exercise || (exercise.kind === 'blanks' && !blankLengths)) return null;
+
   const available = sample.available ?? [exercise.kind];
 
   /* Every surface has its own "is there anything to check yet", and none may submit empty. */
   const filled =
     exercise.kind === 'blanks'
-      ? exercise.cloze.blankLengths.every((_, i) => (blanks[i] ?? '').trim().length > 0)
+      ? (blankLengths ?? []).every((_, i) => (blanks[i] ?? '').trim().length > 0)
       : exercise.kind === 'letters'
         ? written.trim().length > 0
         : exercise.kind === 'order'
@@ -110,7 +126,7 @@ export default function PrototypeReviewSample({
   const base = { day, translation, exercise: exercise.kind, attemptNumber };
   const submit = () => {
     if (exercise.kind === 'blanks') {
-      send({ ...base, words: exercise.cloze.blankLengths.map((_, i) => (blanks[i] ?? '').trim()) });
+      send({ ...base, words: (blankLengths ?? []).map((_, i) => (blanks[i] ?? '').trim()) });
     } else if (exercise.kind === 'letters') {
       send({ ...base, text: written.trim() });
     } else if (exercise.kind === 'order') {
@@ -221,16 +237,16 @@ export default function PrototypeReviewSample({
 
           <p className="proto-review-dock__prompt">{REVIEW_SAMPLE_PROMPTS[exercise.kind]}</p>
 
-          {exercise.kind === 'blanks' ? (
+          {exercise.kind === 'blanks' && cloze && blankLengths ? (
             <p className="proto-challenge__cloze">
-              {exercise.cloze.segments.map((segment, index) => (
+              {(cloze.segments ?? []).map((segment, index) => (
                 <Fragment key={index}>
                   {segment}
-                  {index < exercise.cloze.blankLengths.length ? (
+                  {index < blankLengths.length ? (
                     <input
                       type="text"
                       className="proto-review-dock__blank"
-                      style={{ width: `${Math.max(4, exercise.cloze.blankLengths[index]) + 1}ch` }}
+                      style={{ width: `${Math.max(4, blankLengths[index]) + 1}ch` }}
                       value={blanks[index] ?? ''}
                       onChange={(event) => {
                         const next = [...blanks];

--- a/spa/src/pages/prototype/PrototypeRouteErrorState.tsx
+++ b/spa/src/pages/prototype/PrototypeRouteErrorState.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from '@tanstack/react-router';
 import Icon from '@/components/react/Icon';
 import { isDedicatedPrototypeHost, prototypeHomeRouteTo } from '@/lib/prototype-path';
 import { reportRouteBoundaryError } from '@/utils/diagnostics-client';
+import { isStaleBuild } from '@/utils/build-freshness';
+import { reloadPrototypeAfterUpdate } from '@/utils/prototype-app-update-notice';
 import PrototypeMainPaneShell from './PrototypeMainPaneShell';
 import PrototypePaneEmptyState from './PrototypePaneEmptyState';
 import PrototypeSupportSheet from './PrototypeSupportSheet';
@@ -22,14 +24,53 @@ export default function PrototypeRouteErrorState({ error, reset }: Props) {
   const navigate = useNavigate();
   const reportedRef = useRef(false);
   const [supportOpen, setSupportOpen] = useState(false);
+  const [staleBuild, setStaleBuild] = useState(false);
 
+  /*
+   * Ask whether this bundle is still the deployed one before blaming the code.
+   *
+   * A crash in a client the deploy has moved on from is not a bug the reader can help with by
+   * filing it, and "Try again" re-renders the same stale component. Reloading is the actual
+   * fix, so offer that instead. The answer also rides along on the report, so the admin list
+   * can tell a skew crash from a real one rather than showing both as the same mystery.
+   */
   useEffect(() => {
     if (reportedRef.current) return;
     reportedRef.current = true;
-    reportRouteBoundaryError(error);
+    let cancelled = false;
+    void isStaleBuild().then((stale) => {
+      if (!cancelled && stale) setStaleBuild(true);
+      reportRouteBoundaryError(error, stale ? { staleBuild: true } : null);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [error]);
 
   const detail = errorMessage(error);
+
+  if (staleBuild) {
+    const stalePane = (
+      <PrototypePaneEmptyState
+        className="proto-editor-empty-state--route-error"
+        role="alert"
+        title="Harvous was updated"
+        description={
+          <p className="proto-editor-empty-state__line">
+            This tab is still running an older version. Reload to pick up the latest.
+          </p>
+        }
+        action={{ label: 'Reload', onClick: reloadPrototypeAfterUpdate }}
+      />
+    );
+    return isDedicatedPrototypeHost() ? (
+      <PrototypeMainPaneShell>{stalePane}</PrototypeMainPaneShell>
+    ) : (
+      <div className="page-flex-column">
+        <div className="page-flex-column__main proto-route-error-host">{stalePane}</div>
+      </div>
+    );
+  }
 
   const pane = (
     <>

--- a/spa/src/pages/prototype/__tests__/review-sample-card.test.tsx
+++ b/spa/src/pages/prototype/__tests__/review-sample-card.test.tsx
@@ -38,6 +38,38 @@ beforeEach(() => {
   notNow.mockReset();
 });
 
+/**
+ * A payload this build's types say is impossible, because the reader's build and the server's
+ * are not the same build.
+ *
+ * When the sample payload was re-nested from `sample.cloze` to `sample.exercise.cloze`, every
+ * bundle still cached in a service worker read `undefined.blankLengths` and took the whole Home
+ * route down with it — for free accounts only, since that is who is offered this card.
+ * Rendering nothing beats rendering an error screen over an offer nobody asked for.
+ */
+describe('the sample card, against a payload from another build', () => {
+  it('renders nothing rather than throwing when the cloze is missing', () => {
+    const withoutCloze = {
+      ...sample,
+      exercise: { kind: 'blanks' as const, blankCount: 2 },
+    } as unknown as typeof sample;
+
+    const { container } = render(
+      <PrototypeReviewSample sample={withoutCloze} day="2026-09-03" maxAttempts={2} onSeePlus={seePlus} onNotNow={notNow} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing rather than throwing when the exercise itself is missing', () => {
+    const withoutExercise = { ...sample, exercise: undefined } as unknown as typeof sample;
+
+    const { container } = render(
+      <PrototypeReviewSample sample={withoutExercise} day="2026-09-03" maxAttempts={2} onSeePlus={seePlus} onNotNow={notNow} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
 describe('the sample card', () => {
   it('says whose verse it is, and puts an input in each gap', () => {
     render(<PrototypeReviewSample sample={sample} day="2026-09-03" maxAttempts={2} onSeePlus={seePlus} onNotNow={notNow} />);

--- a/spa/src/pages/prototype/__tests__/route-error-stale-build.test.tsx
+++ b/spa/src/pages/prototype/__tests__/route-error-stale-build.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * What a crash looks like when the bundle, not the code, is the problem.
+ *
+ * "Try again" re-renders the same stale component and fails identically; the honest offer is a
+ * reload. The report still goes out either way — tagged, so the admin list can tell the two
+ * apart instead of showing both as one mystery.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const isStaleBuild = vi.fn();
+const reportRouteBoundaryError = vi.fn();
+const reloadPrototypeAfterUpdate = vi.fn();
+
+vi.mock('@/utils/build-freshness', () => ({ isStaleBuild }));
+vi.mock('@/utils/diagnostics-client', () => ({ reportRouteBoundaryError }));
+vi.mock('@/utils/prototype-app-update-notice', () => ({ reloadPrototypeAfterUpdate }));
+vi.mock('@tanstack/react-router', () => ({ useNavigate: () => vi.fn() }));
+
+const PrototypeRouteErrorState = (await import('../PrototypeRouteErrorState')).default;
+
+beforeEach(() => {
+  isStaleBuild.mockReset();
+  reportRouteBoundaryError.mockReset();
+  reloadPrototypeAfterUpdate.mockReset();
+});
+
+describe('a route crash', () => {
+  const error = new Error("Cannot read properties of undefined (reading 'blankLengths')");
+
+  it('offers a reload, not a retry, when this bundle is behind the deploy', async () => {
+    isStaleBuild.mockResolvedValue(true);
+    render(<PrototypeRouteErrorState error={error} reset={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText(/Harvous was updated/)).toBeTruthy());
+    expect(screen.getByRole('button', { name: /reload/i })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /try again/i })).toBeNull();
+    // The crash is still ours to know about, and is marked as the skew it is.
+    expect(reportRouteBoundaryError).toHaveBeenCalledWith(error, { staleBuild: true });
+  });
+
+  it('shows the ordinary error state when the bundle is current', async () => {
+    isStaleBuild.mockResolvedValue(false);
+    render(<PrototypeRouteErrorState error={error} reset={vi.fn()} />);
+
+    await waitFor(() => expect(reportRouteBoundaryError).toHaveBeenCalledWith(error, null));
+    expect(screen.getByText(/Whoops/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeTruthy();
+    expect(screen.queryByText(/Harvous was updated/)).toBeNull();
+  });
+});

--- a/src/components/react/AdminDiagnosticsPanel.tsx
+++ b/src/components/react/AdminDiagnosticsPanel.tsx
@@ -24,6 +24,25 @@ function statusLabel(status: DiagnosticTriageStatus): string {
   return 'Open';
 }
 
+/**
+ * Which script threw, and where. The single most useful line for telling one of our own
+ * crashes from a browser extension's -- ingest stores at most 200 chars of it.
+ */
+function scriptOrigin(metadata: string | null): string | null {
+  if (!metadata) return null;
+  try {
+    const parsed = JSON.parse(metadata) as Record<string, unknown>;
+    const file = typeof parsed.scriptFilename === 'string' ? parsed.scriptFilename : null;
+    if (!file) return null;
+    const line = typeof parsed.scriptLineno === 'number' ? parsed.scriptLineno : null;
+    const col = typeof parsed.scriptColno === 'number' ? parsed.scriptColno : null;
+    if (line == null) return file;
+    return col == null ? `${file}:${line}` : `${file}:${line}:${col}`;
+  } catch {
+    return null;
+  }
+}
+
 function IssueRow({ issue }: { issue: DiagnosticIssueSummary }) {
   const [expanded, setExpanded] = useState(false);
   const events = useAdminDiagnosticIssueEvents(expanded ? issue.issueSignature : null);
@@ -107,8 +126,11 @@ function IssueRow({ issue }: { issue: DiagnosticIssueSummary }) {
                 <span>{formatWhen(ev.createdAt)}</span>
               </div>
               {ev.route ? <div className="admin-diagnostics__sample-route">{ev.route}</div> : null}
+              {scriptOrigin(ev.metadata) ? (
+                <div className="admin-diagnostics__sample-route">{scriptOrigin(ev.metadata)}</div>
+              ) : null}
               {ev.manualNote ? <div className="admin-diagnostics__sample-note">{ev.manualNote}</div> : null}
-              {ev.stack ? <pre className="admin-diagnostics__sample-stack">{ev.stack.slice(0, 600)}</pre> : null}
+              {ev.stack ? <pre className="admin-diagnostics__sample-stack">{ev.stack}</pre> : null}
             </div>
           ))}
         </div>

--- a/src/utils/__tests__/build-freshness.test.ts
+++ b/src/utils/__tests__/build-freshness.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The check that tells a skew crash from a real one.
+ *
+ * Every uncertain case must resolve to "not stale": claiming staleness pushes a reload at
+ * someone whose actual problem is a bug we should be fixing, and hides it from us while it
+ * does so.
+ */
+describe('isStaleBuild', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  async function load() {
+    return (await import('../build-freshness')).isStaleBuild;
+  }
+
+  it('is stale when the deployed build id differs from ours', async () => {
+    vi.stubGlobal('__BUILD_ID__', 'aaaa1111');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ buildId: 'bbbb2222' }) }),
+    );
+    expect(await (await load())()).toBe(true);
+  });
+
+  it('is not stale when the ids match', async () => {
+    vi.stubGlobal('__BUILD_ID__', 'aaaa1111');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ buildId: 'aaaa1111' }) }),
+    );
+    expect(await (await load())()).toBe(false);
+  });
+
+  it('is not stale when this build has no id at all (local build)', async () => {
+    vi.stubGlobal('__BUILD_ID__', '');
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    expect(await (await load())()).toBe(false);
+    // And it does not even ask — there is nothing to compare against.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('is not stale when the probe fails, 404s, or answers without an id', async () => {
+    vi.stubGlobal('__BUILD_ID__', 'aaaa1111');
+
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    expect(await (await load())()).toBe(false);
+    vi.resetModules();
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) }));
+    expect(await (await load())()).toBe(false);
+    vi.resetModules();
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+    expect(await (await load())()).toBe(false);
+  });
+
+  it('never lets the probe hang a caller that is holding a crash report open', async () => {
+    vi.stubGlobal('__BUILD_ID__', 'aaaa1111');
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ buildId: 'a' }) });
+    vi.stubGlobal('fetch', fetchMock);
+    await (await load())();
+    expect(fetchMock.mock.calls[0][1]?.signal).toBeDefined();
+  });
+});

--- a/src/utils/__tests__/diagnostics-client.test.ts
+++ b/src/utils/__tests__/diagnostics-client.test.ts
@@ -42,6 +42,51 @@ describe('diagnostics-client', () => {
     expect(body.metadata).toHaveProperty('navigatorOnLine');
   });
 
+  it('skips an error thrown by a browser extension', async () => {
+    const fetchMock = vi.mocked(fetch);
+    const { initDiagnosticCapture } = await import('../diagnostics-client');
+    initDiagnosticCapture();
+
+    const err = new Error('window.ethereum.emit is not a function');
+    err.stack = 'TypeError\n    at chrome-extension://abcdefgh/inject.js:1:1';
+    window.dispatchEvent(
+      new ErrorEvent('error', {
+        message: err.message,
+        filename: 'chrome-extension://abcdefgh/inject.js',
+        lineno: 1,
+        colno: 1,
+        error: err,
+      }),
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('still reports our own crash, and carries where it was thrown', async () => {
+    const fetchMock = vi.mocked(fetch);
+    const { initDiagnosticCapture } = await import('../diagnostics-client');
+    initDiagnosticCapture();
+
+    const err = new Error("Cannot read properties of undefined (reading 'blankLengths')");
+    err.stack = 'TypeError\n    at https://app.harvous.com/assets/index.js:49:118';
+    window.dispatchEvent(
+      new ErrorEvent('error', {
+        message: err.message,
+        filename: 'https://app.harvous.com/assets/index.js',
+        lineno: 49,
+        colno: 118,
+        error: err,
+      }),
+    );
+
+    // Count, not times: initDiagnosticCapture() in the earlier cases left their own listeners
+    // on this file's shared jsdom window, and each reports through its own module instance.
+    expect(fetchMock).toHaveBeenCalled();
+    const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+    expect(body.metadata.scriptFilename).toBe('https://app.harvous.com/assets/index.js');
+    expect(body.metadata.scriptLineno).toBe(49);
+  });
+
   it('skips chunk failures from third-party CDNs', async () => {
     const fetchMock = vi.mocked(fetch);
     const { reportClientError } = await import('../diagnostics-client');

--- a/src/utils/__tests__/diagnostics-extension-origin.test.ts
+++ b/src/utils/__tests__/diagnostics-extension-origin.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { isExtensionOriginated } from '../diagnostics-route';
+
+/**
+ * Four of the eight issues open in the admin panel on 2026-09-11 were browser extensions
+ * throwing inside our document: two `og:type` reads (nothing in this repo has ever read an og
+ * tag from the DOM), one `window.ethereum.emit` (no web3 dependency exists), and one
+ * unattributable TDZ error.
+ *
+ * The bar for this filter is that it can never hide one of ours, so most of what follows is
+ * about what it must NOT match.
+ */
+describe('isExtensionOriginated', () => {
+  it('matches an extension filename', () => {
+    expect(isExtensionOriginated('chrome-extension://abcdefghijklmnop/inject.js', null)).toBe(true);
+    expect(isExtensionOriginated('moz-extension://1f2e/content.js', null)).toBe(true);
+    expect(isExtensionOriginated('safari-web-extension://A1B2/page.js', null)).toBe(true);
+  });
+
+  it('matches a stack made only of extension frames', () => {
+    const stack = [
+      "TypeError: null is not an object (evaluating 'document.querySelector(\"meta[property=\\'og:type\\']\").content')",
+      '    at getMeta (chrome-extension://mnopqrst/share.js:12:9)',
+      '    at chrome-extension://mnopqrst/share.js:44:3',
+    ].join('\n');
+    expect(isExtensionOriginated(null, stack)).toBe(true);
+  });
+
+  it('does NOT match our own bundle', () => {
+    const stack = [
+      "TypeError: Cannot read properties of undefined (reading 'blankLengths')",
+      '    at Vt (https://app.harvous.com/assets/PrototypeReviewSample-C1x9.js:1:2048)',
+      '    at https://app.harvous.com/assets/index-1uUOH_2w.js:49:118',
+    ].join('\n');
+    expect(isExtensionOriginated(null, stack)).toBe(false);
+    expect(isExtensionOriginated('https://app.harvous.com/assets/index-1uUOH_2w.js', stack)).toBe(false);
+  });
+
+  it('does NOT match a public script of ours', () => {
+    const stack = '    at https://app.harvous.com/scripts/service-worker-manager.js:31:5';
+    expect(isExtensionOriginated(null, stack)).toBe(false);
+  });
+
+  /* An extension that wraps our code puts its frame in a stack that is still ours to fix. */
+  it('does NOT match a mixed stack that touches our bundle', () => {
+    const stack = [
+      'TypeError: x is not a function',
+      '    at chrome-extension://mnopqrst/hook.js:3:1',
+      '    at https://app.harvous.com/assets/index-1uUOH_2w.js:20:7',
+    ].join('\n');
+    expect(isExtensionOriginated(null, stack)).toBe(false);
+  });
+
+  it('does NOT match when there is nothing to go on', () => {
+    expect(isExtensionOriginated(null, null)).toBe(false);
+    expect(isExtensionOriginated('', '')).toBe(false);
+    expect(isExtensionOriginated(undefined, undefined)).toBe(false);
+  });
+});

--- a/src/utils/build-freshness.ts
+++ b/src/utils/build-freshness.ts
@@ -1,0 +1,55 @@
+/**
+ * Is the bundle running in this tab still the one being served?
+ *
+ * Old bundles keep running for longer than a deploy takes. The service worker answers `/`
+ * stale-while-revalidate (public/sw.js) while `/assets/*` is immutable, so the first
+ * navigation after a deploy loads the previous shell's chunks quite happily; and on the
+ * prototype shell the worker deliberately never force-reloads (see
+ * public/scripts/service-worker-manager.js — forcing it caused iOS PWA reload loops), it only
+ * offers. Someone who dismisses that offer runs yesterday's client against today's API
+ * indefinitely.
+ *
+ * That is a skew, and skews surface as nonsense: when the review sample payload moved from
+ * `sample.cloze` to `sample.exercise.cloze`, cached bundles read `undefined.blankLengths` and
+ * the Home route died with a stack pointing at code that was correct when it shipped.
+ *
+ * Checking a build id turns that into a question the client can answer for itself.
+ */
+
+/** Injected by vite `define` (see vite.config.ts). Empty in local builds. */
+declare const __BUILD_ID__: string | undefined;
+
+const BUILD_ID_URL = '/build-id.json';
+const PROBE_TIMEOUT_MS = 2_000;
+
+export function currentBuildId(): string | null {
+  if (typeof __BUILD_ID__ === 'undefined') return null;
+  return __BUILD_ID__ ? __BUILD_ID__ : null;
+}
+
+/**
+ * Resolves true only when the deployed build id is known, ours is known, and they differ.
+ *
+ * Every uncertainty resolves false. A local build has no id, an offline tab cannot fetch one,
+ * and neither is evidence of staleness — claiming it would push a reload at someone whose real
+ * problem is a bug we should be fixing.
+ */
+export async function isStaleBuild(): Promise<boolean> {
+  const mine = currentBuildId();
+  if (!mine) return false;
+  try {
+    const res = await fetch(BUILD_ID_URL, {
+      cache: 'no-store',
+      credentials: 'omit',
+      // Bounded because a caller is holding a crash report open waiting for this answer.
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    if (!res.ok) return false;
+    const body = (await res.json()) as { buildId?: unknown };
+    const deployed = typeof body.buildId === 'string' ? body.buildId : '';
+    if (!deployed) return false;
+    return deployed !== mine;
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/diagnostics-client.ts
+++ b/src/utils/diagnostics-client.ts
@@ -4,7 +4,11 @@ import type {
   DiagnosticSource,
   DiagnosticSourceEnv,
 } from '@/utils/diagnostic-sources';
-import { isNoiseDiagnosticMessage, redactDiagnosticRoute } from '@/utils/diagnostics-route';
+import {
+  isExtensionOriginated,
+  isNoiseDiagnosticMessage,
+  redactDiagnosticRoute,
+} from '@/utils/diagnostics-route';
 
 const SESSION_STORAGE_KEY = 'harvous_diag_session';
 const SESSION_ROTATE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -224,6 +228,13 @@ export function reportClientError(
   if (shouldIgnoreError(error)) return;
   const message = typeof error === 'string' ? error : error.message || 'Unknown error';
   const stack = typeof error === 'string' ? null : error.stack ?? null;
+  /*
+   * Extension code throwing inside our document. Returning before `rememberError` matters:
+   * otherwise Settings -> Support would offer someone else's wallet extension as the last
+   * thing that went wrong in Harvous.
+   */
+  const scriptFilename = typeof metadata?.scriptFilename === 'string' ? metadata.scriptFilename : null;
+  if (isExtensionOriginated(scriptFilename, stack)) return;
   // A failed dynamic import can surface as both an unhandledrejection and a window error.
   if (isDuplicateReport(`client|${source}|${message}`)) return;
   rememberError(message, stack);
@@ -271,7 +282,10 @@ export function reportManualDiagnostic(manualNote: string): void {
 const ROUTE_BOUNDARY_DEDUPE_MS = 30_000;
 
 /** Report React route-boundary errors (not caught by window.onerror). Dedupes recent identical messages. */
-export function reportRouteBoundaryError(error: unknown): void {
+export function reportRouteBoundaryError(
+  error: unknown,
+  metadata?: Record<string, unknown> | null,
+): void {
   const err = error instanceof Error ? error : new Error(typeof error === 'string' ? error : 'Route error');
   if (shouldIgnoreError(err)) return;
 
@@ -287,7 +301,7 @@ export function reportRouteBoundaryError(error: unknown): void {
     source: 'client_js',
     message,
     stack,
-    metadata: { routeErrorBoundary: true },
+    metadata: { routeErrorBoundary: true, ...(metadata ?? {}) },
   });
 
   void import('@/utils/posthog')

--- a/src/utils/diagnostics-route.ts
+++ b/src/utils/diagnostics-route.ts
@@ -101,3 +101,48 @@ export function isNoiseDiagnosticMessage(message: string): boolean {
   if (lower.includes('is not a valid javascript mime type')) return true;
   return false;
 }
+
+/**
+ * Browser-extension schemes. A script served from one of these is not ours and not
+ * something a deploy can fix.
+ */
+const EXTENSION_SCHEMES = [
+  'chrome-extension://',
+  'moz-extension://',
+  'safari-web-extension://',
+  'safari-extension://',
+  'ms-browser-extension://',
+  'webkit-masked-url://',
+];
+
+/** Path prefixes that only our own bundles and public scripts are served from. */
+const APP_SCRIPT_MARKERS = ['/assets/', '/scripts/'];
+
+function hasExtensionScheme(text: string): boolean {
+  const lower = text.toLowerCase();
+  return EXTENSION_SCHEMES.some((scheme) => lower.includes(scheme));
+}
+
+/**
+ * Is this error the page's problem at all?
+ *
+ * Wallet extensions fighting over `window.ethereum`, SEO/share extensions reading
+ * `meta[property="og:type"]` off a page that has never rendered one — these throw inside our
+ * document, so the global `error` listener reports them and they arrive in the admin list
+ * indistinguishable from our own crashes. They were four of the eight open issues.
+ *
+ * Deliberately conservative, so this can never hide a real bug: a stack that touches our own
+ * bundles is ours no matter what else is in it, and only a stack that is *purely* extension
+ * code counts as foreign. `filename` (from `ErrorEvent`) is the stronger signal and is
+ * trusted on its own, because the browser sets it to the script that actually threw.
+ */
+export function isExtensionOriginated(
+  filename: string | null | undefined,
+  stack: string | null | undefined,
+): boolean {
+  if (filename && hasExtensionScheme(filename)) return true;
+  if (!stack) return false;
+  if (!hasExtensionScheme(stack)) return false;
+  const lower = stack.toLowerCase();
+  return !APP_SCRIPT_MARKERS.some((marker) => lower.includes(marker));
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,34 @@ import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import { createRequire } from 'module';
+import { resolveBuildId } from './scripts/build-id.js';
 const require = createRequire(import.meta.url);
 const pkg = require('./package.json');
+
+const BUILD_ID = resolveBuildId();
+
+/**
+ * Publish this build's identity next to the bundle, so a running client can ask whether it is
+ * still the deploy the server is serving.
+ *
+ * It cannot ask the API instead: the SPA deploys to Cloudflare and the API to Fly,
+ * independently, so they have no build id in common. And `__APP_VERSION__` is package.json's
+ * version, which does not move between two deploys on the same version — the same reason
+ * scripts/inject-sw-cache-version.js appends a build id to CACHE_NAME.
+ */
+function emitBuildId(): Plugin {
+  return {
+    name: 'harvous-emit-build-id',
+    apply: 'build',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'build-id.json',
+        source: JSON.stringify({ buildId: BUILD_ID, version: pkg.version }),
+      });
+    },
+  };
+}
 
 /**
  * Dev only: hook modules are invisible to React Fast Refresh, so hot-patch them and the
@@ -47,7 +73,7 @@ function fullReloadOnHookModuleEdit(): Plugin {
 // The Hono server (server/dev.ts on port 3001) handles all API routes.
 // This builds spa/ → dist-spa/ which Capacitor bundles into the native app.
 export default defineConfig({
-  plugins: [react(), fullReloadOnHookModuleEdit()],
+  plugins: [react(), fullReloadOnHookModuleEdit(), emitBuildId()],
   root: 'spa',
   // Serve public assets (fonts, icons, manifest, sw.js) from the project root's public/
   publicDir: path.resolve(__dirname, 'public'),
@@ -85,6 +111,7 @@ export default defineConfig({
   },
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+    __BUILD_ID__: JSON.stringify(BUILD_ID),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Triage of the eight issues open in the admin diagnostics panel. They turned out to be four
different things, and **half were not our code**.

| Row | Count | Verdict |
|---|---|---|
| `…reading 'blankLengths'` ×3 + `e.cloze.blankLengths` ×1 | ~6 | **Ours** — client/server version skew |
| `HTTP 520 (/api/church/feed)` | 1× | **Ours**, but the origin returned nothing; not a handler bug |
| `og:type` querySelector null | 2× | **Not ours** — nothing here has ever read an og tag from the DOM |
| `window.ethereum.emit` | 1× | **Not ours** — no web3 dependency in the tree |
| `Cannot access 'o' before initialization` | 1× | **Unproven** — zero circular imports in source *and* built chunks |

## Telling our errors from extensions

Extension scripts throw inside our document, so the global `error` listener reports them. They
were indistinguishable from our own crashes because the client has always sent `scriptFilename`
and `sanitizeMetadata` silently dropped it — a three-key allowlist whose missing key was the one
that proves origin.

Now kept (with line and column, surfaced in the panel), and extension errors are filtered at
capture and again at ingest. `isExtensionOriginated` only matches a stack that is *purely*
extension frames, so a stack touching our own bundle is still ours no matter what else is in it —
it cannot hide a real bug.

## The crash: a version skew

Re-nesting the review sample payload from `sample.cloze` to `sample.exercise.cloze` (`72012dbb6`)
left every still-cached bundle reading `undefined.blankLengths`, taking down the whole Home route
— for free accounts only, since that is who is offered the sample card.

Two things kept those bundles alive: `/` is served stale-while-revalidate while `/assets/*` is
immutable, and on the prototype shell the service worker **deliberately never force-reloads**
(forcing it caused iOS PWA loops), it only offers.

So the card narrows on the data rather than the `kind` discriminant, and the client learned to ask
whether it is still the deployed build. Not by sharing an id with the API — the SPA deploys to
Cloudflare and the API to Fly, independently — but by comparing `__BUILD_ID__` against a
`build-id.json` beside the bundle, both from one source shared with the service worker's cache
name. A route crash now asks before blaming the code: a stale bundle gets a reload, instead of a
"Try again" that re-renders the same stale component. Every uncertain case resolves to "not
stale", so this can never push a reload at someone whose real problem is a bug we should be seeing.

## The 520

The handler returns JSON 500 on any throw, so a 520 means the origin returned nothing at all.
Bounded the Worker's `/api/*` proxy so that arrives as a 504 with a body the client can report
rather than a bare 520 carrying no path and no status; OG image generation gets a longer ceiling
since it drives Chromium in-process and serves crawlers. Added the rate limit this route was the
only read endpoint in its file to be missing, and stopped selecting whole note bodies for up to
fifty rows to build a 180-character excerpt.

**Deliberately not done:** removing the feed from Home's first-paint gate. The comment at
`use-home-surface-data.ts:451` documents why it is there, and `isQuerySettled` already returns true
once `isPending` is false — so a failed request settles rather than hanging Home. The Worker
timeout bounds that delay, which is the actual fix.

## Verification

- 6163 tests across 577 files pass; 7 new tests cover the filter, the sanitizer, the cloze payload, build freshness, and the stale-build UI
- Typecheck ratchet passes (125 pre-existing errors, no regressions); none in changed files
- `perf:check` passes at 1152.3 KB; `design:check`, `db:check`, auth/color/terminology checks pass
- Worker builds under `wrangler --dry-run`; `AbortSignal.timeout` confirmed in the Workers runtime types
- Generated SQL inspected via `toSQL()` without touching the database
- **In the built bundle in a browser:** dispatched an extension error and one of ours — the extension error produced zero diagnostics POSTs, ours was reported carrying `scriptFilename`/`scriptLineno`/`scriptColno`. `/build-id.json` serves correctly and the app boots with no new console errors.

## Before merging

Before resolving the four non-ours rows in the panel, confirm against stored data rather than
inference: `GET /api/admin/diagnostics/issues/:signature/events` and check the stacks for
extension schemes. That also settles the `Cannot access 'o'` row either way. The new script-origin
line makes this trivial going forward, but cannot retroactively fill in the field that was being
dropped.

Release notes for 3.9.11 are my copy, not the marketing agent's — worth a pass before they ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)