### PR TITLE
fix: mark which translation is showing in the reader's mobile compare chips

### DIFF
--- a/Changelog/3.9.13.md
+++ b/Changelog/3.9.13.md
@@ -1,0 +1,8 @@
+# Version 3.9.13
+
+**Release Date**: September 12, 2026
+
+## Fixes
+
+- Mark which translation is showing in the reader's mobile compare chips
+

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ Details, versions, and deployment: [docs/TECH_STACK.md](./docs/TECH_STACK.md).
 
 ---
 
-**Version:** 3.9.12
+**Version:** 3.9.13
 **Status:** Official 1.0 Released January 8, 2026

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvous",
   "type": "module",
-  "version": "3.9.12",
+  "version": "3.9.13",
   "repository": {
     "type": "git",
     "url": "https://github.com/harvouscom/harvous.git"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,7 @@
 // Service Worker for Harvous PWA
 // Simple, reliable caching with stale-while-revalidate strategy
 
-const CACHE_NAME = 'harvous-cache-v3-9-12';
+const CACHE_NAME = 'harvous-cache-v3-9-13';
 const CACHE_MAX_AGE = 24 * 60 * 60 * 1000; // 24 hours
 
 /**

--- a/spa/src/pages/dev/design-system/DesignSystemScenePreview.tsx
+++ b/spa/src/pages/dev/design-system/DesignSystemScenePreview.tsx
@@ -16,12 +16,14 @@ import {
   PrototypeSectionHeader,
 } from '../../prototype/design-system';
 import ProtoPopoverShell from '../../prototype/ProtoPopoverShell';
+import ProtoSelectMenu from '../../prototype/ProtoSelectMenu';
 import PrototypePaperStack from '../../prototype/PrototypePaperStack';
 import type { PaperStackOrigin } from '../../../layouts/proto-shell-context';
 import ProtoThreadTrailOrb from '../../prototype/ProtoThreadTrailOrb';
 import PrototypeStudyFeedPart from '../../prototype/PrototypeStudyFeedPart';
 import PrototypeWelcome3Sheet from '../../prototype/PrototypeWelcome3Sheet';
 import PrototypeHomeRow from '../../prototype/PrototypeHomeRow';
+import { TRANSLATION_ORDER, getTranslationAbbreviationDisplay } from '@/data/translations';
 import { RECALL_STATE_LABELS } from '@/utils/review-item-kinds';
 import { buildStudyFeedDays, type StudyFeedItem } from '@/utils/study-feed-items';
 import { AppearancePreviewTile } from '../../prototype/settings/AppearancePreviewTile';
@@ -1079,6 +1081,144 @@ function ReaderInspectorScene() {
 }
 
 
+/* John 3 in two versions, enough of it that the stage scrolls. */
+const COMPARE_SCENE_VERSES: { num: number; net: string; esv: string }[] = [
+  {
+    num: 14,
+    net: 'Just as Moses lifted up the serpent in the wilderness, so must the Son of Man be lifted up,',
+    esv: 'And as Moses lifted up the serpent in the wilderness, so must the Son of Man be lifted up,',
+  },
+  {
+    num: 15,
+    net: 'so that everyone who believes in him may have eternal life.',
+    esv: 'that whoever believes in him may have eternal life.',
+  },
+  {
+    num: 16,
+    net: 'For this is the way God loved the world: He gave his one and only Son, so that everyone who believes in him will not perish but have eternal life.',
+    esv: 'For God so loved the world, that he gave his only Son, that whoever believes in him should not perish but have eternal life.',
+  },
+  {
+    num: 17,
+    net: 'For God did not send his Son into the world to condemn the world, but that the world should be saved through him.',
+    esv: 'For God did not send his Son into the world to condemn the world, but in order that the world might be saved through him.',
+  },
+  {
+    num: 18,
+    net: 'The one who believes in him is not condemned. The one who does not believe has been condemned already, because he has not believed in the name of the one and only Son of God.',
+    esv: 'Whoever believes in him is not condemned, but whoever does not believe is condemned already, because he has not believed in the name of the only Son of God.',
+  },
+];
+
+/**
+ * Comparing two versions where only one fits (ds-24-reader-compare-chips).
+ *
+ * The stage is 380px on purpose. This marking exists only inside
+ * `@container pds-reader-scroll (max-width: 900px)` — above that width both versions are on
+ * screen and neither chip is marked — so a scene staged at a comfortable width would render
+ * the *unmarked* state and quietly cover nothing. That is the scope-chip lesson: a scene that
+ * omits the real container is covering a different component that happens to share a class name.
+ *
+ * Real `ProtoSelectMenu` triggers rather than styled spans, for the same reason. The marking has
+ * to win against the trigger's own resting and hover fills, and a fixture built from `<span>`s
+ * would look right while production lost that fight.
+ *
+ * Both directions are shown because the failure mode is not "the marking is faint", it is "the
+ * two chips are indistinguishable" — which only shows up when you look at the pair twice.
+ */
+function ReaderCompareChipsScene() {
+  const [primary, setPrimary] = useState('NET');
+  const [compare, setCompare] = useState('ESV');
+  const options = TRANSLATION_ORDER.map((id) => ({
+    value: id,
+    label: getTranslationAbbreviationDisplay(id),
+    triggerLabel: getTranslationAbbreviationDisplay(id),
+  }));
+
+  const stage = (showing: 'primary' | 'compare') => (
+    <div className="pds-gallery-reader-compare-stage" key={showing}>
+      <p className="pds-caption">
+        {showing === 'primary'
+          ? `Reading ${getTranslationAbbreviationDisplay(primary)}`
+          : `Swiped across to ${getTranslationAbbreviationDisplay(compare)}`}
+      </p>
+      <div className="pds-reader">
+        <div className="pds-reader__scroll pds-reader-stack pds-reader-compare">
+          <div className="pds-reader__column">
+            <div className="pds-reader__chapter-heading">
+              <h2 className="pds-reader-chapter-title">John 3</h2>
+              <div className="pds-reader__chapter-controls">
+                <ProtoSelectMenu
+                  value={primary}
+                  options={options}
+                  onChange={setPrimary}
+                  label="Translation"
+                  className={`pds-reader__trans-trigger scripture-pill-chrome__trans-chip${
+                    showing === 'primary' ? ' pds-reader__trans-trigger--showing' : ''
+                  }`}
+                  menuClassName="pds-reader__trans-menu"
+                  menuWidth={168}
+                />
+                <ProtoSelectMenu
+                  value={compare}
+                  options={options}
+                  onChange={setCompare}
+                  label="Compared translation"
+                  className={`pds-reader__trans-trigger pds-reader__trans-trigger--compare scripture-pill-chrome__trans-chip${
+                    showing === 'compare' ? ' pds-reader__trans-trigger--showing' : ''
+                  }`}
+                  menuClassName="pds-reader__trans-menu"
+                  menuWidth={168}
+                />
+                <button type="button" className="pds-reader__compare-swap" aria-label="Swap versions">
+                  <Icon name="arrow-right-arrow-left" size={11} aria-hidden />
+                </button>
+                <button type="button" className="pds-reader__compare-close" aria-label="Stop comparing">
+                  <Icon name="xmark" size={11} aria-hidden />
+                </button>
+              </div>
+            </div>
+            {/* Enough chapter to scroll. The bar is sticky only while comparing at this width,
+                and a stage with one verse in it would show the bar sitting still and prove
+                nothing — scroll the stage and it should stay, opaque, with verses passing
+                under it rather than through it. */}
+            {COMPARE_SCENE_VERSES.map((v) => (
+              <div className="pds-reader__block" key={v.num}>
+                <p className="pds-reader-text">
+                  <span className="pds-reader__verse">
+                    <sup className="pds-reader-verse-num">{v.num}</sup>
+                    <span className="pds-reader__verse-text">
+                      {showing === 'primary' ? v.net : v.esv}
+                    </span>
+                  </span>
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="pds-gallery-stack">
+      <PrototypeSectionHeader>Comparing versions on a phone</PrototypeSectionHeader>
+      <p className="pds-caption">
+        Below 900px of <code>.pds-reader__scroll</code> the two columns become one you swipe
+        between, so this row is the only thing saying which version is on screen. The one you are
+        reading carries a surface; the one waiting behind it does not. Present-against-absent
+        rather than a darker fill, because the neutral fills collapse to a single value in dark
+        mode — <code>--pds-bg-chip</code> and <code>--pds-bg-row-selected</code> are both white at
+        10% — which is what this row shipped as, and why it read as unmarked.
+      </p>
+      <div className="pds-gallery-reader-compare-stages">
+        {stage('primary')}
+        {stage('compare')}
+      </div>
+    </div>
+  );
+}
+
 /**
  * Every offline state a translation row can be in, at once.
  *
@@ -1649,6 +1789,8 @@ export default function DesignSystemScenePreview({ scene }: { scene: DesignSyste
       return <ReaderInspectorScene />;
     case 'ds-18-translation-row':
       return <TranslationRowScene />;
+    case 'ds-24-reader-compare-chips':
+      return <ReaderCompareChipsScene />;
     case 'ds-19-note-audience-bar':
       return <NoteAudienceBarScene />;
     case 'ds-20-study-feed':

--- a/spa/src/pages/dev/design-system/sceneRegistry.ts
+++ b/spa/src/pages/dev/design-system/sceneRegistry.ts
@@ -212,6 +212,18 @@ export const DESIGN_SYSTEM_CORE_SCENES: DesignSystemScene[] = [
     // Interactive (text-size + verse-number controls write real prefs).
   },
   {
+    id: 'ds-24-reader-compare-chips',
+    title: 'Compare chips (phone)',
+    phase: 'Patterns',
+    editFiles: [
+      'spa/src/pages/prototype/PrototypeBibleReaderPane.tsx',
+      'spa/src/styles/prototype-components.css',
+      'spa/src/styles/prototype-design-gallery.css',
+    ],
+    screenshotSlug: 'ds-24-reader-compare-chips',
+    // Interactive (both chips are live ProtoSelectMenus) — not a stable visual baseline.
+  },
+  {
     id: 'ds-18-translation-row',
     title: 'Translation row',
     phase: 'Patterns',

--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -19050,13 +19050,117 @@ html.harvous-prototype-route button[class*="proto-"].proto-settings-danger__btn:
   /*
    * Which chip is the text you are looking at.
    *
-   * The same treatment the chapter menu gives its checked row, because it is the same
-   * statement — this one, of the ones offered. Only at this width: above it both versions are
-   * on screen and marking one would claim a precedence the layout does not have.
+   * One chip carries a surface and the other does not. That is the whole marking, and it is
+   * blunter than the fill-against-fill this shipped with for a reason the dark palette makes
+   * unarguable: the marking was `--pds-bg-row-selected` against the chip's resting
+   * `--pds-bg-chip`, which in light is 6.5% black against 6% — half a percent, on a 10px chip,
+   * beside an identical one — and in dark is `100% 0 0 / 0.1` against `100% 0 0 / 0.1`, the
+   * same value twice. There was no marking in dark mode at all. On a phone, where this width
+   * lives and where the marking matters most because only one version is on screen, that is
+   * the whole question the row exists to answer going unanswered.
+   *
+   * Fill-against-fill is not fixable by reaching for a stronger token, which was the obvious
+   * next move. The neutral ladder is compressed in dark — `--pds-bg-chip`,
+   * `--pds-bg-control-strong` and `--pds-bg-row-selected` are all white at 10% — so every
+   * "one step up" lands back on the resting fill. Present-against-absent is the one difference
+   * that survives both palettes, and it says the same thing in each: the version you are
+   * reading is printed on something, the one waiting behind it is not.
+   *
+   * The other chip keeps its border and its weight, so it still reads as a control you can
+   * press rather than a disabled one — the distinction `.proto-appearance-segmented` draws by
+   * keeping both halves at full colour. It is not dimmed; it is just not the one on screen.
+   *
+   * Colour is not an available arm: `prototype-route-overrides.css` pins every prototype button
+   * and its descendants to `--pds-text-primary !important`, so both chips compute one text
+   * colour whatever this file asks for. Background, weight and a lift are the whole vocabulary
+   * here — the same constraint every segmented control in this file works under.
+   *
+   * The `:hover` arm beats the trigger's own hover fill further down this file. Without it,
+   * pointing at either chip on a narrow desktop window paints both the same and the marking
+   * disappears under the pointer. Moot on a touchscreen, which is most of this width.
+   *
+   * Only at this width: above it both versions are on screen and marking one would claim a
+   * precedence the layout does not have.
    */
-  .pds-reader__trans-trigger--showing {
-    background: var(--pds-bg-row-selected);
+  .pds-reader__trans-trigger.proto-select-menu__trigger,
+  .pds-reader__trans-trigger.proto-select-menu__trigger:hover {
+    background: none;
+    box-shadow: none;
+  }
+
+  .pds-reader__trans-trigger--showing.proto-select-menu__trigger,
+  .pds-reader__trans-trigger--showing.proto-select-menu__trigger:hover {
+    background: var(--pds-bg-control-strong);
+    border-color: var(--pds-border-control-strong);
+    box-shadow: var(--pds-shadow-chip-selected);
     font-weight: 600;
+  }
+
+  /*
+   * While comparing, the heading stays.
+   *
+   * The marking above answers "which version is this" only while the row is on screen, and the
+   * row scrolls away with the chapter — so three verses in, a swipe changed the words and the
+   * only thing that named the new version was off the top of the pane. That is the same
+   * complaint the invisible marking was, arriving one scroll later.
+   *
+   * The whole heading, not just the chips: `.pds-reader__chapter-controls` sits inside the
+   * heading, and a sticky child is confined to its parent's box, so pinning the chips alone
+   * would release them the moment the heading passed. Lifting them out is a worse trade — the
+   * heading's one-row-then-stacked arrangement is built around holding both — and "John 3,
+   * NET against ESV" is the right thing to pin anyway: it is the context for the act, not
+   * decoration on top of it.
+   *
+   * Only while comparing, and only here. A chapter you are simply reading keeps the bare canvas
+   * the reader is for; this bar is the mode's own chrome and leaves when the mode does, which is
+   * why it hangs off `.pds-reader-compare` rather than off the reader.
+   *
+   * The background spans the paper rather than the text column — negative margins out to
+   * `--pds-reader-paper-padding-x` and the same number added back as padding — or verses would
+   * slide through the gap either side of the heading while passing under it. Both variables are
+   * re-declared on `.pds-reader__column` at the narrow widths below, and inherit here, so this
+   * tracks the paper instead of restating its numbers.
+   */
+  .pds-reader-compare .pds-reader__chapter-heading {
+    position: sticky;
+    top: 0;
+    /* `top` is measured from the scrollport's *padding* edge, and the clip region is the padding
+       box — so where `.pds-reader-stack` puts `padding-block` on this scroller, `top: 0` pins the
+       bar one `--pds-space-5` down and leaves a band above it where verses are still painted.
+       They scroll through it in full view, over the top of a bar whose whole job is to be the
+       thing in front. The offset is taken back below, on the class that adds the padding. */
+    /* Above the text (`z-index: 2`) and the margin lane, both of which pass underneath. */
+    z-index: var(--pds-z-sticky);
+    /*
+     * Paper colour, but opaque.
+     *
+     * `--pds-paper-sheet` is translucent — it resolves through `--pds-bg-sidebar` to the
+     * toolbar's glass, and measured 78% white. That is right for the sheet, which lies on the
+     * canvas, and wrong for a bar that verses pass underneath: at 78% the text you scrolled
+     * past reads straight through the chips.
+     *
+     * So the canvas goes down first and the paper is painted over it, which is the same
+     * compositing the sheet already gets from lying on the canvas — the bar matches the paper
+     * exactly rather than approximating it with a solid. `.pds-reader-stack__edge` does this
+     * already and for the same reason.
+     *
+     * This is the one shape the "never pair a gradient with a background-color" note does not
+     * cover: that warns against a colour compositing under a gradient that is meant to *fade*,
+     * where it makes the foot more opaque than the token claims. Here both stops are one flat
+     * colour and the compositing is the whole point.
+     */
+    background-color: var(--pds-canvas-default);
+    background-image: linear-gradient(var(--pds-paper-sheet), var(--pds-paper-sheet));
+    margin-inline: calc(-1 * var(--pds-reader-paper-padding-x));
+    padding-inline: calc(var(--pds-reader-text-inset) + var(--pds-reader-paper-padding-x));
+    padding-block: var(--pds-space-3);
+    /* Without a line, text passing under the bar reads as clipped rather than as going behind
+       something. Soft, because this sits on a reading surface all day. */
+    border-bottom: 0.5px solid var(--pds-border-soft);
+  }
+
+  .pds-reader-stack.pds-reader-compare .pds-reader__chapter-heading {
+    top: calc(-1 * var(--pds-space-5));
   }
 
   .pds-reader__compare-row {

--- a/spa/src/styles/prototype-design-gallery.css
+++ b/spa/src/styles/prototype-design-gallery.css
@@ -391,6 +391,37 @@
   overflow: hidden;
 }
 
+/* Comparing two versions on a phone (ds-24-reader-compare-chips).
+ *
+ * The width IS the fixture. The marking that says which version is on screen lives in a
+ * `@container pds-reader-scroll (max-width: 900px)` block, so a stage wide enough to be
+ * comfortable renders the wide state and covers nothing — the failure the scope-chip scene
+ * already taught this gallery, where a scene stayed green for 91 runs while the real control
+ * drew an empty pill. 380px is a phone, which is the only place this state exists.
+ *
+ * Two stages side by side rather than one with a toggle: the whole question is which of the two
+ * chips reads as current, and that is a comparison, not a state you step through. */
+.pds-gallery-reader-compare-stages {
+  display: flex;
+  gap: var(--pds-space-5);
+  flex-wrap: wrap;
+}
+
+.pds-gallery-reader-compare-stage {
+  flex: 0 0 auto;
+  width: 380px;
+  max-width: 100%;
+}
+
+.pds-gallery-reader-compare-stage > .pds-reader {
+  /* Tall enough to scroll, which is the point: the heading pins while comparing at this width,
+     and a stage that fits the whole passage would show it sitting still. */
+  height: 300px;
+  border: 0.5px solid var(--pds-border);
+  border-radius: var(--pds-radius-card);
+  overflow: hidden;
+}
+
 .pds-gallery-reader-markers {
   display: flex;
   gap: var(--pds-space-5);


### PR DESCRIPTION
## What

On a phone, comparing two Bible translations collapses to one column you swipe between — and the chip row naming the current version was effectively invisible.

## Why it was invisible

The marking was `--pds-bg-row-selected` against the chip's resting `--pds-bg-chip`:

| | light | dark |
|---|---|---|
| resting chip | 6% black | white 10% |
| marked chip | 6.5% black | **white 10%** |

Half a percent of black in light mode, and the *identical* computed value in dark mode — no marking at all on a phone in dark mode.

## Fix

- Switched to present-against-absent (filled + bordered + lifted vs. no fill) — the neutral fill ladder collapses to one value in dark, so no stronger token fixes this.
- Pinned the chapter heading while comparing at this width, since the chip row previously scrolled away with the chapter — a mid-chapter swipe changed the words with nothing on screen saying which version you'd landed in. Only while comparing, only below 900px; plain reading keeps the bare canvas.
- Added gallery scene `ds-24-reader-compare-chips`, staged at 380px (the rule only exists inside that container query) and scrollable (the pin only proves itself in motion).

## Verification

- `npm run design:check` — 24 core scenes pass
- `npx vitest run` (reader/gallery/style suites) — 583 tests pass
- `npm run build:spa && npm run perf:check` — 1152.5 KB gzipped, no regression
- Computed-style checks in both light/dark and both swipe directions via the Browser pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)