### PR TITLE
Drop "Insights" from the topical and comparative templates

### DIFF
--- a/src/data/note-templates.ts
+++ b/src/data/note-templates.ts
@@ -62,7 +62,7 @@ export const BUILT_IN_TEMPLATES: NoteTemplate[] = [
     estimatedMinutes: '20–60 min',
     level: 'Beginner–Intermediate',
     titleTemplate: '',
-    content: `<h2>Topic</h2><p>[Your topic or theme]</p><p><br></p><h2>Key Verses</h2><p>List relevant verses from across Scripture.</p><p><br></p><h2>Insights</h2><p>What patterns or themes emerge?</p><p><br></p><h2>Application</h2><p>How does this theme apply today?</p>`,
+    content: `<h2>Topic</h2><p>[Your topic or theme]</p><p><br></p><h2>Key Verses</h2><p>List relevant verses from across Scripture.</p><p><br></p><h2>Patterns</h2><p>What patterns or themes emerge?</p><p><br></p><h2>Application</h2><p>How does this theme apply today?</p>`,
     noteType: 'default',
     iconColor: 'green',
   },
@@ -84,7 +84,7 @@ export const BUILT_IN_TEMPLATES: NoteTemplate[] = [
     estimatedMinutes: '20–60 min',
     level: 'Intermediate',
     titleTemplate: '',
-    content: `<h2>Comparison Focus</h2><p>[What are you comparing? Translations, parallel passages, etc.]</p><p><br></p><h2>Version A</h2><p>Observations and notes.</p><p><br></p><h2>Version B</h2><p>Observations and notes.</p><p><br></p><h2>Key Differences</h2><p>What stands out in comparison?</p><p><br></p><h2>Insights</h2><p>What do the differences reveal?</p>`,
+    content: `<h2>Comparison Focus</h2><p>[What are you comparing? Translations, parallel passages, etc.]</p><p><br></p><h2>Version A</h2><p>Observations and notes.</p><p><br></p><h2>Version B</h2><p>Observations and notes.</p><p><br></p><h2>Key Differences</h2><p>What stands out in comparison?</p><p><br></p><h2>What it shows</h2><p>What do the differences reveal?</p>`,
     noteType: 'default',
     iconColor: 'yellow',
   }


### PR DESCRIPTION
## Summary

`docs/BRAND_VOICE.md` Rule 2 bans the word "Insights" outright ("sounds corporate and elevated"), with an exception only for a verbatim quote — never our own phrasing. Two of the six built-in templates used it as a section heading:

| template | heading |
|---|---|
| Topical Study | "Insights" → "Patterns" |
| Comparative Study | "Insights" → "What it shows" |

The rule applies to anything Harvous curates or creates itself. A built-in template is exactly that — not a quote of anyone else's words — so no exception applies.

## Why now

These two template bodies are the reason harvous.com's `/discover/` page has stayed gated behind `DRAFT_PAGE_SLUGS`. Once these ship and the next `sync-discover-catalog.yml` run pulls the updated content across, that blocker is clear.

## Scope

Swept the rest of `note-templates.ts` plus the Discover seed/snapshot code alongside these two — nothing else in either uses the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)