### PR TITLE
Mobile: paper matches toolbar width, and clears the home indicator

### DIFF
--- a/spa/src/styles/prototype-components.css
+++ b/spa/src/styles/prototype-components.css
@@ -526,7 +526,8 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 0 10px;
+  /* The shell's outer edge for everything below it too — see `--pds-shell-gutter`. */
+  padding: 0 var(--pds-shell-gutter);
   gap: 8px;
 }
 
@@ -1221,8 +1222,11 @@ html[data-shift-hints='1'] .proto-toolbar-orb-group {
 /* Phones — reclaim horizontal room for the center folder chip so the full folder
    name shows without overlapping the side button groups. */
 @media (max-width: 600px) {
+  /* The padding that used to be here is `--pds-shell-gutter` now, and its phone value is
+     declared with the token in prototype-tokens.css — the paper below the toolbar reads the
+     same number, and an override from this file could not be relied on to win: Vite injects
+     the two stylesheets in an order that does not follow their imports. */
   .proto-toolbar-inner {
-    padding: 0 6px;
     gap: 6px;
   }
 
@@ -21432,6 +21436,25 @@ html.harvous-prototype-route .proto-appearance-hero__specimen[data-font='dyslexi
 }
 
 /*
+ * Phones: the paper runs out to the toolbar's own edges, and finishes inside the frame's.
+ *
+ * ── Width. On a desktop the 20px here is invisible, because the stack caps at 640px and
+ * centres long before the padding matters. On a 359px shell it is the whole story: the sheet
+ * started 14px inside the first toolbar button and ended 14px inside the avatar, so the two
+ * surfaces that share the window's left edge did not share it. `--pds-shell-gutter` is the
+ * toolbar's own number, so the page now begins where the controls above it begin.
+ *
+ * The sheet's own bottom corners are rounded to match, next to the rule that squares them.
+ */
+@media (max-width: 899px) {
+  .proto-feed,
+  .proto-hub-frame {
+    padding-left: var(--pds-shell-gutter);
+    padding-right: var(--pds-shell-gutter);
+  }
+}
+
+/*
  * The hub's header row, given the width its own layout assumes.
  *
  * On the rail `.proto-shared-space-header` is a block, so the row inside it is full width for
@@ -21910,6 +21933,33 @@ html.harvous-prototype-route .proto-appearance-hero__specimen[data-font='dyslexi
   background-color: var(--pds-canvas-default);
   background-image: linear-gradient(var(--pds-paper-sheet), var(--pds-paper-sheet));
   box-shadow: var(--pds-paper-shadow-subtle);
+}
+
+/*
+ * ...except, on a phone, the two corners that sit inside the frame's own.
+ *
+ * The sheet is flush with the shell's floor, and at the phone gutter it reaches to within
+ * 6px of the frame's sides — well inside the frame's 18px radius, which clips with
+ * `overflow: hidden`. Left square, the arc shaves a wedge about 12px wide off each bottom
+ * corner, and the page reads as cut off rather than finished. Radius less gutter puts the
+ * sheet's corners concentric inside the frame's, so the paper ends on the same curve the
+ * shell does.
+ *
+ * Not a retreat to card language: the top corners stay square, which is where the sheet
+ * meets nothing and where the squareness is the point. This is the cut a sheet takes from
+ * the tray it is lying in.
+ *
+ * Phones only, and that is the narrower breakpoint on purpose. Above 600px the gutter goes
+ * back to 10px — where the same wedge is under 2px tall — and past roughly 676px the stack
+ * hits its 640px cap and centres, so the sheet is nowhere near the frame's corners and a
+ * rounded bottom on it would be exactly the card bottom this surface keeps being mistaken
+ * for.
+ */
+@media (max-width: 600px) {
+  .proto-feed-sheet {
+    border-bottom-left-radius: calc(var(--pds-shell-frame-radius) - var(--pds-shell-gutter));
+    border-bottom-right-radius: calc(var(--pds-shell-frame-radius) - var(--pds-shell-gutter));
+  }
 }
 
 .proto-feed-sheet__head {

--- a/spa/src/styles/prototype-shell.css
+++ b/spa/src/styles/prototype-shell.css
@@ -609,6 +609,40 @@ html.harvous-prototype-route .proto-shell__detail-toolbar-cell::after {
     --pds-shell-frame-inset: 8px;
   }
 
+  /*
+   * The frame stops short of the home indicator, instead of running under it.
+   *
+   * Measured in an installed iOS standalone app: the layout viewport is the full screen
+   * (`viewport-fit=cover`), `env(safe-area-inset-bottom)` is 34px, and nothing here was
+   * reading it — so a frame sized `100dvh - 2 * 8px` ended 26px inside that strip. What the
+   * bottom of the paper actually met there was the *display's* corner radius, which is far
+   * larger than the frame's own 18px: the sheet's bottom corners were sliced off by the
+   * physical screen and the frame's rounded bottom never appeared at all, so the page simply
+   * ran off the end rather than finishing.
+   *
+   * Stated as `inset + inset-bottom` rather than `max()` of the two, so the gap below the
+   * sheet mirrors the one above it: the same 8px of shell, just measured from the top of the
+   * indicator strip rather than from the glass. The top gets the same treatment for the same
+   * reason — it is 0 on iOS (`apple-mobile-web-app-status-bar-style: default` insets the web
+   * view itself) but not on an Android PWA, where `cover` does put the toolbar under the
+   * status bar.
+   *
+   * Both `vh` and `dvh`: the second is the one that counts, and a browser without it would
+   * otherwise drop the whole declaration and fall back to the safe-area-blind base rule.
+   */
+  .proto-shell-frame {
+    margin-top: calc(var(--pds-shell-frame-inset) + env(safe-area-inset-top, 0px));
+    margin-bottom: calc(var(--pds-shell-frame-inset) + env(safe-area-inset-bottom, 0px));
+    height: calc(
+      100vh - 2 * var(--pds-shell-frame-inset) - env(safe-area-inset-top, 0px) -
+        env(safe-area-inset-bottom, 0px)
+    );
+    height: calc(
+      100dvh - 2 * var(--pds-shell-frame-inset) - env(safe-area-inset-top, 0px) -
+        env(safe-area-inset-bottom, 0px)
+    );
+  }
+
   .proto-shell {
     grid-template-columns: minmax(0, 1fr);
   }

--- a/spa/src/styles/prototype-tokens.css
+++ b/spa/src/styles/prototype-tokens.css
@@ -751,6 +751,20 @@
   /* Prototype shell viewport frame (web — Figma outer padding + shell radius) */
   --pds-shell-frame-inset: 14px;
   --pds-shell-frame-radius: 18px;
+  /*
+   * How far the shell's own contents sit from the frame's inner edge.
+   *
+   * The toolbar sets the line: its button groups are the first thing inside the frame, and
+   * every surface below them is read against that edge. On a phone the paper underneath used
+   * its own 20px and came out 14px narrower on each side than the toolbar above it — two
+   * different left edges in a window only 359px wide, which reads as the sheet being
+   * indented rather than as the page being the page. One number, so they cannot drift.
+   *
+   * The phone value is at the foot of this file rather than beside the toolbar rule it came
+   * from: Vite injects these stylesheets in an order that does not follow their imports, so
+   * a `:root` override living in prototype-components.css loses to this declaration.
+   */
+  --pds-shell-gutter: 10px;
 
   /* Bible reader canvas — mirrors HarvousReaderLayout / ReaderTextSize (Swift).
      Font size + line height are re-set by the reader inspector's text-size control;
@@ -1741,4 +1755,18 @@ html.harvous-prototype-route [data-sonner-toast] [data-description] {
   font-size: 0.6875rem;
   font-weight: 400;
   color: var(--pds-text-secondary);
+}
+
+/*
+ * Phones: the shell's gutter tightens, and the toolbar and the paper tighten together.
+ *
+ * Deliberately at the end of this file. It has to out-cascade the `:root` block at the top,
+ * and it cannot live beside the toolbar rule it belongs to — Vite injects prototype-tokens
+ * after prototype-components in dev, so the same declaration over there loses to the base
+ * value here and the paper quietly went back to the wider gutter.
+ */
+@media (max-width: 600px) {
+  :root {
+    --pds-shell-gutter: 6px;
+  }
 }


### PR DESCRIPTION
## Summary

Two phone-layout fixes, both verified against a real installed iOS PWA (a static replica of the live shell CSS/DOM, added to the home screen in the Simulator — the dev app can't sign in there).

- **Paper width vs. toolbar.** One token, `--pds-shell-gutter` (10px, 6px under 600px), now sets both the toolbar's inner padding and the day sheet's/hub frame's side padding below 900px. They used to disagree (6px vs 20px on a phone), so the paper's edges sat 14px inside the toolbar's on each side — two different "start of the page" positions in a 359px-wide window.

- **Bottom cut off in the installed PWA.** `.proto-shell-frame` now subtracts `env(safe-area-inset-top/bottom)` from its margin and height at the mobile breakpoint. Measured in the installed app: `safe-area-inset-bottom` is 34pt and nothing in the shell was reading it, so the frame's bottom ~26pt (the paper's bottom edge, and the frame's own rounded corners) sat inside the home-indicator strip and was sliced by the display's own — much larger — corner radius, rather than by the frame's 18px one.

- Because the sheet now reaches within 6px of the frame's 18px-radius clip, its bottom corners take `frame-radius - gutter`, phones only (≤600px) — above that width the wedge this would otherwise shave off is under 2px, and past ~676px the stack centres at its 640px cap, clear of the frame's corners entirely.

## Verification

- `npm run design:check` — passed (23 core scenes, 28 shared-spaces scenes)
- `npm run check:color-tokens` — passed
- `prototype-background.test.ts` — 20/20 passed
- `npm run build:spa && npm run perf:check` — passed (1152.5 KB gzipped, no regression)
- Desktop (≥900px) is byte-for-byte unchanged: same 20px padding, square corners, 14px frame inset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)