### PR TITLE
Publish the references Harvous curates, so they can be added

### DIFF
--- a/server/scripts/discover-seed-curated-resources.ts
+++ b/server/scripts/discover-seed-curated-resources.ts
@@ -1,0 +1,206 @@
+/**
+ * Publish the references Harvous curates into the catalog.
+ *
+ * Sister to `discover-seed-builtin-templates.ts`, and the same argument for
+ * skipping submit → review: that flow exists so a stranger's work is read
+ * before it is public, and the publisher here *is* Harvous. These go straight
+ * to `status: 'listed'`.
+ *
+ * What they are for: until now a curated reference on harvous.com could only
+ * send a reader to the publisher. Discover's whole purpose is that you find
+ * something and then take it with you, so every one of these needs a row here —
+ * `POST /api/discover/install` resolves a slug against this table, and a slug
+ * it has never seen is a dead "Add to my Harvous" button.
+ *
+ * Installing one saves a **link** to the reader's own library, via
+ * `prepareResourceInstall`. Nothing of the publisher's is copied, which is both
+ * what the code does and what their terms tend to ask for. `payload` is
+ * therefore exactly a `ResourcePayload`, and its `sourceUrl` is re-validated at
+ * install time by `validateResourceUrl` — which is why every URL in
+ * `CURATED_RESOURCES` is absolute, including our own blog posts.
+ *
+ * Like a built-in template, a curated reference has no row of its own to point
+ * at: it is a link to somebody else's page, not a `LibraryItems` record under
+ * some system account. So `sourceId` holds `curated:<slug>`, prefixed so it can
+ * never collide with a built-in's id (`soap`) or a real `ntpl_`/`libi_`.
+ *
+ * `preview` carries the publisher lockup nested under `source`, plus
+ * `resourceType`, `video` and our `note`. `serializePublic` emits `preview`
+ * whole, so harvous.com receives all of it with no change to the export —
+ * the same trick the built-in seeder uses to add `official: true`. Nested and
+ * named for the type on purpose: the flat `preview.sourceName`/`sourceUrl` mean
+ * something narrower on the site ("Harvous wrote this, crediting an outside
+ * structure") and drive different copy.
+ *
+ * Idempotent: matches on `sourceId`, updates in place, and never touches
+ * `slug`, `status`, `installCount` or `listedAt` — so a re-run after a copy
+ * edit republishes rather than duplicating, and cannot resurrect a delisted
+ * row or reset what people have already installed. Dry by default; `--apply`
+ * writes, `--production` on top when the target is live.
+ */
+import 'dotenv/config';
+import { eq } from 'drizzle-orm';
+import { db, DiscoverListings } from '../db';
+import { requireDbTarget } from '../utils/require-db-target';
+import { CURATED_RESOURCES, type CuratedResource } from '@/data/curated-resources';
+import { isDiscoverCategory } from '@/data/discover-categories';
+import { validateResourceUrl } from '@/utils/validation';
+
+/** Matches `EXCERPT_MAX_LENGTH` in discover-snapshot.ts. */
+const EXCERPT_MAX_LENGTH = 220;
+
+/** `sourceId` for a reference. Prefixed so it cannot collide with a built-in
+ *  template's id or a real row id. */
+function sourceIdFor(entry: CuratedResource): string {
+  return `curated:${entry.slug}`;
+}
+
+/**
+ * Exactly a `ResourcePayload` — this is what `prepareResourceInstall` reads.
+ *
+ * `sourceImage` is null rather than the poster harvous.com mirrors: that file
+ * lives on the marketing site's disk under a path this repo does not serve, so
+ * pointing a library item at it would be a broken thumbnail.
+ */
+function payloadFor(entry: CuratedResource): string {
+  return JSON.stringify({
+    title: entry.title,
+    description: entry.description,
+    sourceUrl: entry.source.url,
+    sourceDomain: entry.source.domain,
+    sourceSiteName: entry.source.name,
+    sourceImage: null,
+  });
+}
+
+function previewFor(entry: CuratedResource): string {
+  return JSON.stringify({
+    /* Somebody else's work, so never "Included". */
+    official: false,
+    sourceDomain: entry.source.domain,
+    sourceSiteName: entry.source.name,
+    excerpt: entry.description.slice(0, EXCERPT_MAX_LENGTH),
+    source: entry.source,
+    resourceType: entry.resourceType,
+    ...(entry.video ? { video: entry.video } : {}),
+    note: entry.note,
+  });
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const apply = argv.includes('--apply');
+  requireDbTarget({ scriptName: 'discover:seed-curated', writes: apply, argv, env: process.env });
+
+  const now = new Date();
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  const seenSlugs = new Set<string>();
+
+  for (const entry of CURATED_RESOURCES) {
+    /* Validate before writing, not after: a bad category is a card the topic
+       filter never matches, and a URL `validateResourceUrl` rejects is a listing
+       whose install button fails for every reader who presses it. Both are
+       silent in production and obvious here. */
+    if (!isDiscoverCategory(entry.category)) {
+      console.log(`  SKIP  ${entry.slug} — category "${entry.category}" is not one Discover knows`);
+      skipped += 1;
+      continue;
+    }
+    if (seenSlugs.has(entry.slug)) {
+      console.log(`  SKIP  ${entry.slug} — listed twice in CURATED_RESOURCES`);
+      skipped += 1;
+      continue;
+    }
+    seenSlugs.add(entry.slug);
+
+    const urlCheck = validateResourceUrl(entry.source.url);
+    if (!urlCheck.isValid) {
+      console.log(`  SKIP  ${entry.slug} — source.url rejected at install: ${urlCheck.error}`);
+      skipped += 1;
+      continue;
+    }
+
+    const sourceId = sourceIdFor(entry);
+    const payload = payloadFor(entry);
+    const preview = previewFor(entry);
+
+    const existing = (
+      await db
+        .select({ id: DiscoverListings.id, slug: DiscoverListings.slug })
+        .from(DiscoverListings)
+        .where(eq(DiscoverListings.sourceId, sourceId))
+        .limit(1)
+    )[0];
+
+    if (existing) {
+      updated += 1;
+      console.log(`  ${apply ? 'UPDATE' : 'would update'}  ${existing.slug} — ${entry.title}`);
+      if (apply) {
+        await db
+          .update(DiscoverListings)
+          .set({
+            title: entry.title,
+            description: entry.description,
+            category: entry.category,
+            /* The publisher is the author, which is what the card's byline
+               reads. Kept in step on update: a source can be renamed. */
+            authorDisplayName: entry.source.name,
+            payload,
+            preview,
+            updatedAt: now,
+          })
+          .where(eq(DiscoverListings.id, existing.id));
+      }
+      continue;
+    }
+
+    created += 1;
+    console.log(
+      `  ${apply ? 'CREATE' : 'would create'}  ${entry.slug.padEnd(40)} ` +
+        `${entry.category.padEnd(15)} ${entry.source.name}`,
+    );
+    if (apply) {
+      await db.insert(DiscoverListings).values({
+        id: `dsc_${crypto.randomUUID()}`,
+        kind: 'resource',
+        sourceId,
+        submittedByUserId: process.env.HARVOUS_SYSTEM_USER_ID ?? 'harvous',
+        /* The publisher, not a person: these were curated by Harvous, and the
+           name worth showing on the card is whose work it is. */
+        authorDisplayName: entry.source.name,
+        title: entry.title,
+        description: entry.description,
+        category: entry.category,
+        /* Authored, never slugified from the title: these slugs are already
+           published URLs on harvous.com and the column is immutable after
+           approval. */
+        slug: entry.slug,
+        payload,
+        preview,
+        status: 'listed',
+        installCount: 0,
+        listedAt: now,
+        staffReadAt: now,
+        reviewedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+  }
+
+  console.log(
+    `\n${created} to create, ${updated} to update` +
+      (skipped ? `, ${skipped} skipped` : '') +
+      (apply ? ' — applied.' : '. Dry run: pass --apply to write.'),
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/src/data/curated-resources.ts
+++ b/src/data/curated-resources.ts
@@ -1,0 +1,629 @@
+/**
+ * The references Harvous curates for Discover.
+ *
+ * Not `BUILT_IN_TEMPLATES`, and deliberately not in anyone's library: these are
+ * links to other people's work — BibleProject videos, public-domain commentary,
+ * study tools — plus a few of our own guides. Installing one saves the link to
+ * your own library, which is the whole point of listing them.
+ *
+ * `server/scripts/discover-seed-curated-resources.ts` publishes these straight
+ * to `status: 'listed'`, the same way `discover-seed-builtin-templates.ts` does
+ * and for the same reason: the publisher here is Harvous, so there is no
+ * submitter to review.
+ *
+ * harvous.com holds the artwork — a mirrored poster and publisher mark per
+ * slug, and the tone taken from that poster — because those are files on its
+ * disk that this repo cannot know about. Everything a reader needs to be told
+ * lives here.
+ */
+
+export type CuratedResourceType = 'video' | 'article' | 'book' | 'tool' | 'guide' | 'series';
+
+export interface CuratedSource {
+  /** As the publisher writes it — "BibleProject", not "bibleproject.com". */
+  name: string;
+  domain: string;
+  /**
+   * The exact page this points at, absolute.
+   *
+   * Absolute even for our own blog posts, which harvous.com writes as
+   * `/blog/...`: this URL is what `prepareResourceInstall` saves to a library,
+   * and `validateResourceUrl` rejects anything without a scheme and a dotted
+   * host. The site pulls ours back to a relative path for its own links.
+   */
+  url: string;
+  homeUrl: string;
+  /** One sentence naming who made it and who owns it. */
+  attribution: string;
+  /** What the licence allows, in plain words. Shown under the CTA. */
+  licence?: string;
+  /** Never host this publisher's media — embed from their own platform. */
+  embedOnly?: boolean;
+}
+
+export interface CuratedVideo {
+  provider: 'youtube';
+  /** The 11-character id, not a URL. */
+  id: string;
+  /** When the publisher put it out. Never when we listed it. */
+  publishedAt?: string;
+  /** ISO 8601, e.g. "PT8M56S". */
+  duration?: string;
+  /** What the badge shows, e.g. "8:56". */
+  durationLabel?: string;
+}
+
+export interface CuratedResource {
+  slug: string;
+  title: string;
+  description: string;
+  /** A Discover category id. */
+  category: string;
+  resourceType: CuratedResourceType;
+  /** Ours, not theirs — what makes the listing page more than a stub. */
+  note: string;
+  listedAt: string;
+  source: CuratedSource;
+  video?: CuratedVideo;
+}
+
+export const CURATED_RESOURCES: CuratedResource[] = [
+  {
+    slug: 'bibleproject-the-story-of-the-bible',
+    title: 'The Story of the Bible',
+    description: 'Six minutes on how the whole Bible holds together as one story, from the garden to the city.',
+    category: 'reference',
+    resourceType: 'video',
+    note: 'Worth watching before a book study, not during one. It gives you the shape of the whole thing, so the book you are about to sit in has somewhere to sit. Write down the one thread you want to follow, and start there.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'BibleProject',
+      domain: 'bibleproject.com',
+      url: 'https://bibleproject.com/videos/the-story-of-the-bible/',
+      homeUrl: 'https://bibleproject.com/',
+      attribution: 'BibleProject is the author and owner of this video. To find more BibleProject resources, visit bibleproject.com.',
+      licence: 'Plays here from BibleProject\'s own YouTube channel. Free to watch, and no account needed.',
+      embedOnly: true,
+    },
+    video: {
+      provider: 'youtube',
+      id: '7_CGP-12AE0',
+      publishedAt: '2017-05-11T14:01:24-07:00',
+      duration: 'PT6M8S',
+      durationLabel: '6:08',
+    },
+  },
+  {
+    slug: 'bibleproject-genesis-1-11',
+    title: 'Genesis 1–11',
+    description: 'An animated overview of the Bible\'s first eleven chapters — creation, the garden, the flood, Babel — drawn as one story rather than four.',
+    category: 'book-study',
+    resourceType: 'video',
+    note: 'We point people here when a book study starts in Genesis and those opening chapters read like separate episodes. Watch it once, then write down the thread you want to follow, and let the study start from that.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'BibleProject',
+      domain: 'bibleproject.com',
+      url: 'https://bibleproject.com/videos/genesis-1-11/',
+      homeUrl: 'https://bibleproject.com/',
+      attribution: 'BibleProject is the author and owner of this video. To find more BibleProject resources, visit bibleproject.com.',
+      licence: 'Plays here from BibleProject\'s own YouTube channel. Free to watch, and no account needed.',
+      embedOnly: true,
+    },
+    video: {
+      provider: 'youtube',
+      id: 'GQI72THyO5I',
+      publishedAt: '2015-12-30T06:15:00-08:00',
+      duration: 'PT8M56S',
+      durationLabel: '8:56',
+    },
+  },
+  {
+    slug: 'bibleproject-justice',
+    title: 'Justice',
+    description: 'What the Bible means by justice, traced as a theme from Genesis through to Jesus.',
+    category: 'topical-study',
+    resourceType: 'video',
+    note: 'A good opener for a topical study, because it does the work of showing that the word carries more than one idea. Keep a note open while you watch and collect the passages it walks through — that list is most of your study already.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'BibleProject',
+      domain: 'bibleproject.com',
+      url: 'https://bibleproject.com/videos/justice/',
+      homeUrl: 'https://bibleproject.com/',
+      attribution: 'BibleProject is the author and owner of this video. To find more BibleProject resources, visit bibleproject.com.',
+      licence: 'Plays here from BibleProject\'s own YouTube channel. Free to watch, and no account needed.',
+      embedOnly: true,
+    },
+    video: {
+      provider: 'youtube',
+      id: 'A14THPoc4-4',
+      publishedAt: '2017-10-27T08:42:58-07:00',
+      duration: 'PT6M2S',
+      durationLabel: '6:02',
+    },
+  },
+  {
+    slug: 'guide-the-lesson-prep-stack',
+    title: 'The lesson prep stack',
+    description: 'A five-part shape for weekly lesson prep — passage, aim, questions, trail, return — with a template you can copy.',
+    category: 'sermon-prep',
+    resourceType: 'guide',
+    note: 'Our own writing, filed here because it is the piece people come back to most. It ends with a template you can copy straight into a note.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Harvous',
+      domain: 'harvous.com',
+      url: 'https://harvous.com/blog/the-lesson-prep-stack/',
+      homeUrl: 'https://harvous.com/blog/',
+      attribution: 'Written for Bright Enough, the Harvous blog.',
+    },
+  },
+  {
+    slug: 'guide-the-five-minute-capture',
+    title: 'The five-minute capture',
+    description: 'What to write down right after you read, so the study you did this morning is still there next month.',
+    category: 'daily-journal',
+    resourceType: 'guide',
+    note: 'The shortest way into a daily habit. Read it once and you have the whole idea; the rest is doing it.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Harvous',
+      domain: 'harvous.com',
+      url: 'https://harvous.com/blog/the-five-minute-capture/',
+      homeUrl: 'https://harvous.com/blog/',
+      attribution: 'Written for Bright Enough, the Harvous blog.',
+    },
+  },
+  {
+    slug: 'guide-plan-the-quarter-not-the-week',
+    title: 'Plan the quarter, not the week',
+    description: 'How to map a teaching quarter once, so each week\'s prep starts from a plan instead of a blank page.',
+    category: 'teaching-prep',
+    resourceType: 'guide',
+    note: 'For anyone whose prep restarts from nothing every Tuesday. Read it before a term begins rather than in the middle of one.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Harvous',
+      domain: 'harvous.com',
+      url: 'https://harvous.com/blog/plan-the-quarter-not-the-week/',
+      homeUrl: 'https://harvous.com/blog/',
+      attribution: 'Written for Bright Enough, the Harvous blog.',
+    },
+  },
+  {
+    slug: 'bible-engagement-project-adults',
+    title: 'Bible Engagement Project — adult curriculum',
+    description: 'Small-group studies for adults, with every age group in a church following the same scope and sequence.',
+    category: 'small-group',
+    resourceType: 'series',
+    note: 'Useful when a whole church wants to be in the same place at the same time. The overview page is open to read; the lessons themselves are behind a free account.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Bible Engagement Project',
+      domain: 'bibleengagementproject.com',
+      url: 'https://bibleengagementproject.com/Adults',
+      homeUrl: 'https://bibleengagementproject.com/',
+      attribution: 'Bible Engagement Project is the author and owner of this curriculum.',
+      licence: 'The overview is open. The lessons need a free Bible Engagement Project account.',
+    },
+  },
+  {
+    slug: 'bible-engagement-project-downloads',
+    title: 'Scope and sequence, as a PDF',
+    description: 'The printable plans behind the Bible Engagement Project curriculum — what each age group covers, and when.',
+    category: 'teaching-prep',
+    resourceType: 'article',
+    note: 'Worth a look even if you use something else entirely. Seeing three years mapped on one page is a good way to notice the gaps in your own plan.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Bible Engagement Project',
+      domain: 'bibleengagementproject.com',
+      url: 'https://bibleengagementproject.com/Downloads',
+      homeUrl: 'https://bibleengagementproject.com/',
+      attribution: 'Bible Engagement Project is the author and owner of these documents.',
+      licence: 'Free to download, and no account needed.',
+    },
+  },
+  {
+    slug: 'blue-letter-bible-study-tools',
+    title: 'Blue Letter Bible study tools',
+    description: 'Interlinears, lexicons, concordances and commentaries, free and open to anyone.',
+    category: 'reference',
+    resourceType: 'tool',
+    note: 'Where to go when a study turns on one word and you want to see it in the original. Keep it on the shelf rather than reading it through.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Blue Letter Bible',
+      domain: 'blueletterbible.org',
+      url: 'https://www.blueletterbible.org/study.cfm',
+      homeUrl: 'https://www.blueletterbible.org/',
+      attribution: 'Blue Letter Bible is the author and owner of these tools.',
+      licence: 'Free to use, and no account needed.',
+    },
+  },
+  {
+    slug: 'matthew-henry-commentary',
+    title: 'Matthew Henry\'s Commentary',
+    description: 'The whole commentary on the whole Bible, written in the early 1700s and long out of copyright.',
+    category: 'reference',
+    resourceType: 'book',
+    note: 'Old, warm, and still worth reading beside a passage you think you already know. Public domain, so you can quote it anywhere.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Christian Classics Ethereal Library',
+      domain: 'ccel.org',
+      url: 'https://www.ccel.org/ccel/henry/mhc.html',
+      homeUrl: 'https://www.ccel.org/',
+      attribution: 'Hosted by the Christian Classics Ethereal Library at Calvin University.',
+      licence: 'Public domain.',
+    },
+  },
+  {
+    slug: 'bibleproject-gospel-of-mark',
+    title: 'Gospel of Mark',
+    description: 'The shortest gospel, drawn end to end — what Mark is arguing and how the pace of it carries the argument.',
+    category: 'book-study',
+    resourceType: 'video',
+    note: 'Start a Mark study here rather than at chapter one. Nine minutes gives you the arc, and the arc is what stops week three feeling like a pile of disconnected miracles.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'BibleProject',
+      domain: 'bibleproject.com',
+      url: 'https://bibleproject.com/videos/gospel-mark/',
+      homeUrl: 'https://bibleproject.com/',
+      attribution: 'BibleProject is the author and owner of this video. To find more BibleProject resources, visit bibleproject.com.',
+      licence: 'Plays here from BibleProject\'s own YouTube channel. Free to watch, and no account needed.',
+      embedOnly: true,
+    },
+    video: {
+      provider: 'youtube',
+      id: 'HGHqu9-DtXk',
+      publishedAt: '2016-09-05T00:00:00Z',
+      duration: 'PT9M31S',
+      durationLabel: '9:31',
+    },
+  },
+  {
+    slug: 'bibleproject-exodus-1-18',
+    title: 'Exodus 1–18',
+    description: 'The first half of Exodus — slavery, the plagues, the sea — as one movement rather than a set of famous scenes.',
+    category: 'book-study',
+    resourceType: 'video',
+    note: 'Useful when a group knows the stories but not the shape they sit in. Watch it, then ask what changes if these are one story instead of five.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'BibleProject',
+      domain: 'bibleproject.com',
+      url: 'https://bibleproject.com/videos/exodus-1-18/',
+      homeUrl: 'https://bibleproject.com/',
+      attribution: 'BibleProject is the author and owner of this video. To find more BibleProject resources, visit bibleproject.com.',
+      licence: 'Plays here from BibleProject\'s own YouTube channel. Free to watch, and no account needed.',
+      embedOnly: true,
+    },
+    video: {
+      provider: 'youtube',
+      id: '0uf-PgW7rqE',
+      publishedAt: '2014-11-28T00:00:00Z',
+      duration: 'PT5M44S',
+      durationLabel: '5:44',
+    },
+  },
+  {
+    slug: 'bibleproject-james',
+    title: 'James',
+    description: 'A short letter about what belief looks like when it reaches your hands, laid out whole.',
+    category: 'book-study',
+    resourceType: 'video',
+    note: 'James is easy to quote and hard to hold together. This gives you the through-line, which is what a study of it needs before the memorable verses take over.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'BibleProject',
+      domain: 'bibleproject.com',
+      url: 'https://bibleproject.com/videos/james/',
+      homeUrl: 'https://bibleproject.com/',
+      attribution: 'BibleProject is the author and owner of this video. To find more BibleProject resources, visit bibleproject.com.',
+      licence: 'Plays here from BibleProject\'s own YouTube channel. Free to watch, and no account needed.',
+      embedOnly: true,
+    },
+    video: {
+      provider: 'youtube',
+      id: 'qn-hLHWwRYY',
+      publishedAt: '2016-12-05T00:00:00Z',
+      duration: 'PT8M2S',
+      durationLabel: '8:02',
+    },
+  },
+  {
+    slug: 'bibleproject-new-testament-overview',
+    title: 'The New Testament',
+    description: 'How the whole New Testament fits together — gospels, Acts, letters, Revelation — in eight minutes.',
+    category: 'reference',
+    resourceType: 'video',
+    note: 'The companion to the whole-Bible video. Worth keeping on the shelf for the week someone asks why the letters are in that order.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'BibleProject',
+      domain: 'bibleproject.com',
+      url: 'https://bibleproject.com/videos/new-testament-overview/',
+      homeUrl: 'https://bibleproject.com/',
+      attribution: 'BibleProject is the author and owner of this video. To find more BibleProject resources, visit bibleproject.com.',
+      licence: 'Plays here from BibleProject\'s own YouTube channel. Free to watch, and no account needed.',
+      embedOnly: true,
+    },
+    video: {
+      provider: 'youtube',
+      id: 'Q0BrP8bqj0c',
+      publishedAt: '2018-09-20T00:00:00Z',
+      duration: 'PT8M17S',
+      durationLabel: '8:17',
+    },
+  },
+  {
+    slug: 'bibleproject-sacrifice-and-atonement',
+    title: 'Sacrifice and atonement',
+    description: 'What the sacrificial system was actually for, and how the New Testament reads Jesus\' death through it.',
+    category: 'topical-study',
+    resourceType: 'video',
+    note: 'A good opener for a topical study that would otherwise stall on unfamiliar ritual. Collect the passages it walks through and you have most of your outline.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'BibleProject',
+      domain: 'bibleproject.com',
+      url: 'https://bibleproject.com/videos/sacrifice-and-atonement/',
+      homeUrl: 'https://bibleproject.com/',
+      attribution: 'BibleProject is the author and owner of this video. To find more BibleProject resources, visit bibleproject.com.',
+      licence: 'Plays here from BibleProject\'s own YouTube channel. Free to watch, and no account needed.',
+      embedOnly: true,
+    },
+    video: {
+      provider: 'youtube',
+      id: 'G_OlRWGLdnw',
+      publishedAt: '2015-08-27T00:00:00Z',
+      duration: 'PT6M50S',
+      durationLabel: '6:50',
+    },
+  },
+  {
+    slug: 'bibleproject-job',
+    title: 'Job',
+    description: 'The design of Job — the frame story, the speeches, and what the book is really asking about how God runs the world.',
+    category: 'deep-study',
+    resourceType: 'video',
+    note: 'Job punishes a chapter-a-day approach. Watch this first so you know which speeches are meant to be wrong, then slow down.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'BibleProject',
+      domain: 'bibleproject.com',
+      url: 'https://bibleproject.com/videos/job/',
+      homeUrl: 'https://bibleproject.com/',
+      attribution: 'BibleProject is the author and owner of this video. To find more BibleProject resources, visit bibleproject.com.',
+      licence: 'Plays here from BibleProject\'s own YouTube channel. Free to watch, and no account needed.',
+      embedOnly: true,
+    },
+    video: {
+      provider: 'youtube',
+      id: 'GswSg2ohqmA',
+      publishedAt: '2016-10-22T00:00:00Z',
+      duration: 'PT7M14S',
+      durationLabel: '7:14',
+    },
+  },
+  {
+    slug: 'guide-prep-a-lesson-that-leaves-a-trail',
+    title: 'Prep a lesson that leaves a trail',
+    description: 'How to prepare so the study survives the week — for you and for the people you taught.',
+    category: 'sermon-prep',
+    resourceType: 'guide',
+    note: 'The companion to the lesson prep stack: that one gives you the shape, this one gives you what to do with it afterwards.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Harvous',
+      domain: 'harvous.com',
+      url: 'https://harvous.com/blog/prep-a-lesson-that-leaves-a-trail/',
+      homeUrl: 'https://harvous.com/blog/',
+      attribution: 'Written for Bright Enough, the Harvous blog.',
+    },
+  },
+  {
+    slug: 'guide-asking-better-questions',
+    title: 'Asking better questions in class and group',
+    description: 'Why the questions you plan matter more than the answers you prepared, and how to write ones that open a room.',
+    category: 'small-group',
+    resourceType: 'guide',
+    note: 'Read it the week before a term starts. It changes what you write in the questions section of your prep, which is the part most likely to be filled in last.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Harvous',
+      domain: 'harvous.com',
+      url: 'https://harvous.com/blog/asking-better-questions-in-class-and-group/',
+      homeUrl: 'https://harvous.com/blog/',
+      attribution: 'Written for Bright Enough, the Harvous blog.',
+    },
+  },
+  {
+    slug: 'guide-the-monday-retention-loop',
+    title: 'The Monday retention loop',
+    description: 'What to do on Monday so that Sunday\'s teaching is still doing something on Thursday.',
+    category: 'sermon-notes',
+    resourceType: 'guide',
+    note: 'For anyone who has watched a good Sunday evaporate by midweek. Short, and the loop it describes takes about ten minutes to run.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Harvous',
+      domain: 'harvous.com',
+      url: 'https://harvous.com/blog/the-monday-retention-loop/',
+      homeUrl: 'https://harvous.com/blog/',
+      attribution: 'Written for Bright Enough, the Harvous blog.',
+    },
+  },
+  {
+    slug: 'guide-teaching-through-a-book',
+    title: 'Teaching through a book',
+    description: 'Planning a series that walks through one book — where to break it, and what to keep visible across weeks.',
+    category: 'teaching-prep',
+    resourceType: 'guide',
+    note: 'Pair it with a BibleProject overview of the book you are about to teach. One gives you the arc, the other gives you the weeks.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Harvous',
+      domain: 'harvous.com',
+      url: 'https://harvous.com/blog/teaching-through-a-book/',
+      homeUrl: 'https://harvous.com/blog/',
+      attribution: 'Written for Bright Enough, the Harvous blog.',
+    },
+  },
+  {
+    slug: 'spurgeon-morning-and-evening',
+    title: 'Morning and Evening',
+    description: 'Spurgeon\'s daily readings, two for every day of the year, written in the 1860s.',
+    category: 'daily-journal',
+    resourceType: 'book',
+    note: 'A daily devotional that is genuinely old and genuinely short. Useful as a second voice beside your own reading rather than as a replacement for it.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Christian Classics Ethereal Library',
+      domain: 'ccel.org',
+      url: 'https://www.ccel.org/ccel/spurgeon/morneve.html',
+      homeUrl: 'https://www.ccel.org/',
+      attribution: 'Hosted by the Christian Classics Ethereal Library at Calvin University.',
+      licence: 'Public domain.',
+    },
+  },
+  {
+    slug: 'augustine-confessions',
+    title: 'Augustine\'s Confessions',
+    description: 'The fourth-century autobiography that reads as one long prayer, in full.',
+    category: 'deep-study',
+    resourceType: 'book',
+    note: 'Slow reading, and worth it. Keep a note open for the sentences you will want again — there are more of them than you expect.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Christian Classics Ethereal Library',
+      domain: 'ccel.org',
+      url: 'https://www.ccel.org/ccel/augustine/confessions.html',
+      homeUrl: 'https://www.ccel.org/',
+      attribution: 'Hosted by the Christian Classics Ethereal Library at Calvin University.',
+      licence: 'Public domain.',
+    },
+  },
+  {
+    slug: 'bible-engagement-project-kids',
+    title: 'Bible Engagement Project — kids',
+    description: 'Kids\' curriculum that follows the same scope and sequence as the adult and youth material.',
+    category: 'teaching-prep',
+    resourceType: 'series',
+    note: 'Worth a look if your children\'s ministry and your adult classes are currently in unrelated places in the Bible on the same Sunday.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Bible Engagement Project',
+      domain: 'bibleengagementproject.com',
+      url: 'https://bibleengagementproject.com/Kids',
+      homeUrl: 'https://bibleengagementproject.com/',
+      attribution: 'Bible Engagement Project is the author and owner of this curriculum.',
+      licence: 'The overview is open. The lessons need a free Bible Engagement Project account.',
+    },
+  },
+  {
+    slug: 'step-bible',
+    title: 'STEP Bible',
+    description: 'Interlinears, lexicons and morphology from Tyndale House, Cambridge — open, and free of charge.',
+    category: 'reference',
+    resourceType: 'tool',
+    note: 'The one to reach for when a study turns on a single word and you want to see it in Greek or Hebrew without owning software. Keep it on the shelf; do not try to read it through.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'STEP Bible',
+      domain: 'stepbible.org',
+      url: 'https://www.stepbible.org/',
+      homeUrl: 'https://www.stepbible.org/',
+      attribution: 'STEP Bible is made by Tyndale House, Cambridge.',
+      licence: 'Free to use, and no account needed.',
+    },
+  },
+  {
+    slug: 'openbible-topics',
+    title: 'Bible topics, indexed',
+    description: 'A topical index built from cross-reference data — what the whole Bible says on a subject, ranked and linked.',
+    category: 'topical-study',
+    resourceType: 'tool',
+    note: 'A fast way to gather the passages before a topical study rather than working from the ones you already remember. Check what it gives you in context; an index cannot do that part.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'OpenBible.info',
+      domain: 'openbible.info',
+      url: 'https://www.openbible.info/topics/',
+      homeUrl: 'https://www.openbible.info/',
+      attribution: 'OpenBible.info is the author of this index.',
+      licence: 'Free, and the underlying data is Creative Commons licensed.',
+    },
+  },
+  {
+    slug: 'working-preacher-bible-index',
+    title: 'Commentary, book by book',
+    description: 'Free scholarly commentary on each passage, written weekly by biblical scholars at Luther Seminary.',
+    category: 'sermon-prep',
+    resourceType: 'tool',
+    note: 'Where to go on a Tuesday when the passage is not opening. Written for people who have to say something useful about it on Sunday, which is a different job from a study Bible\'s.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Working Preacher',
+      domain: 'workingpreacher.org',
+      url: 'https://www.workingpreacher.org/bible-index',
+      homeUrl: 'https://www.workingpreacher.org/',
+      attribution: 'Working Preacher is published by Luther Seminary.',
+      licence: 'Free to read, and no account needed.',
+    },
+  },
+  {
+    slug: 'working-preacher-craft-of-preaching',
+    title: 'The craft of preaching',
+    description: 'Essays on the work itself — shaping a sermon, reading a room, and keeping going over years.',
+    category: 'teaching-prep',
+    resourceType: 'article',
+    note: 'Less about this week\'s text and more about how you do the job. Worth reading in a quiet week rather than a busy one.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Working Preacher',
+      domain: 'workingpreacher.org',
+      url: 'https://www.workingpreacher.org/craft-of-preaching',
+      homeUrl: 'https://www.workingpreacher.org/',
+      attribution: 'Working Preacher is published by Luther Seminary.',
+      licence: 'Free to read, and no account needed.',
+    },
+  },
+  {
+    slug: 'tgc-courses',
+    title: 'Free courses',
+    description: 'A library of video courses on books of the Bible, theology and teaching — free to watch.',
+    category: 'teaching-prep',
+    resourceType: 'series',
+    note: 'Course-shaped rather than article-shaped, so it suits a term of preparation better than a single week. Worth knowing it is written from a Reformed evangelical position.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'The Gospel Coalition',
+      domain: 'thegospelcoalition.org',
+      url: 'https://www.thegospelcoalition.org/course/',
+      homeUrl: 'https://www.thegospelcoalition.org/',
+      attribution: 'The Gospel Coalition is the author and owner of these courses.',
+      licence: 'Free to watch. Some courses ask for a free account.',
+    },
+  },
+  {
+    slug: 'ligonier-dust-to-glory',
+    title: 'Dust to Glory',
+    description: 'R.C. Sproul\'s survey of the whole Bible, Genesis to Revelation, in fifty-seven parts.',
+    category: 'book-study',
+    resourceType: 'series',
+    note: 'A long walk rather than a lookup. Good as the spine of a year-long study, with a shorter overview alongside it for each book you reach.',
+    listedAt: '2026-09-10',
+    source: {
+      name: 'Ligonier Ministries',
+      domain: 'ligonier.org',
+      url: 'https://www.ligonier.org/learn/series/dust-to-glory',
+      homeUrl: 'https://www.ligonier.org/',
+      attribution: 'Dust to Glory is taught by R.C. Sproul and owned by Ligonier Ministries.',
+      licence: 'Free to stream. Written from a Reformed position.',
+    },
+  },
+];

