### PR TITLE
Library search: focus on chip click too, not just ⇧K

### DIFF
--- a/spa/src/pages/prototype/library-panel/PrototypeLibraryPanelHost.tsx
+++ b/spa/src/pages/prototype/library-panel/PrototypeLibraryPanelHost.tsx
@@ -22,12 +22,14 @@ import { useProtoAnchoredPopoverPosition } from '../useProtoAnchoredPopoverPosit
 import { useDismissOnOutside } from '../../../hooks/usePopoverDismiss';
 import PrototypeSearchInput from '../components/PrototypeSearchInput';
 import { useProtoShell } from '../../../layouts/proto-shell-context';
+import { useCoarsePointer } from '../../../lib/use-coarse-pointer';
 import PrototypeLibraryPanel from './PrototypeLibraryPanel';
 import PrototypeLibraryBody from './PrototypeLibraryBody';
 import PrototypeLibraryTabs from './PrototypeLibraryTabs';
 import PrototypeLibrarySearchResults, {
   type LibraryNavigationItem,
 } from './PrototypeLibrarySearchResults';
+import { shouldAutoFocusLibrarySearch } from './library-panel-view';
 import { useLibraryPanelSearch } from './use-library-panel-search';
 import { useLibraryPanelData } from './library-panel-data';
 import { useLibrarySearchHistory } from './use-library-search-history';
@@ -50,6 +52,15 @@ export default function PrototypeLibraryPanelHost({
     closeLibraryPanel,
     isMobileSidebar,
   } = useProtoShell();
+
+  /*
+   * Whether a caret is welcome, asked of the input device rather than the layout.
+   *
+   * `isMobileSidebar` is a breakpoint, and the two disagree on the case that matters: an
+   * iPad at a desktop width still has no keyboard but the one that slides up over the
+   * results. The device decides.
+   */
+  const isCoarsePointer = useCoarsePointer();
 
   /* During the exit morph the view is still set; this only covers the frame after the
      timer clears it, by which point the host is unmounted anyway. */
@@ -173,17 +184,15 @@ export default function PrototypeLibraryPanelHost({
           id="proto-library-search-input"
           /*
            * The field takes focus as the panel opens, so ⇧K lands ready to type and
-           * the chip — which now says "Search" — does what it advertises. Declarative
+           * the chip — which says "Search" — does what it advertises. Declarative
            * rather than a `querySelector` after a frame: the panel is a lazy chunk, and on
            * the first open of a session that element does not exist yet when the frame
            * fires, so the one-shot focus silently found nothing.
            *
-           * Desktop only. On a phone this is a bottom sheet, and stealing focus there
-           * raises the keyboard over the very list you opened it to browse.
+           * The opener only asks; `shouldAutoFocusLibrarySearch` decides, and refuses on a
+           * finger.
            */
-          /* Only when the opener asked — see `autoFocusSearch`. Mobile never takes it:
-             a caret there raises the on-screen keyboard over the results. */
-          autoFocus={!isMobileSidebar && Boolean(view.autoFocusSearch)}
+          autoFocus={shouldAutoFocusLibrarySearch({ view, isMobileSidebar, isCoarsePointer })}
           value={search.input}
           onChange={search.setInput}
           onClear={search.clear}

--- a/spa/src/pages/prototype/library-panel/__tests__/library-panel-view.test.ts
+++ b/spa/src/pages/prototype/library-panel/__tests__/library-panel-view.test.ts
@@ -12,6 +12,7 @@ import {
   isSameLibraryPanelView,
   libraryDrillTitle,
   libraryPanelShowsBack,
+  shouldAutoFocusLibrarySearch,
   LIBRARY_TABS,
   type LibraryPanelView,
 } from '../library-panel-view';
@@ -21,7 +22,14 @@ describe('LIBRARY_CHIP_OPENING_VIEW', () => {
     // The chip says "Search" in every mode, so it opens the same place in every mode.
     // It used to branch — a note opened its folder, the reader its book — and that went
     // when the chip stopped naming them.
-    expect(LIBRARY_CHIP_OPENING_VIEW).toEqual({ tab: 'all', drill: null });
+    expect(LIBRARY_CHIP_OPENING_VIEW.tab).toBe('all');
+    expect(LIBRARY_CHIP_OPENING_VIEW.drill).toBeNull();
+  });
+
+  it('asks for the caret, the same as the chord', () => {
+    // A control labelled Search opens ready to search. Whether the caret is actually taken
+    // is the panel's call, not the opener's — a finger never gets it.
+    expect(LIBRARY_CHIP_OPENING_VIEW.autoFocusSearch).toBe(true);
   });
 });
 
@@ -160,6 +168,49 @@ describe('autoFocusSearch', () => {
         { tab: 'all', drill: null, autoFocusSearch: true },
         { tab: 'notes', drill: null, autoFocusSearch: true },
       ),
+    ).toBe(false);
+  });
+});
+
+/**
+ * The opener asks for the caret; the device decides whether it gets it. Both refusals are
+ * kept because they catch different machines — see `shouldAutoFocusLibrarySearch`.
+ */
+describe('shouldAutoFocusLibrarySearch', () => {
+  const asked = { autoFocusSearch: true };
+
+  it('gives the caret to a mouse at desktop width', () => {
+    expect(
+      shouldAutoFocusLibrarySearch({ view: asked, isMobileSidebar: false, isCoarsePointer: false }),
+    ).toBe(true);
+  });
+
+  it('refuses on a phone', () => {
+    // A bottom sheet with the keyboard up over it shows less of the library than no sheet.
+    expect(
+      shouldAutoFocusLibrarySearch({ view: asked, isMobileSidebar: true, isCoarsePointer: true }),
+    ).toBe(false);
+  });
+
+  it('refuses a finger on a tablet laid out as a desktop', () => {
+    // The case the breakpoint alone gets wrong: wide enough to look like a desktop, with no
+    // keyboard but the one that slides up.
+    expect(
+      shouldAutoFocusLibrarySearch({ view: asked, isMobileSidebar: false, isCoarsePointer: true }),
+    ).toBe(false);
+  });
+
+  it('refuses a mouse in a narrow window', () => {
+    // And the case the pointer alone gets wrong, which is why neither check is dropped.
+    expect(
+      shouldAutoFocusLibrarySearch({ view: asked, isMobileSidebar: true, isCoarsePointer: false }),
+    ).toBe(false);
+  });
+
+  it('takes nothing that was not asked for', () => {
+    // A drill names a destination, not a query.
+    expect(
+      shouldAutoFocusLibrarySearch({ view: {}, isMobileSidebar: false, isCoarsePointer: false }),
     ).toBe(false);
   });
 });