--- a/src/lib/pending-auth-redirect.ts
+++ b/src/lib/pending-auth-redirect.ts
@@ -14,6 +14,17 @@ const ALLOWED_PENDING_PATHS = [
   /^\/invitations\/[A-Za-z0-9_-]+\/?$/,
   /^\/shared\/note\/[A-Za-z0-9_-]+\/?$/,
   /^\/shared\/thread\/[A-Za-z0-9_-]+\/?$/,
+  /**
+   * Discover → sign-up → back, to finish the install they came for.
+   *
+   * `PublicDiscoverListingPage` has always called `writePendingAuthRedirect`
+   * here, but with no pattern to match it silently stored nothing and returned
+   * false. Resume still worked, riding on `?install=1` surviving inside Clerk's
+   * `redirect_url`, with a 600s sessionStorage record as the backup — so this
+   * was a belt with no braces. Worth having now that every curated reference is
+   * installable and this is the path most new readers arrive by.
+   */
+  /^\/discover\/[A-Za-z0-9_-]+\/?$/,
   /** Marketing / pricing → Harvous Plus checkout after sign-in or sign-up. */
   /^\/upgrade\/?$/,
   /** Legacy upgrade alias. */


### PR DESCRIPTION
## Why

Discover's purpose is that you find something and then **take it with you**. For the 29 curated references on harvous.com it did the opposite — each could only send a reader to the publisher.

"Add to my Harvous" wasn't offered because it *couldn't work*: `POST /api/discover/install` resolves a slug against `DiscoverListings`, and these slugs have never been in it.

```
/api/discover/listings/soap                      → 200
/api/discover/listings/bibleproject-genesis-1-11 → 404
```

This PR is the rows that close that gap. Pairs with harvouscom/harvous.com#25, which must deploy **first**.

## What it adds

**`src/data/curated-resources.ts`** — 29 references (BibleProject, Bible Engagement Project, CCEL, Working Preacher, STEP Bible, OpenBible, TGC, Ligonier, plus 7 of our own guides). Mirrors how `note-templates.ts` holds the built-ins. harvous.com keeps the artwork — mirrored posters and publisher marks are files on its disk — but everything a reader needs to be told lives here.

**`server/scripts/discover-seed-curated-resources.ts`** — mirrors `discover-seed-builtin-templates.ts`, and skips submit → review on the same grounds: that flow exists so a stranger's work is read before it's public, and the publisher here is Harvous.

### Decisions worth reviewing

- **Installing saves a *link*.** Through `prepareResourceInstall` — nothing of the publisher's is copied, which is both what the code does and what their terms tend to ask for. `payload` is therefore exactly a `ResourcePayload`.

- **Every URL is absolute, our own `/blog/` posts included.** `sourceUrl` is re-validated at install by `validateResourceUrl`, which needs a scheme and a dotted host. A site-relative path would be rejected for *every reader who pressed the button*. The site pulls ours back to relative for its own links.

- **`sourceId` is `curated:<slug>`.** Like a built-in, a curated reference has no row to point at — it's a link to somebody else's page, not a `LibraryItems` record under a system account. Prefixed so it can never collide with a built-in's id (`soap`) or a real `ntpl_`/`libi_`.

- **`preview` carries the lockup nested under `source`.** `serializePublic` emits `preview` whole, so harvous.com receives all of it **with no change to the export** — the same property the built-in seeder uses to add `official: true`. Nested and named for the type deliberately: the flat `preview.sourceName`/`sourceUrl` already mean something narrower on the site and drive different copy.

- **Validation runs before the write.** A bad category is a card the topic filter never matches; a rejected URL is a button that fails for everyone. Both silent in production, both loud here.

- **Idempotent on `sourceId`**, updating in place and never touching `slug`, `status`, `installCount` or `listedAt` — so a re-run after a copy edit republishes rather than duplicating, and cannot resurrect a delisted row or reset what people have installed.

**Also:** `/discover/` added to `ALLOWED_PENDING_PATHS`. `PublicDiscoverListingPage` has always called `writePendingAuthRedirect`, but with no pattern to match it stored nothing and returned `false`. Resume survived on `?install=1` riding inside Clerk's `redirect_url` — a belt with no braces, worth having now that this is the path most new readers arrive by.

## Dry run (production target, nothing written)

```
[discover:seed-curated] target: PRODUCTION (project mhri…)
  would create  bibleproject-the-story-of-the-bible   reference      BibleProject
  … 27 more …
  would create  ligonier-dust-to-glory                book-study     Ligonier Ministries

29 to create, 0 to update. Dry run: pass --apply to write.
```

**0 skipped** — every category known, every URL accepted by `validateResourceUrl`, no duplicate slugs. `tsc --noEmit` clean for all three files.

## Not applied

Writing to production is a deliberate, separate step:

```bash
npx tsx server/scripts/discover-seed-curated-resources.ts --apply --production
```

⚠️ **One more command belongs in the same window.** `/discover/topical-study/` still renders "Insights" live — a word `BRAND_VOICE.md` bans. The code fix merged as 94a22ab1c, but the sync reads the *database* and nothing in the deploy runs a seeder, so the old headings are still being served. Re-running the built-in seeder rewrites `preview` in place (dry run confirms `6 to update`):

```bash
npx tsx server/scripts/discover-seed-builtin-templates.ts --apply --production
```

Then publish both without waiting for the 6-hour tick:

```bash
gh workflow run sync-discover-catalog.yml -R harvouscom/harvous
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)