--- a/spa/src/pages/prototype/library-panel/library-panel-view.ts
+++ b/spa/src/pages/prototype/library-panel/library-panel-view.ts
@@ -41,11 +41,16 @@ export type LibraryPanelView = {
   /**
    * Whether the search field takes focus on open.
    *
-   * Set by the chords that mean "search" and left off everywhere else. Reaching for ⇧K is
-   * already the first keystroke of a query, so a caret is what you asked for; clicking the
-   * chip is a pointer gesture that means "show me", and stealing focus there commits you to
-   * typing before you have looked. It also swallows the keyboard: with the caret in the
-   * field, the arrow keys move a text cursor rather than the list.
+   * Set by anything that means "search" — the chords, and the chip, which reads "Search"
+   * and so promises a place to type. Reaching for ⇧K is already the first keystroke of a
+   * query; clicking a control labelled Search is the same intent by another hand, and
+   * making the reader click twice to start typing is a step the label already took.
+   *
+   * Left off everywhere else: a drill names a destination, not a query.
+   *
+   * The ask is not the answer — the panel refuses it on a touch device, where a caret
+   * raises the on-screen keyboard over the results the tap was meant to show. See
+   * `PrototypeLibraryPanelHost`.
    *
    * An opening condition like `querySeed`, so `isSameLibraryPanelView` ignores it — two
    * openings of the same place are the same place however focus was handled.
@@ -61,6 +66,29 @@ export type LibraryPanelView = {
    */
   selectOnOpen?: boolean;
 };
+
+/**
+ * Does the search field actually take the caret on this open?
+ *
+ * The opener only asks (`autoFocusSearch`); this decides. Two refusals rather than one,
+ * because they catch different devices: the breakpoint catches the phone, where the panel
+ * is a bottom sheet and a caret raises the keyboard over the list; the pointer catches the
+ * tablet that is wide enough to be laid out as a desktop and still has no keyboard but
+ * that one. A mouse on a narrow window is the case the breakpoint alone would get wrong in
+ * the other direction, and it is why neither check is dropped for the other.
+ */
+export function shouldAutoFocusLibrarySearch({
+  view,
+  isMobileSidebar,
+  isCoarsePointer,
+}: {
+  view: Pick<LibraryPanelView, 'autoFocusSearch'>;
+  isMobileSidebar: boolean;
+  isCoarsePointer: boolean;
+}): boolean {
+  if (!view.autoFocusSearch) return false;
+  return !isMobileSidebar && !isCoarsePointer;
+}
 
 /** Tab order for the chip row and for ⇧← / ⇧→ cycling. */
 export const LIBRARY_TABS: LibraryTab[] = [
@@ -85,7 +113,13 @@ export const LIBRARY_TABS: LibraryTab[] = [
  * destination — see `useLibraryPanelNav`. The rule was never "never drill", it is that a
  * control opens what it says it opens.
  */
-export const LIBRARY_CHIP_OPENING_VIEW: LibraryPanelView = { tab: 'all', drill: null };
+export const LIBRARY_CHIP_OPENING_VIEW: LibraryPanelView = {
+  tab: 'all',
+  drill: null,
+  /* The chip says Search, so it opens ready to search — the same landing ⇧K gets. Only
+     on a pointer that is not a finger; see `autoFocusSearch`. */
+  autoFocusSearch: true,
+};
 
 /**
  * ⇧← / ⇧→ — walk the tabs.


### PR DESCRIPTION
## Summary
The Library panel's search field (behind the toolbar's Search chip / `⇧K`) now auto-focuses when the chip is clicked, not only via the keyboard shortcut. Touch/mobile is explicitly excluded, since a raised on-screen keyboard would bury the results the tap opened.

## Changes
- `LIBRARY_CHIP_OPENING_VIEW` now sets `autoFocusSearch: true`, so a chip click asks for focus the same way `⇧K` already does.
- Added `shouldAutoFocusLibrarySearch()` — decides whether the ask is honored, refusing on the mobile-sidebar breakpoint *or* a coarse (touch) pointer, checked independently (an iPad at desktop width is wide-but-touch; a mouse in a narrow window is narrow-but-precise).
- `PrototypeLibraryPanelHost` wires in the existing `useCoarsePointer()` hook and calls the new helper instead of the old breakpoint-only check.
- Test coverage for all four device combinations.

## Verification
- `npx vitest run` on the library-panel suite + shell + keyboard-shortcuts tests: 198/198 passing.
- `tsc --noEmit`: clean on touched files.
- `npm run build:spa && npm run perf:check`: passes, no bundle regression.
- Manual check in-browser: chip click at desktop width focuses the field immediately; chip click at mobile width opens the sheet with focus correctly withheld.

🤖 Generated with [Claude Code](https://claude.com/claude-code)